### PR TITLE
Read Github Private Key from file

### DIFF
--- a/lib/github/index.ts
+++ b/lib/github/index.ts
@@ -1,8 +1,17 @@
 import { Octokit } from "@octokit/rest"
+import * as fs from "fs"
 import { App } from "octokit"
 
 import { auth } from "@/auth"
 import { getInstallationId } from "@/lib/utils-server"
+
+function getPrivateKeyFromFile(): string {
+  const privateKeyPath = process.env.GITHUB_APP_PRIVATE_KEY_PATH
+  if (!privateKeyPath) {
+    throw new Error("GITHUB_APP_PRIVATE_KEY_PATH is not set")
+  }
+  return fs.readFileSync(privateKeyPath, "utf8")
+}
 
 export default async function getOctokit(): Promise<Octokit> {
   // Try to authenticate using user session
@@ -14,7 +23,7 @@ export default async function getOctokit(): Promise<Octokit> {
   // Fallback to GitHub App authentication
   const app = new App({
     appId: process.env.GITHUB_APP_ID,
-    privateKey: process.env.GITHUB_APP_PRIVATE_KEY,
+    privateKey: getPrivateKeyFromFile(),
   })
 
   // Assuming you have the installation ID from the webhook or other source


### PR DESCRIPTION
This updates the logic so we don't save a full .pem file into .env. Now we save the .pem file locally, and we just save the path to that pem file in environment.

Fixes #179