### PR TITLE
Allows user to upload own OpenAI API key

### DIFF
--- a/app/[username]/[repo]/page.tsx
+++ b/app/[username]/[repo]/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react"
 
+import ApiKeyInput from "@/components/APIKeyInput"
 import IssueTable from "@/components/IssueTable"
 import { TableSkeleton } from "@/components/TableSkeleton"
 
@@ -15,9 +16,12 @@ export default async function RepoPage({ params }: Props) {
 
   return (
     <main className="container mx-auto p-4">
-      <h1 className="text-2xl font-bold mb-4">
-        {username} / {repo}
-      </h1>
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-2xl font-bold mb-4">
+          {username} / {repo}
+        </h1>
+        <ApiKeyInput />
+      </div>
       <Suspense fallback={<TableSkeleton />}>
         <IssueTable username={username} repoName={repo} />
       </Suspense>

--- a/app/api/comment/route.ts
+++ b/app/api/comment/route.ts
@@ -15,12 +15,13 @@ import commentOnIssue from "@/lib/workflows/commentOnIssue"
 type RequestBody = {
   issueNumber: number
   repo: GitHubRepository
+  apiKey: string
 }
 
 export async function POST(request: NextRequest) {
-  const { issueNumber, repo }: RequestBody = await request.json()
+  const { issueNumber, repo, apiKey }: RequestBody = await request.json()
 
-  const response = await commentOnIssue(issueNumber, repo)
+  const response = await commentOnIssue(issueNumber, repo, apiKey)
 
   return NextResponse.json(response)
 }

--- a/app/api/openai/check/route.ts
+++ b/app/api/openai/check/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server"
+
+export const GET = async (req: NextRequest) => {
+  // Get the API key from cookies
+  const { apiKey } = await req.json()
+
+  if (!apiKey) {
+    return NextResponse.json({ error: "API key is missing" }, { status: 400 })
+  }
+
+  try {
+    // Make a simple request to OpenAI to check if the key works
+    const response = await fetch("https://api.openai.com/v1/engines", {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    })
+
+    if (response.ok) {
+      return NextResponse.json({ message: "API key is valid" }, { status: 200 })
+    } else if (response.status === 401) {
+      return NextResponse.json(
+        { error: "Authentication error: Invalid API key" },
+        { status: 401 }
+      )
+    } else {
+      const errorData = await response.json()
+      return NextResponse.json(
+        { error: errorData.error || "An error occurred" },
+        { status: response.status }
+      )
+    }
+  } catch (error) {
+    console.error(error)
+    return NextResponse.json(
+      { error: "An unforeseen error occurred: " + error },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/openai/check/route.ts
+++ b/app/api/openai/check/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server"
 
-export const GET = async (req: NextRequest) => {
+export const POST = async (req: NextRequest) => {
   // Get the API key from cookies
   const { apiKey } = await req.json()
 
@@ -17,7 +17,7 @@ export const GET = async (req: NextRequest) => {
     })
 
     if (response.ok) {
-      return NextResponse.json({ message: "API key is valid" }, { status: 200 })
+      return NextResponse.json({ success: true }, { status: 200 })
     } else if (response.status === 401) {
       return NextResponse.json(
         { error: "Authentication error: Invalid API key" },

--- a/app/api/resolve/route.ts
+++ b/app/api/resolve/route.ts
@@ -9,10 +9,11 @@ import { resolveIssue } from "@/lib/workflows/resolveIssue"
 type RequestBody = {
   issueNumber: number
   repo: GitHubRepository
+  apiKey: string
 }
 
 export async function POST(request: NextRequest) {
-  const { issueNumber, repo }: RequestBody = await request.json()
+  const { issueNumber, repo, apiKey }: RequestBody = await request.json()
   const repoName = repo.name
   const repoUrl = repo.url
   const cloneUrl = repo.clone_url
@@ -49,7 +50,7 @@ export async function POST(request: NextRequest) {
     // This workflow starts with a coordinator agent, that will call other agents to figure out what to do
     // And resolve the issue
 
-    await resolveIssue(issue, repoName)
+    await resolveIssue(issue, repoName, apiKey)
 
     return NextResponse.json(
       { message: "Finished agent workflow." },

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { Inter } from "next/font/google"
 import { SessionProvider } from "next-auth/react"
 
 import { auth } from "@/auth"
+import { Toaster } from "@/components/ui/toaster"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -27,6 +28,7 @@ export default async function RootLayout({
         style={{ "--custom-amber": "#B45309" } as React.CSSProperties}
       >
         <SessionProvider session={session}>{children}</SessionProvider>
+        <Toaster />
       </body>
     </html>
   )

--- a/components/APIKeyInput.tsx
+++ b/components/APIKeyInput.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { Loader2 } from "lucide-react"
 import { useEffect, useState } from "react"
 
 import { Button } from "@/components/ui/button"
@@ -13,6 +14,7 @@ const ApiKeyInput = () => {
   const [apiKey, setApiKey] = useState("")
   const [maskedKey, setMaskedKey] = useState("")
   const [isEditing, setIsEditing] = useState(false)
+  const [isVerifying, setIsVerifying] = useState(false)
 
   const { toast } = useToast()
 
@@ -32,6 +34,7 @@ const ApiKeyInput = () => {
 
   const handleSave = async () => {
     try {
+      setIsVerifying(true)
       const response = await fetch("/api/openai/check", {
         method: "POST",
         headers: {
@@ -64,13 +67,14 @@ const ApiKeyInput = () => {
       console.error("Failed to verify API key:", error)
       localStorage.removeItem(LOCAL_STORAGE_KEY)
     } finally {
+      setIsVerifying(false)
       setIsEditing(false)
     }
   }
 
   const maskApiKey = (key: string) => {
     if (key.length <= 10) return key
-    return `${key.slice(0, 5)}**********${key.slice(-5)}`
+    return `${key.slice(0, 5)}**********${key.slice(-4)}`
   }
 
   return (
@@ -78,7 +82,7 @@ const ApiKeyInput = () => {
       <div>
         <Label
           htmlFor="openai-api-key"
-          className="text-xs text-muted-foreground"
+          className="text-xs text-muted-foreground font-light"
         >
           OpenAI API Key
         </Label>
@@ -93,7 +97,9 @@ const ApiKeyInput = () => {
         />
       </div>
       {isEditing ? (
-        <Button onClick={handleSave}>Save</Button>
+        <Button onClick={handleSave} disabled={isVerifying}>
+          {isVerifying ? <Loader2 className="w-4 h-4 animate-spin" /> : "Save"}
+        </Button>
       ) : (
         <Button onClick={() => setIsEditing(!isEditing)} variant="secondary">
           Edit

--- a/components/APIKeyInput.tsx
+++ b/components/APIKeyInput.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { useToast } from "@/hooks/use-toast"
 
 const LOCAL_STORAGE_KEY = "openAIApiKey"
 
@@ -12,6 +13,8 @@ const ApiKeyInput = () => {
   const [apiKey, setApiKey] = useState("")
   const [maskedKey, setMaskedKey] = useState("")
   const [isEditing, setIsEditing] = useState(false)
+
+  const { toast } = useToast()
 
   useEffect(() => {
     const storedKey = localStorage.getItem(LOCAL_STORAGE_KEY)
@@ -29,7 +32,7 @@ const ApiKeyInput = () => {
 
   const handleSave = async () => {
     try {
-      const response = await fetch("/api/test", {
+      const response = await fetch("/api/openai/check", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -37,12 +40,25 @@ const ApiKeyInput = () => {
         body: JSON.stringify({ apiKey }),
       })
 
+      if (!response.ok) {
+        toast({
+          title: "API key verification failed",
+          description: "Please check your API key and try again.",
+          variant: "destructive",
+        })
+        localStorage.removeItem(LOCAL_STORAGE_KEY)
+        return
+      }
+
       const result = await response.json()
 
       if (result.success) {
+        toast({
+          title: "API key saved",
+          description:
+            "Your API key was verified and saved successfully. You can now generate Github comments and create Pull Requests.",
+        })
         localStorage.setItem(LOCAL_STORAGE_KEY, apiKey)
-      } else {
-        localStorage.removeItem(LOCAL_STORAGE_KEY)
       }
     } catch (error) {
       console.error("Failed to verify API key:", error)

--- a/components/APIKeyInput.tsx
+++ b/components/APIKeyInput.tsx
@@ -7,8 +7,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { useToast } from "@/hooks/use-toast"
-
-const LOCAL_STORAGE_KEY = "openAIApiKey"
+import { LOCAL_STORAGE_KEY } from "@/lib/globals"
 
 const ApiKeyInput = () => {
   const [apiKey, setApiKey] = useState("")

--- a/components/APIKeyInput.tsx
+++ b/components/APIKeyInput.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input"
 const ApiKeyInput = () => {
   const [apiKey, setApiKey] = useState("")
   const [maskedKey, setMaskedKey] = useState("")
+  const [isEditing, setIsEditing] = useState(false)
 
   useEffect(() => {
     const storedKey = localStorage.getItem("openaiApiKey")
@@ -17,14 +18,15 @@ const ApiKeyInput = () => {
     }
   }, [])
 
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newKey = event.target.value
     setApiKey(newKey)
     setMaskedKey(maskApiKey(newKey))
   }
 
   const handleSave = () => {
-    localStorage.setItem("openaiApiKey", apiKey)
+    localStorage.setItem("openAIApiKey", apiKey)
+    setIsEditing(false)
   }
 
   const maskApiKey = (key: string) => {
@@ -36,12 +38,20 @@ const ApiKeyInput = () => {
     <div className="flex items-center justify-end gap-2">
       <Input
         type="text"
-        value={apiKey}
-        onChange={handleChange}
-        placeholder="Enter API Key"
+        id="openai-api-key"
+        placeholder={isEditing ? "Enter your OpenAI API key" : ""}
+        value={isEditing ? apiKey : maskedKey}
+        onChange={handleInputChange}
+        readOnly={!isEditing}
+        className={!isEditing ? "bg-gray-100 text-gray-500" : ""}
       />
-      <Button onClick={handleSave}>Save</Button>
-      <div className="ml-2">{maskedKey}</div>
+      {isEditing ? (
+        <Button onClick={handleSave}>Save</Button>
+      ) : (
+        <Button onClick={() => setIsEditing(!isEditing)} variant="secondary">
+          Edit
+        </Button>
+      )}
     </div>
   )
 }

--- a/components/APIKeyInput.tsx
+++ b/components/APIKeyInput.tsx
@@ -27,9 +27,29 @@ const ApiKeyInput = () => {
     setMaskedKey(maskApiKey(newKey))
   }
 
-  const handleSave = () => {
-    localStorage.setItem(LOCAL_STORAGE_KEY, apiKey)
-    setIsEditing(false)
+  const handleSave = async () => {
+    try {
+      const response = await fetch("/api/test", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ apiKey }),
+      })
+
+      const result = await response.json()
+
+      if (result.success) {
+        localStorage.setItem(LOCAL_STORAGE_KEY, apiKey)
+      } else {
+        localStorage.removeItem(LOCAL_STORAGE_KEY)
+      }
+    } catch (error) {
+      console.error("Failed to verify API key:", error)
+      localStorage.removeItem(LOCAL_STORAGE_KEY)
+    } finally {
+      setIsEditing(false)
+    }
   }
 
   const maskApiKey = (key: string) => {

--- a/components/APIKeyInput.tsx
+++ b/components/APIKeyInput.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
 
 const ApiKeyInput = () => {
   const [apiKey, setApiKey] = useState("")
@@ -35,16 +36,24 @@ const ApiKeyInput = () => {
   }
 
   return (
-    <div className="flex items-center justify-end gap-2">
-      <Input
-        type="text"
-        id="openai-api-key"
-        placeholder={isEditing ? "Enter your OpenAI API key" : ""}
-        value={isEditing ? apiKey : maskedKey}
-        onChange={handleInputChange}
-        readOnly={!isEditing}
-        className={!isEditing ? "bg-gray-100 text-gray-500" : ""}
-      />
+    <div className="flex items-end justify-end gap-2">
+      <div>
+        <Label
+          htmlFor="openai-api-key"
+          className="text-xs text-muted-foreground"
+        >
+          OpenAI API Key
+        </Label>
+        <Input
+          type="text"
+          id="openai-api-key"
+          placeholder={isEditing ? "Enter your OpenAI API key" : ""}
+          value={isEditing ? apiKey : maskedKey}
+          onChange={handleInputChange}
+          readOnly={!isEditing}
+          className={!isEditing ? "bg-gray-100 text-gray-500" : ""}
+        />
+      </div>
       {isEditing ? (
         <Button onClick={handleSave}>Save</Button>
       ) : (

--- a/components/APIKeyInput.tsx
+++ b/components/APIKeyInput.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+
+const ApiKeyInput = () => {
+  const [apiKey, setApiKey] = useState("")
+  const [maskedKey, setMaskedKey] = useState("")
+
+  useEffect(() => {
+    const storedKey = localStorage.getItem("openaiApiKey")
+    if (storedKey) {
+      setApiKey(storedKey)
+      setMaskedKey(maskApiKey(storedKey))
+    }
+  }, [])
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newKey = event.target.value
+    setApiKey(newKey)
+    setMaskedKey(maskApiKey(newKey))
+  }
+
+  const handleSave = () => {
+    localStorage.setItem("openaiApiKey", apiKey)
+  }
+
+  const maskApiKey = (key: string) => {
+    if (key.length <= 10) return key
+    return `${key.slice(0, 5)}**********${key.slice(-5)}`
+  }
+
+  return (
+    <div className="flex items-center justify-end gap-2">
+      <Input
+        type="text"
+        value={apiKey}
+        onChange={handleChange}
+        placeholder="Enter API Key"
+      />
+      <Button onClick={handleSave}>Save</Button>
+      <div className="ml-2">{maskedKey}</div>
+    </div>
+  )
+}
+
+export default ApiKeyInput

--- a/components/APIKeyInput.tsx
+++ b/components/APIKeyInput.tsx
@@ -6,13 +6,15 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 
+const LOCAL_STORAGE_KEY = "openAIApiKey"
+
 const ApiKeyInput = () => {
   const [apiKey, setApiKey] = useState("")
   const [maskedKey, setMaskedKey] = useState("")
   const [isEditing, setIsEditing] = useState(false)
 
   useEffect(() => {
-    const storedKey = localStorage.getItem("openaiApiKey")
+    const storedKey = localStorage.getItem(LOCAL_STORAGE_KEY)
     if (storedKey) {
       setApiKey(storedKey)
       setMaskedKey(maskApiKey(storedKey))
@@ -26,7 +28,7 @@ const ApiKeyInput = () => {
   }
 
   const handleSave = () => {
-    localStorage.setItem("openAIApiKey", apiKey)
+    localStorage.setItem(LOCAL_STORAGE_KEY, apiKey)
     setIsEditing(false)
   }
 

--- a/components/AddGithubCommentButton.tsx
+++ b/components/AddGithubCommentButton.tsx
@@ -1,9 +1,11 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
 import { Button } from "@/components/ui/button"
+import { toast } from "@/hooks/use-toast"
 import { GitHubRepository } from "@/lib/types"
+import { getApiKeyFromLocalStorage } from "@/lib/utils"
 
 export function AddGithubCommentButton({
   issueNumber,
@@ -13,12 +15,35 @@ export function AddGithubCommentButton({
   repo: GitHubRepository
 }) {
   const [isLoading, setIsLoading] = useState(false)
+  const [apiKey, setApiKey] = useState("")
+
+  // Load any existing API key from local storage
+  useEffect(() => {
+    const key = getApiKeyFromLocalStorage()
+    if (key) {
+      setApiKey(key)
+    }
+  }, [])
 
   const handleAddComment = async () => {
+    if (!apiKey) {
+      // Pull API key if recently saved
+      const key = getApiKeyFromLocalStorage()
+      if (!key) {
+        toast({
+          title: "API key not found",
+          description: "Please save an OpenAI API key first.",
+          variant: "destructive",
+        })
+        return
+      }
+      setApiKey(key)
+    }
+
     setIsLoading(true)
     const response = await fetch("/api/comment", {
       method: "POST",
-      body: JSON.stringify({ issueNumber, repo }),
+      body: JSON.stringify({ issueNumber, repo, apiKey }),
     })
     console.log(response)
     setIsLoading(false)

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,8 +1,8 @@
 "use client"
 
-import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
 import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react"
 
 import { cn } from "@/lib/utils"
 

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -1,0 +1,129 @@
+"use client"
+
+import * as ToastPrimitives from "@radix-ui/react-toast"
+import { cva, type VariantProps } from "class-variance-authority"
+import { X } from "lucide-react"
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const ToastProvider = ToastPrimitives.Provider
+
+const ToastViewport = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Viewport
+    ref={ref}
+    className={cn(
+      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      className
+    )}
+    {...props}
+  />
+))
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName
+
+const toastVariants = cva(
+  "group pointer-events-auto relative flex w-full items-center justify-between space-x-2 overflow-hidden rounded-md border p-4 pr-6 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+  {
+    variants: {
+      variant: {
+        default: "border bg-background text-foreground",
+        destructive:
+          "destructive group border-destructive bg-destructive text-destructive-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+const Toast = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> &
+    VariantProps<typeof toastVariants>
+>(({ className, variant, ...props }, ref) => {
+  return (
+    <ToastPrimitives.Root
+      ref={ref}
+      className={cn(toastVariants({ variant }), className)}
+      {...props}
+    />
+  )
+})
+Toast.displayName = ToastPrimitives.Root.displayName
+
+const ToastAction = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Action>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Action
+    ref={ref}
+    className={cn(
+      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-secondary focus:outline-none focus:ring-1 focus:ring-ring disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
+      className
+    )}
+    {...props}
+  />
+))
+ToastAction.displayName = ToastPrimitives.Action.displayName
+
+const ToastClose = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Close>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Close
+    ref={ref}
+    className={cn(
+      "absolute right-1 top-1 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-1 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      className
+    )}
+    toast-close=""
+    {...props}
+  >
+    <X className="h-4 w-4" />
+  </ToastPrimitives.Close>
+))
+ToastClose.displayName = ToastPrimitives.Close.displayName
+
+const ToastTitle = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Title>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Title
+    ref={ref}
+    className={cn("text-sm font-semibold [&+div]:text-xs", className)}
+    {...props}
+  />
+))
+ToastTitle.displayName = ToastPrimitives.Title.displayName
+
+const ToastDescription = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Description>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Description
+    ref={ref}
+    className={cn("text-sm opacity-90", className)}
+    {...props}
+  />
+))
+ToastDescription.displayName = ToastPrimitives.Description.displayName
+
+type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>
+
+type ToastActionElement = React.ReactElement<typeof ToastAction>
+
+export {
+  Toast,
+  ToastAction,
+  type ToastActionElement,
+  ToastClose,
+  ToastDescription,
+  type ToastProps,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+}

--- a/components/ui/toaster.tsx
+++ b/components/ui/toaster.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import {
+  Toast,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from "@/components/ui/toast"
+import { useToast } from "@/hooks/use-toast"
+
+export function Toaster() {
+  const { toasts } = useToast()
+
+  return (
+    <ToastProvider>
+      {toasts.map(function ({ id, title, description, action, ...props }) {
+        return (
+          <Toast key={id} {...props}>
+            <div className="grid gap-1">
+              {title && <ToastTitle>{title}</ToastTitle>}
+              {description && (
+                <ToastDescription>{description}</ToastDescription>
+              )}
+            </div>
+            {action}
+            <ToastClose />
+          </Toast>
+        )
+      })}
+      <ToastViewport />
+    </ToastProvider>
+  )
+}

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -1,0 +1,191 @@
+"use client"
+
+// Inspired by react-hot-toast library
+import * as React from "react"
+
+import type { ToastActionElement, ToastProps } from "@/components/ui/toast"
+
+const TOAST_LIMIT = 1
+const TOAST_REMOVE_DELAY = 1000000
+
+type ToasterToast = ToastProps & {
+  id: string
+  title?: React.ReactNode
+  description?: React.ReactNode
+  action?: ToastActionElement
+}
+
+const actionTypes = {
+  ADD_TOAST: "ADD_TOAST",
+  UPDATE_TOAST: "UPDATE_TOAST",
+  DISMISS_TOAST: "DISMISS_TOAST",
+  REMOVE_TOAST: "REMOVE_TOAST",
+} as const
+
+let count = 0
+
+function genId() {
+  count = (count + 1) % Number.MAX_SAFE_INTEGER
+  return count.toString()
+}
+
+type ActionType = typeof actionTypes
+
+type Action =
+  | {
+      type: ActionType["ADD_TOAST"]
+      toast: ToasterToast
+    }
+  | {
+      type: ActionType["UPDATE_TOAST"]
+      toast: Partial<ToasterToast>
+    }
+  | {
+      type: ActionType["DISMISS_TOAST"]
+      toastId?: ToasterToast["id"]
+    }
+  | {
+      type: ActionType["REMOVE_TOAST"]
+      toastId?: ToasterToast["id"]
+    }
+
+interface State {
+  toasts: ToasterToast[]
+}
+
+const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>()
+
+const addToRemoveQueue = (toastId: string) => {
+  if (toastTimeouts.has(toastId)) {
+    return
+  }
+
+  const timeout = setTimeout(() => {
+    toastTimeouts.delete(toastId)
+    dispatch({
+      type: "REMOVE_TOAST",
+      toastId: toastId,
+    })
+  }, TOAST_REMOVE_DELAY)
+
+  toastTimeouts.set(toastId, timeout)
+}
+
+export const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case "ADD_TOAST":
+      return {
+        ...state,
+        toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
+      }
+
+    case "UPDATE_TOAST":
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === action.toast.id ? { ...t, ...action.toast } : t
+        ),
+      }
+
+    case "DISMISS_TOAST": {
+      const { toastId } = action
+
+      // ! Side effects ! - This could be extracted into a dismissToast() action,
+      // but I'll keep it here for simplicity
+      if (toastId) {
+        addToRemoveQueue(toastId)
+      } else {
+        state.toasts.forEach((toast) => {
+          addToRemoveQueue(toast.id)
+        })
+      }
+
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === toastId || toastId === undefined
+            ? {
+                ...t,
+                open: false,
+              }
+            : t
+        ),
+      }
+    }
+    case "REMOVE_TOAST":
+      if (action.toastId === undefined) {
+        return {
+          ...state,
+          toasts: [],
+        }
+      }
+      return {
+        ...state,
+        toasts: state.toasts.filter((t) => t.id !== action.toastId),
+      }
+  }
+}
+
+const listeners: Array<(state: State) => void> = []
+
+let memoryState: State = { toasts: [] }
+
+function dispatch(action: Action) {
+  memoryState = reducer(memoryState, action)
+  listeners.forEach((listener) => {
+    listener(memoryState)
+  })
+}
+
+type Toast = Omit<ToasterToast, "id">
+
+function toast({ ...props }: Toast) {
+  const id = genId()
+
+  const update = (props: ToasterToast) =>
+    dispatch({
+      type: "UPDATE_TOAST",
+      toast: { ...props, id },
+    })
+  const dismiss = () => dispatch({ type: "DISMISS_TOAST", toastId: id })
+
+  dispatch({
+    type: "ADD_TOAST",
+    toast: {
+      ...props,
+      id,
+      open: true,
+      onOpenChange: (open) => {
+        if (!open) dismiss()
+      },
+    },
+  })
+
+  return {
+    id: id,
+    dismiss,
+    update,
+  }
+}
+
+function useToast() {
+  const [state, setState] = React.useState<State>(memoryState)
+
+  React.useEffect(() => {
+    listeners.push(setState)
+    return () => {
+      const index = listeners.indexOf(setState)
+      if (index > -1) {
+        listeners.splice(index, 1)
+      }
+    }
+  }, [state])
+
+  return {
+    ...state,
+    toast,
+    dismiss: (toastId?: string) => dispatch({ type: "DISMISS_TOAST", toastId }),
+  }
+}
+
+export { toast, useToast }

--- a/lib/agents/thinker.ts
+++ b/lib/agents/thinker.ts
@@ -22,10 +22,10 @@ export class ThinkerAgent {
   issue: Issue
   trace: LangfuseTraceClient
 
-  constructor(dirPath: string, trace: LangfuseTraceClient) {
+  constructor(dirPath: string, trace: LangfuseTraceClient, apiKey: string) {
     this.prompt = thinkerAgentPrompt
     this.llm = new OpenAI({
-      apiKey: process.env.OPENAI_API_KEY,
+      apiKey,
     })
     this.dirPath = dirPath
     this.trace = trace

--- a/lib/globals.ts
+++ b/lib/globals.ts
@@ -1,0 +1,1 @@
+export const LOCAL_STORAGE_KEY = "openai-api-key"

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,12 @@
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
 
+import { LOCAL_STORAGE_KEY } from "@/lib/globals"
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
+}
+
+export function getApiKeyFromLocalStorage(): string | null {
+  return localStorage.getItem(LOCAL_STORAGE_KEY)
 }

--- a/lib/workflows/commentOnIssue.ts
+++ b/lib/workflows/commentOnIssue.ts
@@ -16,7 +16,8 @@ import { GitHubRepository } from "@/lib/types"
 
 export default async function commentOnIssue(
   issueNumber: number,
-  repo: GitHubRepository
+  repo: GitHubRepository,
+  apiKey: string
 ) {
   console.log("commentOnIssue workflow", issueNumber, repo)
 
@@ -39,7 +40,7 @@ export default async function commentOnIssue(
   }
 
   // Create the thinker agent
-  const thinker = new ThinkerAgent(dirPath, trace)
+  const thinker = new ThinkerAgent(dirPath, trace, apiKey)
   thinker.issue = issue
 
   const span = trace.span({ name: "generateComment" })

--- a/lib/workflows/resolveIssue.ts
+++ b/lib/workflows/resolveIssue.ts
@@ -10,7 +10,11 @@ import { Issue } from "@/lib/types"
 import { getRepoFromString } from "../github/content"
 import { langfuse } from "../langfuse"
 
-export const resolveIssue = async (issue: Issue, repoName: string) => {
+export const resolveIssue = async (
+  issue: Issue,
+  repoName: string,
+  apiKey: string
+) => {
   // Get or create a local directory to work off of
   const repository = await getRepoFromString(repoName)
   const baseDir = await getLocalRepoDir(repository.full_name)
@@ -25,7 +29,8 @@ export const resolveIssue = async (issue: Issue, repoName: string) => {
     repository,
     trace,
     baseDir,
-    repoName
+    repoName,
+    apiKey
   )
   await agent.run()
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-dropdown-menu": "^2.1.4",
         "@radix-ui/react-label": "^2.1.1",
         "@radix-ui/react-slot": "^1.1.1",
+        "@radix-ui/react-toast": "^1.2.5",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "langfuse": "^3.32.0",
@@ -1292,6 +1293,67 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.5.tgz",
+      "integrity": "sha512-ZzUsAaOx8NdXZZKcFNDhbSlbsCUy8qQWmzTdgrlrhhZAOx2ofLtKrBDW9fkqhFvXgmtv560Uj16pkLkqML7SHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-collection": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.4",
+        "@radix-ui/react-portal": "1.1.3",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-visually-hidden": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.4.tgz",
+      "integrity": "sha512-XDUI0IVYVSwjMXxM6P4Dfti7AH+Y4oS/TB+sglZ/EXc7cqLwGAmp1NlMrcUjj7ks6R5WTZuWKv44FBbLpwU3sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
@@ -1390,6 +1452,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.1.1.tgz",
+      "integrity": "sha512-vVfA2IZ9q/J+gEamvj761Oq1FpWgCDaNOOIfbPVp2MVPLEomUr5+Vf7kJGwQ24YxZSlQVar7Bes8kyTo5Dshpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@octokit/rest": "^21.0.2",
         "@radix-ui/react-dropdown-menu": "^2.1.4",
+        "@radix-ui/react-label": "^2.1.1",
         "@radix-ui/react-slot": "^1.1.1",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
@@ -1072,6 +1073,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.1.tgz",
+      "integrity": "sha512-UUw5E4e/2+4kFMH7+YxORXGWggtY6sM8WIwh5RZchhLuUg2H1hc98Py+pr8HMz6rdaYrK2t296ZEjYLOCO5uUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.4",
     "@radix-ui/react-label": "^2.1.1",
     "@radix-ui/react-slot": "^1.1.1",
+    "@radix-ui/react-toast": "^1.2.5",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "langfuse": "^3.32.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@octokit/rest": "^21.0.2",
     "@radix-ui/react-dropdown-menu": "^2.1.4",
+    "@radix-ui/react-label": "^2.1.1",
     "@radix-ui/react-slot": "^1.1.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",


### PR DESCRIPTION
This allows the user to use their own OpenAI API key. 

They'll be prompted when looking at an issues page.

They cannot run any actions if the key is not uploaded.

For now, the key is saved in local storage on their browser, and is sent over network requests for the `/api/resolve` and `/api/comment` API endpoints.

This is not as secure. Next step is to implement a database, and secure those API keys on a database, tied to the user. So we'll also need to setup user management with the database.

There needs to be some encryptino of the key in transit and at rest.

And users can then save their own API key, and use the applicadtion with their own API key.