### PR TITLE
Added Link Column to IssueTable

### DIFF
--- a/components/IssueRow.tsx
+++ b/components/IssueRow.tsx
@@ -133,6 +133,11 @@ export function IssueRow({ issue, repo }: IssueRowProps) {
         <div className="flex-1">
           <CreatePullRequestButton issueNumber={issue.number} repo={repo} />
         </div>
+        <div className="flex-1">
+          <a href={issue.html_url} target="_blank" rel="noopener noreferrer" className="text-blue-500 underline">
+            View Issue
+          </a>
+        </div>        
       </div>
       {expandedIssue === issue.id && (
         <div className="w-full py-2 px-4">

--- a/components/IssueTable.tsx
+++ b/components/IssueTable.tsx
@@ -23,6 +23,7 @@ export default async function IssueTable({ repoName }: Props) {
           <div className="flex-1 font-bold">Status</div>
           <div className="flex-1 font-bold">Comment</div>
           <div className="flex-1 font-bold">Actions</div>
+          <div className="flex-1 font-bold">Link</div> {/* New Link column added */}
         </div>
         <div>
           {issues.map((issue) => (


### PR DESCRIPTION
This update introduces a 'Link' column in the IssueTable component, which provides users with direct clickable links to GitHub issue pages. Each link opens in a new tab for convenience, enhancing navigation possibilities.