### PR TITLE
Automatically link PRs with issues

### DIFF
--- a/lib/github/pullRequests.ts
+++ b/lib/github/pullRequests.ts
@@ -29,20 +29,25 @@ export async function createPullRequest({
   branch,
   title,
   body,
+  issueNumber,
 }: {
   repo: string
   branch: string
   title: string
   body: string
+  issueNumber?: number
 }) {
   const octokit = await getOctokit()
   const user = await getGithubUser()
+
+  // Append issue-closing keyword if issueNumber is provided
+  const finalBody = issueNumber ? `${body}\nCloses #${issueNumber}` : body;
 
   const pullRequest = await octokit.pulls.create({
     owner: user.login,
     repo,
     title,
-    body,
+    body: finalBody,
     head: branch,
     base: "main",
   })


### PR DESCRIPTION
This update modifies the `createPullRequest` function to automatically append an issue-closing keyword to the pull request description when an issue number is provided. This ensures that when a pull request is merged, the related issue is automatically closed if the default branch is targeted.