### PR TITLE
Updates git clone with user's auth tokens

### DIFF
--- a/app/api/resolve/route.ts
+++ b/app/api/resolve/route.ts
@@ -18,8 +18,14 @@ export async function POST(request: NextRequest) {
   const { issueNumber, repo, apiKey }: RequestBody = await request.json()
   const repoName = repo.name
   const repoUrl = repo.url
+
   const session = await auth()
-  const token = session?.user?.accessToken
+
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const token = session.user?.accessToken
 
   try {
     console.debug("[DEBUG] Starting POST request handler")

--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -18,6 +18,7 @@ import {
 import path from "path"
 import { z } from "zod"
 
+import { auth } from "@/auth"
 import {
   createDirectoryTree,
   getFileContent,
@@ -34,6 +35,7 @@ import {
 } from "@/lib/tools"
 import UploadAndPRTool from "@/lib/tools/UploadAndPR"
 import { GitHubRepository, Issue } from "@/lib/types"
+import { getCloneUrlWithAccessToken } from "@/lib/utils"
 
 export class CoordinatorAgent {
   private readonly agent: OpenAI
@@ -341,6 +343,9 @@ export class LibrarianAgent {
     // Run this before generating responses
     const repoPath = await getLocalRepoDir(this.repository.full_name)
 
+    const session = await auth()
+    const token = session?.user?.accessToken
+
     // Check if .git and codebase exist in tempDir
     // If not, clone the repo
     // If so, checkout the branch
@@ -349,7 +354,13 @@ export class LibrarianAgent {
     if (!gitExists) {
       // Clone the repo
       console.debug(`[DEBUG] Cloning repo: ${this.repository.clone_url}`)
-      await cloneRepo(this.repository.clone_url, repoPath)
+
+      // Attach access token to cloneUrl
+      const cloneUrlWithToken = getCloneUrlWithAccessToken(
+        this.repository.full_name,
+        token
+      )
+      await cloneRepo(cloneUrlWithToken, repoPath)
     }
 
     console.debug(`[DEBUG] Checking out branch ${this.branch}`)

--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -344,7 +344,12 @@ export class LibrarianAgent {
     const repoPath = await getLocalRepoDir(this.repository.full_name)
 
     const session = await auth()
-    const token = session?.user?.accessToken
+
+    if (!session) {
+      throw new Error("Unauthorized")
+    }
+
+    const token = session.user?.accessToken
 
     // Check if .git and codebase exist in tempDir
     // If not, clone the repo

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -10,3 +10,11 @@ export function cn(...inputs: ClassValue[]) {
 export function getApiKeyFromLocalStorage(): string | null {
   return localStorage.getItem(LOCAL_STORAGE_KEY)
 }
+
+export function getCloneUrlWithAccessToken(
+  userRepo: string,
+  token: string
+): string {
+  // userRepo format is "username/repo", like "youngchingjui/issue-to-pr"
+  return `https://${token}@github.com/${userRepo}.git`
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -15,6 +15,6 @@ export function getCloneUrlWithAccessToken(
   userRepo: string,
   token: string
 ): string {
-  // userRepo format is "username/repo", like "youngchingjui/issue-to-pr"
+  // userRepo format is "username/repo"
   return `https://${token}@github.com/${userRepo}.git`
 }


### PR DESCRIPTION
This allows other users to also run `git clone` locally on our machine, as the authentication tokens are attached onto the git clone url.

This is a fairly messy implementation, and we'll need to clean it up a bit.

Especially since we add calls to `auth()`, which checks for user's authentication.

We haven't fully thought through when these auth checks might fail, or how to handle those failures.