### PR TITLE
fix bug from async nature of setting state

### DIFF
--- a/components/AddGithubCommentButton.tsx
+++ b/components/AddGithubCommentButton.tsx
@@ -26,9 +26,10 @@ export function AddGithubCommentButton({
   }, [])
 
   const handleAddComment = async () => {
-    if (!apiKey) {
+    let key = apiKey
+    if (!key) {
       // Pull API key if recently saved
-      const key = getApiKeyFromLocalStorage()
+      key = getApiKeyFromLocalStorage()
       if (!key) {
         toast({
           title: "API key not found",
@@ -37,13 +38,13 @@ export function AddGithubCommentButton({
         })
         return
       }
-      setApiKey(key)
+      setApiKey(key) // Async, will not be used in this call, but will be used in future calls
     }
 
     setIsLoading(true)
     const response = await fetch("/api/comment", {
       method: "POST",
-      body: JSON.stringify({ issueNumber, repo, apiKey }),
+      body: JSON.stringify({ issueNumber, repo, apiKey: key }),
     })
     console.log(response)
     setIsLoading(false)

--- a/components/CreatePullRequestButton.tsx
+++ b/components/CreatePullRequestButton.tsx
@@ -25,9 +25,10 @@ export function CreatePullRequestButton({
   }, [])
 
   const handleCreatePR = async () => {
-    if (!apiKey) {
+    let key = apiKey
+    if (!key) {
       // Pull API key if recently saved
-      const key = getApiKeyFromLocalStorage()
+      key = getApiKeyFromLocalStorage()
       if (!key) {
         toast({
           title: "API key not found",
@@ -36,7 +37,7 @@ export function CreatePullRequestButton({
         })
         return
       }
-      setApiKey(key)
+      setApiKey(key) // Async, will not be used in this call, but will be used in future calls
     }
 
     setIsLoading(true)
@@ -47,7 +48,7 @@ export function CreatePullRequestButton({
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ issueNumber, repo, apiKey }),
+        body: JSON.stringify({ issueNumber, repo, apiKey: key }),
       })
 
       const data = await response.json()


### PR DESCRIPTION
Not the cleanest implementation, but it works.

Now, we're tracking the apikey in 2 variables, 1 state variable and 1 locally scoped variable.

This can certainly be cleaned up somehow, maybe in another issue.