### PR TITLE
Add functionality to view public repo issues and pull requests by URL

### DIFF
--- a/app/api/github/getDetails/route.ts
+++ b/app/api/github/getDetails/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getIssue } from "@/lib/github/issues";
+import { getPullRequest } from "@/lib/github/pullRequests";
+
+async function getDetails(url: string) {
+  const issueMatch = url.match(/\/issues\/(\d+)/);
+  const pullRequestMatch = url.match(/\/pull\/(\d+)/);
+
+  if (issueMatch) {
+    const issueNumber = parseInt(issueMatch[1], 10);
+    const repositoryFullName = extractRepoFullName(url);
+    return await getIssue({ fullName: repositoryFullName, issueNumber });
+  } else if (pullRequestMatch) {
+    const pullNumber = parseInt(pullRequestMatch[1], 10);
+    const repositoryFullName = extractRepoFullName(url);
+    return await getPullRequest({ repoFullName: repositoryFullName, pullNumber });
+  } else {
+    throw new Error("URL does not correspond to an issue or pull request");
+  }
+}
+
+function extractRepoFullName(url: string): string {
+  const match = url.match(/github.com\/(.+)\/(.+?)(?=\/)/);
+  if (!match) {
+    throw new Error("Invalid GitHub URL");
+  }
+  return `${match[1]}/${match[2]}`;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { url } = await request.json();
+    const data = await getDetails(url);
+    return NextResponse.json(data);
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+}

--- a/app/external-issues/page.tsx
+++ b/app/external-issues/page.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from "react";
+import { useRouter } from "next/router";
+import { Input } from "../../components/ui/input";
+import { Button } from "../../components/ui/button";
+import { IssueTable } from "../../components/issues/IssueTable";
+
+const ExternalIssuesPage = () => {
+    const [url, setUrl] = useState("");
+    const [data, setData] = useState(null);
+    const router = useRouter();
+
+    const handleSubmit = async () => {
+        const { owner, repo, number } = parseGithubUrl(url);
+        try {
+            const response = await fetch(`/api/github/getDetails?owner=${owner}&repo=${repo}&number=${number}`);
+            const result = await response.json();
+            setData(result);
+        } catch (error) {
+            console.error("Error fetching repository data:", error);
+        }
+    };
+
+    const parseGithubUrl = (url) => {
+        const match = url.match(/github.com[/:]([^/]+)[/:]([^/]+)(?:/issues/|/pull/)(\d+)/);
+        if (!match) throw new Error("Invalid GitHub URL");
+        
+        return { owner: match[1], repo: match[2], number: match[3] };
+    }; 
+
+    return (
+        <div className="p-4">
+            <h1 className="text-xl mb-4">External GitHub Issues</h1>
+            <Input 
+                type="text" 
+                placeholder="Enter GitHub Issue/Pull URL" 
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                className="mb-2"
+            />
+            <Button onClick={handleSubmit}>Fetch Issue/Pull Request</Button>
+            {data && (
+                <div className="mt-4">
+                    <IssueTable repoFullName={`${data.owner}/${data.repo}`} />
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default ExternalIssuesPage;


### PR DESCRIPTION
This PR introduces a new feature that allows users to paste a URL of a GitHub issue or pull request for a public repository and view its details. This includes creating a new page for user input and updating the API to fetch the necessary data.

Closes #263