### PR TITLE
Add 'Go to issue' button for direct GitHub issue navigation

### DIFF
--- a/components/IssueRow.tsx
+++ b/components/IssueRow.tsx
@@ -112,6 +112,8 @@ export function IssueRow({ issue, repo }: IssueRowProps) {
     }
   }
 
+  const issueUrl = `https://github.com/${repo.owner}/${repo.name}/issues/${issue.number}`
+
   return (
     <div className="flex flex-col border-b">
       <div className="flex py-2 px-4">
@@ -128,6 +130,17 @@ export function IssueRow({ issue, repo }: IssueRowProps) {
           >
             <MessageCircle className="mr-2 h-4 w-4" />
             Add GitHub Comment
+          </Button>
+        </div>
+        <div className="flex-1 flex items-center">
+          <Button
+            as="a"
+            href={issueUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            variant="secondary"
+          >
+            Go to issue
           </Button>
         </div>
         <div className="flex-1">


### PR DESCRIPTION
This PR introduces a new button labeled 'Go to issue' within the IssueRow component. The button links directly to the GitHub issue page, utilizing the issue number and repository details. Styled with the 'secondary' variant to match the existing UI, this enhancement improves user navigation and access to GitHub issues directly from the application.