### PR TITLE
Integrate GitHub Apps with Existing OAuth Authentication

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -1,13 +1,47 @@
 import NextAuth, { DefaultSession, Session } from "next-auth"
 import GithubProvider from "next-auth/providers/github"
+import jwt from 'jsonwebtoken'; // Import JSON Web Token library
+import axios from 'axios'; // Import axios for HTTP requests
 
-// Allows us to attach accessToken to session.user with TypeScript
+// Allows us to attach accessToken and installationToken to session.user with TypeScript
 declare module "next-auth" {
   interface Session {
     user: {
-      accessToken?: string
+      accessToken?: string,
+      installationToken?: string
     } & DefaultSession["user"]
   }
+}
+
+// Function to generate a GitHub App JWT
+function generateGitHubAppJWT() {
+  const appId = process.env.GITHUB_APP_ID;
+  const privateKey = process.env.GITHUB_APP_PRIVATE_KEY.replace(/\\n/g, '\n');
+
+  const now = Math.floor(Date.now() / 1000);
+  const payload = {
+    iat: now,
+    exp: now + (10 * 60), // JWT expiration set to 10 minutes
+    iss: appId
+  };
+
+  return jwt.sign(payload, privateKey, { algorithm: 'RS256' });
+}
+
+// Function to fetch the installation token
+async function fetchInstallationToken(installationId: string) {
+  const jwt = generateGitHubAppJWT();
+  const response = await axios.post(
+    `https://api.github.com/app/installations/${installationId}/access_tokens`,
+    {},
+    {
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: 'application/vnd.github.v3+json'
+      }
+    }
+  );
+  return response.data.token;
 }
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
@@ -25,14 +59,21 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
   callbacks: {
     async jwt({ token, account }) {
       if (account) {
-        token.accessToken = account.access_token
+        token.accessToken = account.access_token;
       }
-      return token
+      
+      // Fetch and include the GitHub App installation token if applicable
+      if (process.env.GITHUB_APP_INSTALLATION_ID) {
+        token.installationToken = await fetchInstallationToken(process.env.GITHUB_APP_INSTALLATION_ID);
+      }
+      
+      return token;
     },
     async session({ session, token }) {
-      const user = (session as Session).user
-      user.accessToken = token.accessToken as string
-      return session
+      const user = (session as Session).user;
+      user.accessToken = token.accessToken as string;
+      user.installationToken = token.installationToken as string;
+      return session;
     },
   },
 })


### PR DESCRIPTION
This update introduces GitHub Apps authentication to the existing setup, allowing installation tokens alongside existing OAuth for user authentication. The changes include:
- Addition of GitHub App token handling in `auth.ts`.
- Ensured compatibility and integrity within `route.ts` for seamless operation with new tokens.
- Maintained backward compatibility for both OAuth and App tokens. 

This transition enables the app to interface with specific repositories via installation tokens, enhancing functionality and repository-specific permissions.