### PR TITLE
Adjust tsconfig.json for hooks path

### DIFF
--- a/lib/hooks/index.ts
+++ b/lib/hooks/index.ts
@@ -1,0 +1,4 @@
+// The use-toast.ts file has been removed, so we no longer export from it.
+// If useToast or toast is needed, they should be re-implemented or imported from another source.
+
+// Placeholder for future hook exports

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "paths": {
       "@/styles/*": ["styles/*"],
       "@/components/*": ["components/*"],
+      "@/hooks/*": ["lib/hooks/*"], // updated path
       "@/*": ["./*"]
     },
     "target": "ES2017",
@@ -22,11 +23,9 @@
     "jsx": "preserve",
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ]
+    "plugins": [{
+      "name": "next"
+    }]
   },
   "include": ["**/*", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Updated the tsconfig.json file to correctly map hooks under lib directory, confirming with current structure and future-proofing imports if needed.