### PR TITLE
Remove Hardcoded GitHub Sign-in Scope

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -17,7 +17,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       clientSecret: process.env.AUTH_GITHUB_SECRET,
       authorization: {
         params: {
-          scope: "read:user repo",
+          scope: process.env.AUTH_GITHUB_SCOPE || "read:user repo",
         },
       },
     }),


### PR DESCRIPTION
This pull request removes the hardcoded `scope` value from the GitHub sign-in configuration in the `auth.ts` file and replaces it with an environment variable `AUTH_GITHUB_SCOPE`. This change allows others to configure the scope according to their needs.