### PR TITLE
Automatically link PR with related issue

### DIFF
--- a/lib/github/pullRequests.ts
+++ b/lib/github/pullRequests.ts
@@ -29,20 +29,24 @@ export async function createPullRequest({
   branch,
   title,
   body,
+  issueNumber,
 }: {
   repo: string
   branch: string
   title: string
   body: string
+  issueNumber: number
 }) {
   const octokit = await getOctokit()
   const user = await getGithubUser()
+
+  const fullBody = `${body}\n\nCloses #${issueNumber}`;
 
   const pullRequest = await octokit.pulls.create({
     owner: user.login,
     repo,
     title,
-    body,
+    body: fullBody,
     head: branch,
     base: "main",
   })


### PR DESCRIPTION
Updated the pull request creation process to automatically include the issue closing keyword in the description. This ensures that when a pull request is merged, the related issue is automatically closed in the GitHub repository.