### PR TITLE
Enhance PR creation to automatically link with issues

### DIFF
--- a/lib/github/pullRequests.ts
+++ b/lib/github/pullRequests.ts
@@ -29,20 +29,27 @@ export async function createPullRequest({
   branch,
   title,
   body,
+  issueNumber,
 }: {
   repo: string
   branch: string
   title: string
   body: string
+  issueNumber?: number
 }) {
   const octokit = await getOctokit()
   const user = await getGithubUser()
+
+  let prBody = body;
+  if (issueNumber) {
+    prBody += `\n\nCloses #${issueNumber}`;
+  }
 
   const pullRequest = await octokit.pulls.create({
     owner: user.login,
     repo,
     title,
-    body,
+    body: prBody,
     head: branch,
     base: "main",
   })

--- a/lib/tools/UploadAndPR.ts
+++ b/lib/tools/UploadAndPR.ts
@@ -24,6 +24,7 @@ const uploadAndPRParameters = z.object({
   pullRequest: z.object({
     title: z.string().describe("The title of the pull request"),
     body: z.string().describe("The body of the pull request"),
+    issueNumber: z.number().optional().describe("The associated issue number, if available")
   }),
 })
 
@@ -107,6 +108,7 @@ class UploadAndPRTool implements Tool<typeof uploadAndPRParameters> {
         branch,
         title: pullRequest.title,
         body: pullRequest.body,
+        issueNumber: pullRequest.issueNumber
       })
       return JSON.stringify(pr)
     } catch (error) {


### PR DESCRIPTION
This pull request updates the PR creation process to include an automatic link to the related issue by appending the closing keyword in the PR description. The changes involve:

- Modification of 'createPullRequest' function to optionally accept 'issueNumber'.
- Adjusting any relevant function calls to pass this parameter where available.

These updates ensure that any merged PR will automatically close the associated issue if the issue number is provided during PR creation.