### PR TITLE
Handle Error When Branch Already Exists

### DIFF
--- a/lib/github/git.ts
+++ b/lib/github/git.ts
@@ -9,18 +9,35 @@ export async function createBranch(
   const octokit = await getOctokit()
   const user = await getGithubUser()
 
-  // Get the latest commit SHA of the base branch
-  const { data: baseBranchData } = await octokit.repos.getBranch({
-    owner: user.login,
-    repo,
-    branch: baseBranch,
-  })
+  try {
+    // Check if the branch already exists
+    await octokit.repos.getBranch({
+      owner: user.login,
+      repo,
+      branch,
+    })
 
-  // Create a new branch
-  await octokit.git.createRef({
-    owner: user.login,
-    repo,
-    ref: `refs/heads/${branch}`,
-    sha: baseBranchData.commit.sha,
-  })
+    console.error(`Branch '${branch}' already exists.`)
+  } catch (error) {
+    // If the branch does not exist, proceed to create it
+    if (error.status === 404) {
+      // Get the latest commit SHA of the base branch
+      const { data: baseBranchData } = await octokit.repos.getBranch({
+        owner: user.login,
+        repo,
+        branch: baseBranch,
+      })
+
+      // Create a new branch
+      await octokit.git.createRef({
+        owner: user.login,
+        repo,
+        ref: `refs/heads/${branch}`,
+        sha: baseBranchData.commit.sha,
+      })
+    } else {
+      // Handle other errors that might occur
+      console.error(`An error occurred: ${error.message}`)
+    }
+  }
 }


### PR DESCRIPTION
Enhanced the `createBranch` function to handle scenarios where a branch with the same name already exists.

Features:
- Checks if a branch already exists before attempting to create it.
- Uses a `try-catch` block to handle errors gracefully.
- Provides user-friendly feedback when a branch already exists or an error occurs.