### PR TITLE
Refactor GitHub functions to use explicit repository names

### DIFF
--- a/lib/agents/librarian.ts
+++ b/lib/agents/librarian.ts
@@ -87,7 +87,7 @@ export class LibrarianAgent {
     const span = this.trace.span({ name: "Get file content" })
     try {
       const content = await getGithubFileContent({
-        repo: this.repository.name,
+        repoFullName: this.repository.full_name,
         path,
         branch: this.branch,
       })

--- a/lib/github/content.ts
+++ b/lib/github/content.ts
@@ -1,5 +1,4 @@
 import getOctokit from "@/lib/github"
-import { getGithubUser } from "@/lib/github/users"
 import { AuthenticatedUserRepository, GitHubRepository } from "@/lib/types"
 
 export class GitHubError extends Error {
@@ -15,22 +14,22 @@ export class GitHubError extends Error {
 // TODO: Since all octokit functions here are using octokit.repos, then
 // This file should be renamed to `repos.tsx` to reflect the resource being called
 export async function getFileContent({
-  repo,
+  repoFullName,
   path,
   branch,
 }: {
-  repo: string
+  repoFullName: string
   path: string
   branch: string
 }) {
   try {
     const octokit = await getOctokit()
-    const user = await getGithubUser()
-    if (!user) {
-      throw new Error("Failed to get authenticated user")
+    const [owner, repo] = repoFullName.split("/")
+    if (!owner || !repo) {
+      throw new Error("Invalid repository format. Expected 'owner/repo'")
     }
     const file = await octokit.repos.getContent({
-      owner: user.login,
+      owner,
       repo,
       path,
       ref: branch,
@@ -67,10 +66,7 @@ export async function updateFileContent({
   const octokit = await getOctokit()
   const [owner, repo] = repoFullName.split("/")
   const sha = await getFileSha({ repoFullName, path, branch })
-  const user = await getGithubUser()
-  if (!user) {
-    throw new Error("Failed to get authenticated user")
-  }
+
   await octokit.rest.repos.createOrUpdateFileContents({
     owner,
     repo,
@@ -119,15 +115,18 @@ export async function getFileSha({
 }
 
 export async function checkBranchExists(
-  repo: string,
+  repoFullName: string,
   branch: string
 ): Promise<boolean> {
   const octokit = await getOctokit()
-  const user = await getGithubUser()
+  const [owner, repo] = repoFullName.split("/")
+  if (!owner || !repo) {
+    throw new Error("Invalid repository format. Expected 'owner/repo'")
+  }
 
   try {
     await octokit.repos.getBranch({
-      owner: user.login,
+      owner,
       repo,
       branch,
     })

--- a/lib/github/git.ts
+++ b/lib/github/git.ts
@@ -1,5 +1,4 @@
 import getOctokit from "@/lib/github"
-import { getGithubUser } from "@/lib/github/users"
 
 export enum BranchCreationStatus {
   Success,
@@ -15,27 +14,27 @@ type BranchCreationResult = {
 }
 
 export async function createBranch(
-  repo: string,
+  fullRepo: string,
   branch: string,
   baseBranch: string = "main"
 ): Promise<BranchCreationResult> {
   const octokit = await getOctokit()
-  const user = await getGithubUser()
-  if (!user) {
-    throw new Error("Failed to get authenticated user")
+  const [owner, repo] = fullRepo.split("/")
+  if (!owner || !repo) {
+    throw new Error("Invalid repository format. Expected 'owner/repo'")
   }
 
   try {
     // Get the latest commit SHA of the base branch
     const { data: baseBranchData } = await octokit.repos.getBranch({
-      owner: user.login,
+      owner,
       repo,
       branch: baseBranch,
     })
 
     // Create a new branch
     await octokit.git.createRef({
-      owner: user.login,
+      owner,
       repo,
       ref: `refs/heads/${branch}`,
       sha: baseBranchData.commit.sha,

--- a/lib/github/issues.ts
+++ b/lib/github/issues.ts
@@ -1,4 +1,3 @@
-import { getGithubUser } from "@/lib/github/users"
 import { GitHubIssue, GitHubIssueComment, ListForRepoParams } from "@/lib/types"
 
 import getOctokit from "."
@@ -41,19 +40,19 @@ export async function createIssueComment({
 }
 
 export async function getIssueComments({
-  repo,
+  repoFullName,
   issueNumber,
 }: {
-  repo: string
+  repoFullName: string
   issueNumber: number
 }): Promise<GitHubIssueComment[]> {
   const octokit = await getOctokit()
-  const user = await getGithubUser()
-  if (!user) {
-    throw new Error("Failed to get authenticated user")
+  const [owner, repo] = repoFullName.split("/")
+  if (!owner || !repo) {
+    throw new Error("Invalid repository format. Expected 'owner/repo'")
   }
   const comments = await octokit.issues.listComments({
-    owner: user.login,
+    owner,
     repo,
     issue_number: issueNumber,
   })

--- a/lib/github/pullRequests.ts
+++ b/lib/github/pullRequests.ts
@@ -1,5 +1,4 @@
 import getOctokit from "@/lib/github"
-import { getGithubUser } from "@/lib/github/users"
 import {
   IssueComment,
   PullRequest,
@@ -8,22 +7,22 @@ import {
 } from "@/lib/types"
 
 export async function getPullRequestOnBranch({
-  repo,
+  repoFullName,
   branch,
 }: {
-  repo: string
+  repoFullName: string
   branch: string
 }) {
   const octokit = await getOctokit()
-  const user = await getGithubUser()
-  if (!user) {
-    throw new Error("Failed to get authenticated user")
+  const [owner, repo] = repoFullName.split("/")
+  if (!owner || !repo) {
+    throw new Error("Invalid repository format. Expected 'owner/repo'")
   }
-  const userName = user.login
+
   const pr = await octokit.pulls.list({
-    owner: userName,
+    owner,
     repo,
-    head: `${userName}:${branch}`,
+    head: `${owner}:${branch}`,
   })
 
   if (pr.data.length > 0) {
@@ -34,22 +33,22 @@ export async function getPullRequestOnBranch({
 }
 
 export async function createPullRequest({
-  repo,
+  repoFullName,
   branch,
   title,
   body,
   issueNumber,
 }: {
-  repo: string
+  repoFullName: string
   branch: string
   title: string
   body: string
   issueNumber?: number
 }) {
   const octokit = await getOctokit()
-  const user = await getGithubUser()
-  if (!user) {
-    throw new Error("Failed to get authenticated user")
+  const [owner, repo] = repoFullName.split("/")
+  if (!owner || !repo) {
+    throw new Error("Invalid repository format. Expected 'owner/repo'")
   }
 
   let fullBody = body
@@ -58,7 +57,7 @@ export async function createPullRequest({
   }
 
   const pullRequest = await octokit.pulls.create({
-    owner: user.login,
+    owner,
     repo,
     title,
     body: fullBody,

--- a/lib/tools/UploadAndPR.ts
+++ b/lib/tools/UploadAndPR.ts
@@ -77,7 +77,7 @@ class UploadAndPRTool implements Tool<typeof uploadAndPRParameters> {
     )
     if (!branchExists) {
       const branchCreationResult = await createBranch(
-        this.repository.name,
+        this.repository.full_name,
         branch
       )
       if (
@@ -113,7 +113,7 @@ class UploadAndPRTool implements Tool<typeof uploadAndPRParameters> {
 
     // Check if PR on branch exists before creating new one
     const existingPR = await getPullRequestOnBranch({
-      repo: this.repository.name,
+      repoFullName: this.repository.full_name,
       branch,
     })
     if (existingPR) {
@@ -127,7 +127,7 @@ class UploadAndPRTool implements Tool<typeof uploadAndPRParameters> {
     console.debug("[DEBUG] Creating pull request")
     try {
       const pr = await createPullRequest({
-        repo: this.repository.name,
+        repoFullName: this.repository.full_name,
         branch,
         title: pullRequest.title,
         body: pullRequest.body,

--- a/lib/workflows/resolveIssue.ts
+++ b/lib/workflows/resolveIssue.ts
@@ -39,7 +39,7 @@ export const resolveIssue = async (
 
   // Retrieve all the comments on the issue
   const comments = await getIssueComments({
-    repo: repository.name,
+    repoFullName: repository.full_name,
     issueNumber: issue.number,
   })
 


### PR DESCRIPTION
This PR addresses issue #271 by refactoring GitHub functions to use explicit repository names instead of relying on `getGithubUser()` for repository ownership.

Changes made:
- Updated `git.ts`: Modified `createBranch` to accept full repository name
- Updated `issues.ts`: Modified `getIssueComments` to use full repository name
- Updated `pullRequests.ts`: Modified `getPullRequestOnBranch` and `createPullRequest` to use full repository name
- Updated `content.ts`: Modified `getFileContent` and `checkBranchExists` to use full repository name
- Updated all calling code in `UploadAndPR.ts`, `resolveIssue.ts`, and `librarian.ts` to use the new parameter format

The `getGithubUser()` function is still used in components where it's needed for displaying user information (`Navigation.tsx` and `redirect/page.tsx`), but it's no longer used for repository operations.

These changes make the codebase more flexible by:
1. Supporting operations on repositories not owned by the authenticated user
2. Making repository ownership explicit in function calls
3. Reducing coupling with authentication state

Closes #271