### PR TITLE
Refactor searchCode to Return Essential Fields

### DIFF
--- a/lib/github/search.ts
+++ b/lib/github/search.ts
@@ -7,10 +7,22 @@ export async function searchCode({
 }: {
   repoFullName: string
   query: string
-}): Promise<SearchCodeItem[]> {
+}): Promise<Partial<SearchCodeItem>[]> {
   const octokit = await getOctokit()
   const response = await octokit.rest.search.code({
     q: `${query} repo:${repoFullName}`,
   })
-  return response.data.items
+  
+  // Filter the result items to include only the specified fields
+  const filteredItems = response.data.items.map(item => ({
+    name: item.name,
+    path: item.path,
+    sha: item.sha,
+    description: item.description,
+    repository: {
+      full_name: item.repository.full_name,
+    },
+  }))
+
+  return filteredItems
 }


### PR DESCRIPTION
This change modifies the `searchCode` function in `lib/github/search.ts` to return only the essential fields needed as per the issue request, thereby reducing the payload size. Included fields are: `name`, `path`, `sha`, `description`, and within the `repository` object, only `full_name`. This is to ensure the data is concise and contains only relevant information.

Closes #238