### PR TITLE
Filter out PRs from issues list

### DIFF
--- a/lib/github/issues.ts
+++ b/lib/github/issues.ts
@@ -75,5 +75,6 @@ export async function getIssueList({
     repo,
     ...rest,
   })
-  return issues.data
+  // Filter out pull requests from the list of issues
+  return issues.data.filter(issue => !issue.pull_request)
 }


### PR DESCRIPTION
This PR resolves the issue of displaying pull requests in the issues list by filtering them out on both backend and frontend. The `getIssueList` function was enhanced to exclude pull requests, and the `IssueTable` component now applies additional filtering to ensure it only lists issues.