### PR TITLE
Add feature to view external GitHub issues and pull requests by URL

### DIFF
--- a/app/[username]/[repo]/external/page.tsx
+++ b/app/[username]/[repo]/external/page.tsx
@@ -1,0 +1,71 @@
+import { Suspense, useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+interface Props {
+  params: {
+    username: string;
+    repo: string;
+  };
+}
+
+export default function ExternalPage({ params }: Props) {
+  const { username, repo } = params;
+  const [url, setUrl] = useState('');
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchDetails = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/github/fetchDetails/route.ts', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ url })
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch details.');
+      }
+
+      const result = await response.json();
+      setData(result);
+    } catch (ex) {
+      setError((ex as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">
+        {username} / {repo} - External
+      </h1>
+      <div className="mb-4">
+        <Input
+          type="text"
+          placeholder="Enter GitHub URL"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          className="mb-2"
+        />
+        <Button onClick={fetchDetails} disabled={loading}>
+          {loading ? 'Loading...' : 'Fetch Details'}
+        </Button>
+      </div>
+      {error && <div className="text-red-500">{error}</div>}
+      {data && !loading && !error && (
+        <div className="p-4 bg-gray-100 rounded">
+          <pre className="whitespace-pre-wrap">
+            {JSON.stringify(data, null, 2)}
+          </pre>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/app/[username]/[repo]/external/page.tsx
+++ b/app/[username]/[repo]/external/page.tsx
@@ -1,45 +1,48 @@
-import { Suspense, useState } from 'react';
-import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
+"use client"
+
+import { useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
 
 interface Props {
   params: {
-    username: string;
-    repo: string;
-  };
+    username: string
+    repo: string
+  }
 }
 
 export default function ExternalPage({ params }: Props) {
-  const { username, repo } = params;
-  const [url, setUrl] = useState('');
-  const [data, setData] = useState(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const { username, repo } = params
+  const [url, setUrl] = useState("")
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   const fetchDetails = async () => {
-    setLoading(true);
-    setError(null);
+    setLoading(true)
+    setError(null)
     try {
-      const response = await fetch('/api/github/fetchDetails/route.ts', {
-        method: 'POST',
+      const response = await fetch("/api/github/fetchDetails/route.ts", {
+        method: "POST",
         headers: {
-          'Content-Type': 'application/json'
+          "Content-Type": "application/json",
         },
-        body: JSON.stringify({ url })
-      });
+        body: JSON.stringify({ url }),
+      })
 
       if (!response.ok) {
-        throw new Error('Failed to fetch details.');
+        throw new Error(response.statusText || "Failed to fetch details.")
       }
 
-      const result = await response.json();
-      setData(result);
+      const result = await response.json()
+      setData(result)
     } catch (ex) {
-      setError((ex as Error).message);
+      setError((ex as Error).message)
     } finally {
-      setLoading(false);
+      setLoading(false)
     }
-  };
+  }
 
   return (
     <main className="container mx-auto p-4">
@@ -55,7 +58,7 @@ export default function ExternalPage({ params }: Props) {
           className="mb-2"
         />
         <Button onClick={fetchDetails} disabled={loading}>
-          {loading ? 'Loading...' : 'Fetch Details'}
+          {loading ? "Loading..." : "Fetch Details"}
         </Button>
       </div>
       {error && <div className="text-red-500">{error}</div>}
@@ -67,5 +70,5 @@ export default function ExternalPage({ params }: Props) {
         </div>
       )}
     </main>
-  );
+  )
 }

--- a/app/api/github/fetchDetails/route.ts
+++ b/app/api/github/fetchDetails/route.ts
@@ -1,54 +1,83 @@
-import { NextApiRequest, NextApiResponse } from 'next';
-import { getIssue } from '@/lib/github/issues';
-import { getPullRequest } from '@/lib/github/pullRequests';
+import { NextApiRequest, NextApiResponse } from "next"
+
+import { getIssue } from "@/lib/github/issues"
+import { getPullRequest } from "@/lib/github/pullRequests"
 
 /**
  * Parse a GitHub URL to extract the repo details and issue/pull request number.
  */
-function parseGithubUrl(url: string): { type: 'issue' | 'pull', owner: string, repo: string, number: number } | null {
-  const issueRegex = /github.com\/(.+)\/(.+)\/issues\/(\d+)/;
-  const pullRegex = /github.com\/(.+)\/(.+)\/pull\/(\d+)/;
+function parseGithubUrl(
+  url: string
+): {
+  type: "issue" | "pull"
+  owner: string
+  repo: string
+  number: number
+} | null {
+  const issueRegex = /github.com\/(.+)\/(.+)\/issues\/(\d+)/
+  const pullRegex = /github.com\/(.+)\/(.+)\/pull\/(\d+)/
 
-  let match = issueRegex.exec(url);
+  let match = issueRegex.exec(url)
   if (match) {
-    return { type: 'issue', owner: match[1], repo: match[2], number: Number(match[3]) };
+    return {
+      type: "issue",
+      owner: match[1],
+      repo: match[2],
+      number: Number(match[3]),
+    }
   }
 
-  match = pullRegex.exec(url);
+  match = pullRegex.exec(url)
   if (match) {
-    return { type: 'pull', owner: match[1], repo: match[2], number: Number(match[3]) };
+    return {
+      type: "pull",
+      owner: match[1],
+      repo: match[2],
+      number: Number(match[3]),
+    }
   }
 
-  return null;
+  return null
 }
 
 /**
  * The handler function for the API route.
  */
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const { url } = req.body;
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const { url } = req.body
 
   if (!url) {
-    return res.status(400).json({ error: 'URL is required' });
+    return res.status(400).json({ error: "URL is required" })
   }
 
-  const parsed = parseGithubUrl(url);
+  const parsed = parseGithubUrl(url)
 
   if (!parsed) {
-    return res.status(400).json({ error: 'Invalid GitHub URL' });
+    return res.status(400).json({ error: "Invalid GitHub URL" })
   }
 
-  const { type, owner, repo, number } = parsed;
+  const { type, owner, repo, number } = parsed
 
   try {
-    if (type === 'issue') {
-      const issue = await getIssue({ fullName: `${owner}/${repo}`, issueNumber: number });
-      return res.status(200).json(issue);
-    } else if (type === 'pull') {
-      const pullRequest = await getPullRequest({ repoFullName: `${owner}/${repo}`, pullNumber: number });
-      return res.status(200).json(pullRequest);
+    if (type === "issue") {
+      const issue = await getIssue({
+        fullName: `${owner}/${repo}`,
+        issueNumber: number,
+      })
+      return res.status(200).json(issue)
+    } else if (type === "pull") {
+      const pullRequest = await getPullRequest({
+        repoFullName: `${owner}/${repo}`,
+        pullNumber: number,
+      })
+      return res.status(200).json(pullRequest)
     }
   } catch (error) {
-    return res.status(500).json({ error: 'Failed to fetch details from GitHub' });
+    return res
+      .status(500)
+      .json({ error: "Failed to fetch details from GitHub" })
   }
 }

--- a/app/api/github/fetchDetails/route.ts
+++ b/app/api/github/fetchDetails/route.ts
@@ -1,0 +1,54 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { getIssue } from '@/lib/github/issues';
+import { getPullRequest } from '@/lib/github/pullRequests';
+
+/**
+ * Parse a GitHub URL to extract the repo details and issue/pull request number.
+ */
+function parseGithubUrl(url: string): { type: 'issue' | 'pull', owner: string, repo: string, number: number } | null {
+  const issueRegex = /github.com\/(.+)\/(.+)\/issues\/(\d+)/;
+  const pullRegex = /github.com\/(.+)\/(.+)\/pull\/(\d+)/;
+
+  let match = issueRegex.exec(url);
+  if (match) {
+    return { type: 'issue', owner: match[1], repo: match[2], number: Number(match[3]) };
+  }
+
+  match = pullRegex.exec(url);
+  if (match) {
+    return { type: 'pull', owner: match[1], repo: match[2], number: Number(match[3]) };
+  }
+
+  return null;
+}
+
+/**
+ * The handler function for the API route.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { url } = req.body;
+
+  if (!url) {
+    return res.status(400).json({ error: 'URL is required' });
+  }
+
+  const parsed = parseGithubUrl(url);
+
+  if (!parsed) {
+    return res.status(400).json({ error: 'Invalid GitHub URL' });
+  }
+
+  const { type, owner, repo, number } = parsed;
+
+  try {
+    if (type === 'issue') {
+      const issue = await getIssue({ fullName: `${owner}/${repo}`, issueNumber: number });
+      return res.status(200).json(issue);
+    } else if (type === 'pull') {
+      const pullRequest = await getPullRequest({ repoFullName: `${owner}/${repo}`, pullNumber: number });
+      return res.status(200).json(pullRequest);
+    }
+  } catch (error) {
+    return res.status(500).json({ error: 'Failed to fetch details from GitHub' });
+  }
+}


### PR DESCRIPTION
This PR adds a new API endpoint and a frontend page to allow users to view details of GitHub issues or pull requests from public repositories by submitting a URL. It uses the existing functions from `lib/github` to fetch the required details.

Closes #263