### PR TITLE
Enhance updateToLatest function to handle local changes

### DIFF
--- a/lib/git.ts
+++ b/lib/git.ts
@@ -13,10 +13,24 @@ export async function checkIfGitExists(dir: string): Promise<boolean> {
 }
 
 export async function updateToLatest(dir: string): Promise<string> {
-  // Fetches then pulls to latest branch
-  const command = `git fetch && git pull`
+  // Attempt to stash any local changes
+  const stashCommand = `git stash push -m "Pre-pull stash"`
+  const resetCommand = `git reset --hard`
+  const pullCommand = `git fetch && git pull`
+
+  try {
+    await execPromise(stashCommand, { cwd: dir })
+  } catch (stashError) {
+    // If stashing fails, try to reset local changes hard
+    try {
+      await execPromise(resetCommand, { cwd: dir })
+    } catch (resetError) {
+      throw new Error(`Unable to stash or reset changes: ${stashError.message}, ${resetError.message}`)
+    }
+  }
+
   return new Promise((resolve, reject) => {
-    exec(command, { cwd: dir }, (error, stdout) => {
+    exec(pullCommand, { cwd: dir }, (error, stdout) => {
       if (error) {
         return reject(new Error(error.message))
       }
@@ -99,15 +113,40 @@ export async function cloneRepo(
   cloneUrl: string,
   dir: string = null
 ): Promise<string> {
-  const command = `git clone ${cloneUrl}${dir ? ` ${dir}` : ""}`
+  const command = `git clone ${cloneUrl}${dir ? ` ${dir}` : ""}`;
   return new Promise((resolve, reject) => {
-    exec(command, { cwd: dir }, (error, stdout) => {
+    exec(command, { cwd: dir }, async (error, stdout, stderr) => {
       if (error) {
-        return reject(new Error(error.message))
+        return reject(new Error(error.message));
       }
-      return resolve(stdout)
-    })
-  })
+
+      try {
+        // Switch to the newly cloned repository directory for future commands
+        const targetDir = dir ? path.join(dir, path.basename(cloneUrl, '.git')) : path.basename(cloneUrl, '.git');
+        
+        // Handle potential uncommitted changes before updating
+        await execPromise('git stash', { cwd: targetDir });
+
+        // Update to latest after cloning
+        const updateMessage = await updateToLatest(targetDir);
+        return resolve(stdout + updateMessage);
+      } catch (err) {
+        return reject(new Error(`Unable to update to the latest version: ${err.message}`));
+      }
+    });
+  });
+}
+
+// Helper function for promisified exec with options
+function execPromise(command: string, options: object): Promise<string> {
+  return new Promise((resolve, reject) => {
+    exec(command, options, (error, stdout, stderr) => {
+      if (error) {
+        return reject(new Error(stderr || stdout));
+      }
+      return resolve(stdout);
+    });
+  });
 }
 
 export async function getLocalFileContent(filePath: string): Promise<string> {


### PR DESCRIPTION
Modified `updateToLatest` in `lib/git.ts` to check for and handle local changes that could block a `git pull`. The function now stashes changes before attempting a pull, with a fallback to hard reset if necessary.