### PR TITLE
Enhance commentOnIssue workflow to update initial comment

### DIFF
--- a/lib/github/issues.ts
+++ b/lib/github/issues.ts
@@ -73,3 +73,28 @@ export async function getIssueList({
   // Filter out pull requests from the list of issues
   return issues.data.filter((issue) => !issue.pull_request)
 }
+
+export async function updateIssueComment({
+  commentId,
+  repoFullName,
+  comment,
+}: {
+  commentId: number
+  repoFullName: string
+  comment: string
+}): Promise<GitHubIssueComment> {
+  const octokit = await getOctokit()
+  const [owner, repo] = repoFullName.split("/")
+  try {
+    const updatedComment = await octokit.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: commentId,
+      body: comment,
+    })
+    return updatedComment.data
+  } catch (error) {
+    console.error(`Failed to update comment: ${commentId}`, error)
+    throw error
+  }
+}

--- a/lib/workflows/commentOnIssue.ts
+++ b/lib/workflows/commentOnIssue.ts
@@ -1,6 +1,10 @@
 import { ThinkerAgent } from "@/lib/agents/thinker"
 import { createDirectoryTree } from "@/lib/fs"
-import { createIssueComment, getIssue, updateIssueComment } from "@/lib/github/issues"
+import {
+  createIssueComment,
+  getIssue,
+  updateIssueComment,
+} from "@/lib/github/issues"
 import { langfuse } from "@/lib/langfuse"
 import { updateJobStatus } from "@/lib/redis"
 import { SearchCodeTool } from "@/lib/tools"
@@ -30,9 +34,9 @@ export default async function commentOnIssue(
   const initialComment = await createIssueComment({
     issueNumber,
     repoFullName: repo.full_name,
-    comment: "[Issue To PR] Generating plan...please wait a minute."
-  });
-  const initialCommentId = initialComment.id;
+    comment: "[Issue To PR] Generating plan...please wait a minute.",
+  })
+  const initialCommentId = initialComment.id
 
   updateJobStatus(jobId, "Setting up the local repository")
   // Setup local repository using setupLocalRepository
@@ -65,11 +69,10 @@ export default async function commentOnIssue(
   updateJobStatus(jobId, "Updating initial comment with final response")
   // Update the initial comment with the final response
   await updateIssueComment({
-    issueNumber,
     repoFullName: repo.full_name,
     commentId: initialCommentId,
     comment: response,
-  });
+  })
 
   updateJobStatus(jobId, "Comment updated successfully")
 
@@ -77,5 +80,5 @@ export default async function commentOnIssue(
   updateJobStatus(jobId, "Stream finished")
 
   // Return the comment
-  return { status: "complete", issueComment }
+  return { status: "complete", issueComment: response }
 }


### PR DESCRIPTION
This pull request updates the `commentOnIssue` workflow to post an initial comment when the workflow starts. Once the workflow completes, it updates that initial comment with the final results instead of creating a new comment. Additionally, a new `updateIssueComment` function is added to `lib/github/issues.ts` to facilitate this functionality. This enhancement aims to create a cleaner, more organized flow of comments on GitHub issues, addressing Issue #123.

Closes #206