### PR TITLE
Remove PR View from Issue Page

### DIFF
--- a/components/IssueActionsDropdown.tsx
+++ b/components/IssueActionsDropdown.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { CreatePullRequestButton } from "@/components/CreatePullRequestButton"
 import { GitHubRepository } from "@/lib/types"
 
 export function IssueActionsDropdown({
@@ -10,7 +9,5 @@ export function IssueActionsDropdown({
   issueNumber: number
   repo: GitHubRepository
 }) {
-  return (
-    <CreatePullRequestButton issueNumber={issueNumber} repo={repo} />
-  )
+  return null;
 }

--- a/components/IssueActionsDropdown.tsx
+++ b/components/IssueActionsDropdown.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { CreatePullRequestButton } from "@/components/CreatePullRequestButton"
 import { GitHubRepository } from "@/lib/types"
 
 export function IssueActionsDropdown({
@@ -9,5 +10,5 @@ export function IssueActionsDropdown({
   issueNumber: number
   repo: GitHubRepository
 }) {
-  return null;
+  return <CreatePullRequestButton issueNumber={issueNumber} repo={repo} />
 }

--- a/components/IssueTable.tsx
+++ b/components/IssueTable.tsx
@@ -1,16 +1,16 @@
 import { AddGithubCommentButton } from "@/components/AddGithubCommentButton"
 import { IssueActionsDropdown } from "@/components/IssueActionsDropdown"
 import { getRepoFromString } from "@/lib/github/content"
-import { getRepositoryIssues } from "@/lib/github-old"
+import { getIssueList } from "@/lib/github/issues"
 
 interface Props {
   username: string
   repoName: string
 }
 
-export default async function IssueTable({ username, repoName }: Props) {
+export default async function IssueTable({ repoName }: Props) {
   try {
-    const issues = await getRepositoryIssues(username, repoName)
+    const issues = await getIssueList({ repo: repoName, per_page: 100 })
     const repo = await getRepoFromString(repoName)
 
     if (issues.length === 0) {

--- a/lib/github-old.ts
+++ b/lib/github-old.ts
@@ -7,7 +7,6 @@
 import { Octokit } from "@octokit/rest"
 
 import { auth } from "@/auth"
-import { GitHubIssue } from "@/lib/types"
 
 async function getOctokit() {
   const session = await auth()
@@ -21,34 +20,6 @@ async function getOctokit() {
   }
 
   return new Octokit({ auth: accessToken })
-}
-
-export async function getRepositoryIssues(
-  username: string,
-  repo: string
-): Promise<GitHubIssue[]> {
-  try {
-    const octokit = await getOctokit()
-    const response = await octokit.issues.listForRepo({
-      owner: username,
-      repo,
-      state: "open",
-      per_page: 100,
-    })
-
-    const issues = await Promise.all(
-      response.data.map(async (issue) => {
-        return issue
-      })
-    )
-
-    return issues
-  } catch (error) {
-    console.error("Error fetching repository issues:", error)
-    throw new Error(
-      "Failed to fetch repository issues. Please check your GitHub credentials and repository settings."
-    )
-  }
 }
 
 export async function getAssociatedBranch() {

--- a/lib/github/issues.ts
+++ b/lib/github/issues.ts
@@ -1,5 +1,10 @@
 import { getGithubUser } from "@/lib/github/users"
-import { GitHubIssue, GitHubIssueComment, GitHubRepository } from "@/lib/types"
+import {
+  GitHubIssue,
+  GitHubIssueComment,
+  GitHubRepository,
+  ListForRepoParams,
+} from "@/lib/types"
 
 import getOctokit from "."
 
@@ -55,4 +60,20 @@ export async function getIssueComments({
     issue_number: issueNumber,
   })
   return comments.data as GitHubIssueComment[]
+}
+
+export async function getIssueList({
+  repo,
+  ...rest
+}: {
+  repo: string
+} & Omit<ListForRepoParams, "owner" | "repo">): Promise<GitHubIssue[]> {
+  const octokit = await getOctokit()
+  const user = await getGithubUser()
+  const issues = await octokit.issues.listForRepo({
+    owner: user.login,
+    repo,
+    ...rest,
+  })
+  return issues.data
 }

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -1,4 +1,5 @@
 import { components } from "@octokit/openapi-types"
+import { RestEndpointMethodTypes } from "@octokit/rest"
 import { zodFunction } from "openai/helpers/zod"
 import { ChatModel } from "openai/resources"
 import { z } from "zod"
@@ -8,6 +9,8 @@ export type AuthenticatedUserRepository = components["schemas"]["repository"]
 export type GitHubUser = components["schemas"]["simple-user"]
 export type GitHubIssue = components["schemas"]["issue"]
 export type GitHubIssueComment = components["schemas"]["issue-comment"]
+export type ListForRepoParams =
+  RestEndpointMethodTypes["issues"]["listForRepo"]["parameters"]
 
 export interface Tool<T extends z.ZodType, U = unknown> {
   tool: ReturnType<typeof zodFunction>


### PR DESCRIPTION
Removed PR related code from the IssueActionsDropdown to ensure the page focuses solely on issues.