### PR TITLE
Handle Error If Branch Already Exists

### DIFF
--- a/lib/github/git.ts
+++ b/lib/github/git.ts
@@ -9,18 +9,38 @@ export async function createBranch(
   const octokit = await getOctokit()
   const user = await getGithubUser()
 
-  // Get the latest commit SHA of the base branch
-  const { data: baseBranchData } = await octokit.repos.getBranch({
+  // Check if the branch already exists
+  const { data: branches } = await octokit.repos.listBranches({
     owner: user.login,
     repo,
-    branch: baseBranch,
   })
+  const branchExists = branches.some(({ name }) => name === branch)
 
-  // Create a new branch
-  await octokit.git.createRef({
-    owner: user.login,
-    repo,
-    ref: `refs/heads/${branch}`,
-    sha: baseBranchData.commit.sha,
-  })
+  if (branchExists) {
+    console.log(`Branch '${branch}' already exists.`)
+    return `Branch '${branch}' already exists.`
+  }
+
+  try {
+    // Get the latest commit SHA of the base branch
+    const { data: baseBranchData } = await octokit.repos.getBranch({
+      owner: user.login,
+      repo,
+      branch: baseBranch,
+    })
+
+    // Create a new branch
+    await octokit.git.createRef({
+      owner: user.login,
+      repo,
+      ref: `refs/heads/${branch}`,
+      sha: baseBranchData.commit.sha,
+    })
+
+    console.log(`Branch '${branch}' created successfully.`)
+    return `Branch '${branch}' created successfully.`
+  } catch (error) {
+    console.error(`Failed to create branch '${branch}':`, error)
+    return `Failed to create branch '${branch}': ${error.message}`
+  }
 }


### PR DESCRIPTION
Updated the `createBranch` function to handle cases where the branch already exists:

- Checks if a branch already exists before attempting to create a new one.
- Uses a try-catch block to manage exceptions from the GitHub API.
- Provides user feedback when a branch creation attempt fails due to an existing branch.