### PR TITLE
Handle null returns from getGithubUser() safely

### DIFF
--- a/lib/github/content.ts
+++ b/lib/github/content.ts
@@ -26,6 +26,9 @@ export async function getFileContent({
   try {
     const octokit = await getOctokit()
     const user = await getGithubUser()
+    if (!user) {
+      throw new Error("Failed to get authenticated user")
+    }
     const file = await octokit.repos.getContent({
       owner: user.login,
       repo,
@@ -64,6 +67,10 @@ export async function updateFileContent({
   const octokit = await getOctokit()
   const [owner, repo] = repoFullName.split("/")
   const sha = await getFileSha({ repoFullName, path, branch })
+  const user = await getGithubUser()
+  if (!user) {
+    throw new Error("Failed to get authenticated user")
+  }
   await octokit.rest.repos.createOrUpdateFileContents({
     owner,
     repo,

--- a/lib/github/git.ts
+++ b/lib/github/git.ts
@@ -21,6 +21,9 @@ export async function createBranch(
 ): Promise<BranchCreationResult> {
   const octokit = await getOctokit()
   const user = await getGithubUser()
+  if (!user) {
+    throw new Error("Failed to get authenticated user")
+  }
 
   try {
     // Get the latest commit SHA of the base branch

--- a/lib/github/issues.ts
+++ b/lib/github/issues.ts
@@ -49,6 +49,9 @@ export async function getIssueComments({
 }): Promise<GitHubIssueComment[]> {
   const octokit = await getOctokit()
   const user = await getGithubUser()
+  if (!user) {
+    throw new Error("Failed to get authenticated user")
+  }
   const comments = await octokit.issues.listComments({
     owner: user.login,
     repo,

--- a/lib/github/pullRequests.ts
+++ b/lib/github/pullRequests.ts
@@ -16,6 +16,9 @@ export async function getPullRequestOnBranch({
 }) {
   const octokit = await getOctokit()
   const user = await getGithubUser()
+  if (!user) {
+    throw new Error("Failed to get authenticated user")
+  }
   const userName = user.login
   const pr = await octokit.pulls.list({
     owner: userName,
@@ -45,6 +48,9 @@ export async function createPullRequest({
 }) {
   const octokit = await getOctokit()
   const user = await getGithubUser()
+  if (!user) {
+    throw new Error("Failed to get authenticated user")
+  }
 
   let fullBody = body
   if (issueNumber !== undefined) {

--- a/lib/github/users.ts
+++ b/lib/github/users.ts
@@ -1,12 +1,17 @@
 import getOctokit from "@/lib/github"
 import { GitHubUser } from "@/lib/types"
 
-export async function getGithubUser(): Promise<GitHubUser> {
+export async function getGithubUser(): Promise<GitHubUser | null> {
   const octokit = await getOctokit()
   if (!octokit) {
     console.log("No Octokit instance found")
     return null
   }
-  const user = await octokit.users.getAuthenticated()
-  return user.data
+  try {
+    const user = await octokit.users.getAuthenticated()
+    return user.data
+  } catch (error) {
+    console.error("Failed to get authenticated user:", error)
+    return null
+  }
 }


### PR DESCRIPTION
This PR addresses Issue #270 by properly handling null returns from `getGithubUser()`.

Changes made:
- Updated `getGithubUser()` return type to correctly indicate it can return `null`
- Added try-catch block to handle API errors in `getGithubUser()`
- Added null checks in all functions using `getGithubUser()`
- Added appropriate error handling when user authentication fails

This ensures that our application handles unauthenticated states gracefully and provides clear error messages when authentication is required.

Fixes #270