### PR TITLE
Add per-installation Auto-Post-Plan setting, API and UI

### DIFF
--- a/app/api/settings/auto-post-plan/route.ts
+++ b/app/api/settings/auto-post-plan/route.ts
@@ -1,42 +1,46 @@
-import { NextRequest, NextResponse } from "next/server";
-import { getAutoPostPlanSetting, setAutoPostPlanSetting } from "@/lib/services/SettingsService";
-import type { AutoPostPlanSetting } from "@/lib/types/settings";
+import { NextRequest, NextResponse } from "next/server"
 
-// For demo: extract installationId from a custom header.
-// Replace with session/auth logic for production.
-function extractInstallationId(req: NextRequest): number | null {
-  const raw = req.headers.get('x-installation-id');
-  if (!raw) return null;
-  const n = Number(raw);
-  if (!Number.isInteger(n)) return null;
-  return n;
-}
+import {
+  getAutoPostPlanSetting,
+  setAutoPostPlanSetting,
+} from "@/lib/services/SettingsService"
+import type { AutoPostPlanSetting } from "@/lib/types/settings"
+import { getInstallationId } from "@/lib/utils/utils-server"
 
 // --- GET: return setting --- //
 export async function GET(req: NextRequest) {
-  const installationId = extractInstallationId(req);
+  const installationId = getInstallationId()
   if (!installationId) {
-    return NextResponse.json({ error: "Missing or invalid installation id" }, { status: 400 });
+    return NextResponse.json(
+      { error: "Missing or invalid installation id" },
+      { status: 400 }
+    )
   }
-  const enabled = await getAutoPostPlanSetting(installationId);
-  return NextResponse.json({ enabled });
+  const enabled = await getAutoPostPlanSetting(Number(installationId))
+  return NextResponse.json({ enabled })
 }
 
 // --- PATCH: update setting --- //
 export async function PATCH(req: NextRequest) {
-  const installationId = extractInstallationId(req);
+  const installationId = getInstallationId()
   if (!installationId) {
-    return NextResponse.json({ error: "Missing or invalid installation id" }, { status: 400 });
+    return NextResponse.json(
+      { error: "Missing or invalid installation id" },
+      { status: 400 }
+    )
   }
-  let data: Partial<AutoPostPlanSetting> = {};
+  let data: Partial<AutoPostPlanSetting> = {}
   try {
-    data = await req.json();
+    data = await req.json()
   } catch (e) {
-    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 })
   }
   if (typeof data.enabled !== "boolean") {
-    return NextResponse.json({ error: "Missing 'enabled' boolean" }, { status: 400 });
+    return NextResponse.json(
+      { error: "Missing 'enabled' boolean" },
+      { status: 400 }
+    )
   }
-  await setAutoPostPlanSetting(installationId, data.enabled);
-  return NextResponse.json({ enabled: data.enabled });
+  await setAutoPostPlanSetting(Number(installationId), data.enabled)
+  return NextResponse.json({ enabled: data.enabled })
 }

--- a/app/api/settings/auto-post-plan/route.ts
+++ b/app/api/settings/auto-post-plan/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAutoPostPlanSetting, setAutoPostPlanSetting } from "@/lib/services/SettingsService";
+import type { AutoPostPlanSetting } from "@/lib/types/settings";
+
+// For demo: extract installationId from a custom header.
+// Replace with session/auth logic for production.
+function extractInstallationId(req: NextRequest): number | null {
+  const raw = req.headers.get('x-installation-id');
+  if (!raw) return null;
+  const n = Number(raw);
+  if (!Number.isInteger(n)) return null;
+  return n;
+}
+
+// --- GET: return setting --- //
+export async function GET(req: NextRequest) {
+  const installationId = extractInstallationId(req);
+  if (!installationId) {
+    return NextResponse.json({ error: "Missing or invalid installation id" }, { status: 400 });
+  }
+  const enabled = await getAutoPostPlanSetting(installationId);
+  return NextResponse.json({ enabled });
+}
+
+// --- PATCH: update setting --- //
+export async function PATCH(req: NextRequest) {
+  const installationId = extractInstallationId(req);
+  if (!installationId) {
+    return NextResponse.json({ error: "Missing or invalid installation id" }, { status: 400 });
+  }
+  let data: Partial<AutoPostPlanSetting> = {};
+  try {
+    data = await req.json();
+  } catch (e) {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  if (typeof data.enabled !== "boolean") {
+    return NextResponse.json({ error: "Missing 'enabled' boolean" }, { status: 400 });
+  }
+  await setAutoPostPlanSetting(installationId, data.enabled);
+  return NextResponse.json({ enabled: data.enabled });
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,15 @@
+import dynamic from "next/dynamic";
+
+const AutoPostPlanSetting = dynamic(
+  () => import("@/components/settings/AutoPostPlanSetting"),
+  { ssr: false }
+);
+
+export default function SettingsPage() {
+  return (
+    <div className="max-w-2xl mx-auto py-8 px-4">
+      <h2 className="text-2xl font-bold mb-6">Settings</h2>
+      <AutoPostPlanSetting />
+    </div>
+  );
+}

--- a/components/settings/AutoPostPlanSetting.tsx
+++ b/components/settings/AutoPostPlanSetting.tsx
@@ -1,0 +1,107 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Label } from "@/components/ui/label"
+import { Loader2 } from "lucide-react"
+import { useToast } from "@/lib/hooks/use-toast"
+
+interface ApiResult {
+  enabled: boolean
+  error?: string
+}
+
+// For demo/testing: hardcoded installation ID.
+// In a production install, supply this from user session/app context.
+const DEMO_INSTALL_ID = 1
+
+const AutoPostPlanSetting = () => {
+  const [enabled, setEnabled] = useState<boolean>(false)
+  const [loading, setLoading] = useState<boolean>(true)
+  const [saving, setSaving] = useState<boolean>(false)
+  const { toast } = useToast()
+
+  useEffect(() => {
+    async function fetchSetting() {
+      setLoading(true)
+      try {
+        const res = await fetch("/api/settings/auto-post-plan", {
+          headers: { "x-installation-id": String(DEMO_INSTALL_ID) }
+        })
+        if (!res.ok) throw new Error("Could not fetch setting")
+        const json: ApiResult = await res.json()
+        if (typeof json.enabled === "boolean") {
+          setEnabled(json.enabled)
+        }
+      } catch (err) {
+        toast({
+          title: "Error loading setting",
+          description: err instanceof Error ? err.message : String(err),
+          variant: "destructive",
+        })
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchSetting()
+  }, [toast])
+
+  async function handleChange(checked: boolean) {
+    setSaving(true)
+    try {
+      const res = await fetch("/api/settings/auto-post-plan", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "x-installation-id": String(DEMO_INSTALL_ID)
+        },
+        body: JSON.stringify({ enabled: checked })
+      })
+      const json: ApiResult = await res.json()
+      if (!res.ok || json.error) {
+        throw new Error(json.error || "Could not update setting")
+      }
+      setEnabled(json.enabled)
+      toast({ title: "Preference updated", description: "Changed setting for plan auto-posting." })
+    } catch (err) {
+      toast({
+        title: "Error updating setting",
+        description: err instanceof Error ? err.message : String(err),
+        variant: "destructive",
+      })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-start gap-2 py-4">
+      <Label className="font-semibold">Automatically post Plan as GitHub comment when a new issue is created?</Label>
+      <div className="flex items-center gap-3">
+        <Checkbox
+          id="auto-post-plan-checkbox"
+          checked={enabled}
+          disabled={loading || saving}
+          onCheckedChange={val => typeof val === "boolean" && handleChange(val)}
+        />
+        <Label htmlFor="auto-post-plan-checkbox" className="text-muted-foreground text-sm">
+          {loading ? (
+            <span className="flex items-center gap-1"><Loader2 className="animate-spin h-4 w-4" />Loading…</span>
+          ) : saving ? (
+            <span className="flex items-center gap-1"><Loader2 className="animate-spin h-4 w-4" />Saving…</span>
+          ) : enabled ? (
+            "Enabled (will auto-comment on new issues)" 
+          ) : (
+            "Disabled (no automatic plan comment)"
+          )}
+        </Label>
+      </div>
+      <div className="text-xs text-muted-foreground max-w-md">
+        This preference automatically generates and posts a Plan as a comment when a new GitHub issue is opened in any repository under this installation. <br />
+        You can enable or disable it here at any time.
+      </div>
+    </div>
+  )
+}
+
+export default AutoPostPlanSetting;

--- a/components/settings/AutoPostPlanSetting.tsx
+++ b/components/settings/AutoPostPlanSetting.tsx
@@ -1,9 +1,10 @@
 "use client"
 
+import { Loader2 } from "lucide-react"
 import { useEffect, useState } from "react"
+
 import { Checkbox } from "@/components/ui/checkbox"
 import { Label } from "@/components/ui/label"
-import { Loader2 } from "lucide-react"
 import { useToast } from "@/lib/hooks/use-toast"
 
 interface ApiResult {
@@ -26,7 +27,7 @@ const AutoPostPlanSetting = () => {
       setLoading(true)
       try {
         const res = await fetch("/api/settings/auto-post-plan", {
-          headers: { "x-installation-id": String(DEMO_INSTALL_ID) }
+          headers: { "x-installation-id": String(DEMO_INSTALL_ID) },
         })
         if (!res.ok) throw new Error("Could not fetch setting")
         const json: ApiResult = await res.json()
@@ -53,16 +54,19 @@ const AutoPostPlanSetting = () => {
         method: "PATCH",
         headers: {
           "Content-Type": "application/json",
-          "x-installation-id": String(DEMO_INSTALL_ID)
+          "x-installation-id": String(DEMO_INSTALL_ID),
         },
-        body: JSON.stringify({ enabled: checked })
+        body: JSON.stringify({ enabled: checked }),
       })
       const json: ApiResult = await res.json()
       if (!res.ok || json.error) {
         throw new Error(json.error || "Could not update setting")
       }
       setEnabled(json.enabled)
-      toast({ title: "Preference updated", description: "Changed setting for plan auto-posting." })
+      toast({
+        title: "Preference updated",
+        description: "Changed setting for plan auto-posting.",
+      })
     } catch (err) {
       toast({
         title: "Error updating setting",
@@ -76,32 +80,47 @@ const AutoPostPlanSetting = () => {
 
   return (
     <div className="flex flex-col items-start gap-2 py-4">
-      <Label className="font-semibold">Automatically post Plan as GitHub comment when a new issue is created?</Label>
+      <Label className="font-semibold">
+        Automatically post Plan as GitHub comment when a new issue is created?
+      </Label>
       <div className="flex items-center gap-3">
         <Checkbox
           id="auto-post-plan-checkbox"
           checked={enabled}
           disabled={loading || saving}
-          onCheckedChange={val => typeof val === "boolean" && handleChange(val)}
+          onCheckedChange={(val) =>
+            typeof val === "boolean" && handleChange(val)
+          }
         />
-        <Label htmlFor="auto-post-plan-checkbox" className="text-muted-foreground text-sm">
+        <Label
+          htmlFor="auto-post-plan-checkbox"
+          className="text-muted-foreground text-sm"
+        >
           {loading ? (
-            <span className="flex items-center gap-1"><Loader2 className="animate-spin h-4 w-4" />Loading…</span>
+            <span className="flex items-center gap-1">
+              <Loader2 className="animate-spin h-4 w-4" />
+              Loading…
+            </span>
           ) : saving ? (
-            <span className="flex items-center gap-1"><Loader2 className="animate-spin h-4 w-4" />Saving…</span>
+            <span className="flex items-center gap-1">
+              <Loader2 className="animate-spin h-4 w-4" />
+              Saving…
+            </span>
           ) : enabled ? (
-            "Enabled (will auto-comment on new issues)" 
+            "Enabled (will auto-comment on new issues)"
           ) : (
             "Disabled (no automatic plan comment)"
           )}
         </Label>
       </div>
       <div className="text-xs text-muted-foreground max-w-md">
-        This preference automatically generates and posts a Plan as a comment when a new GitHub issue is opened in any repository under this installation. <br />
+        This preference automatically generates and posts a Plan as a comment
+        when a new GitHub issue is opened in any repository under this
+        installation. <br />
         You can enable or disable it here at any time.
       </div>
     </div>
   )
 }
 
-export default AutoPostPlanSetting;
+export default AutoPostPlanSetting

--- a/lib/services/SettingsService.ts
+++ b/lib/services/SettingsService.ts
@@ -1,0 +1,34 @@
+import { redis } from "../redis";
+import type { AutoPostPlanSetting } from "../types/settings";
+
+const AUTO_POST_PLAN_KEY_PREFIX = "settings:autoPostPlan:";
+
+function makeKey(installationId: number): string {
+  return `${AUTO_POST_PLAN_KEY_PREFIX}${installationId}`;
+}
+
+/**
+ * Get the auto-post plan setting for a GitHub App installation.
+ * Returns `false` (off) by default if there is no value set.
+ */
+export async function getAutoPostPlanSetting(
+  installationId: number
+): Promise<boolean> {
+  const key = makeKey(installationId);
+  const result = await redis.get(key);
+  if (result === null || typeof result !== "boolean") {
+    return false;
+  }
+  return result;
+}
+
+/**
+ * Set the auto-post plan setting for a GitHub App installation.
+ */
+export async function setAutoPostPlanSetting(
+  installationId: number,
+  value: boolean
+): Promise<void> {
+  const key = makeKey(installationId);
+  await redis.set(key, value);
+}

--- a/lib/services/SettingsService.ts
+++ b/lib/services/SettingsService.ts
@@ -1,10 +1,9 @@
-import { redis } from "../redis";
-import type { AutoPostPlanSetting } from "../types/settings";
+import { redis } from "@/lib/redis"
 
-const AUTO_POST_PLAN_KEY_PREFIX = "settings:autoPostPlan:";
+const AUTO_POST_PLAN_KEY_PREFIX = "settings:autoPostPlan:"
 
 function makeKey(installationId: number): string {
-  return `${AUTO_POST_PLAN_KEY_PREFIX}${installationId}`;
+  return `${AUTO_POST_PLAN_KEY_PREFIX}${installationId}`
 }
 
 /**
@@ -14,12 +13,12 @@ function makeKey(installationId: number): string {
 export async function getAutoPostPlanSetting(
   installationId: number
 ): Promise<boolean> {
-  const key = makeKey(installationId);
-  const result = await redis.get(key);
+  const key = makeKey(installationId)
+  const result = await redis.get(key)
   if (result === null || typeof result !== "boolean") {
-    return false;
+    return false
   }
-  return result;
+  return result
 }
 
 /**
@@ -29,6 +28,6 @@ export async function setAutoPostPlanSetting(
   installationId: number,
   value: boolean
 ): Promise<void> {
-  const key = makeKey(installationId);
-  await redis.set(key, value);
+  const key = makeKey(installationId)
+  await redis.set(key, value)
 }

--- a/lib/types/settings.ts
+++ b/lib/types/settings.ts
@@ -1,0 +1,4 @@
+export interface AutoPostPlanSetting {
+  installationId: number;
+  enabled: boolean;
+}

--- a/lib/webhook.ts
+++ b/lib/webhook.ts
@@ -2,8 +2,8 @@ import { v4 as uuidv4 } from "uuid"
 
 import { getRepoFromString } from "@/lib/github/content"
 import { updateJobStatus } from "@/lib/redis-old"
-import commentOnIssue from "@/lib/workflows/commentOnIssue"
 import { getAutoPostPlanSetting } from "@/lib/services/SettingsService"
+import commentOnIssue from "@/lib/workflows/commentOnIssue"
 
 // Subscribed events for Github App
 enum GitHubEvent {
@@ -27,7 +27,7 @@ export const routeWebhookHandler = async ({
   payload,
 }: {
   event: string
-  payload: any
+  payload: object
 }) => {
   if (!Object.values(GitHubEvent).includes(event as GitHubEvent)) {
     console.error("Invalid event type:", event)


### PR DESCRIPTION
## Description

- Adds a backend service in Redis for storing the auto-post plan setting by GitHub App installation.
- Exposes API endpoint at `/api/settings/auto-post-plan` to GET and PATCH the value (reads installation id from header for demo purposes).
- Webhook handler updated to check the setting before posting plan comment on new GitHub issues.
- Adds a settings UI component with a checkbox to enable/disable this feature.
- Integrates the checkbox setting in the Settings page (`/settings`).

## How to test
- Use `/settings` to view and update the Auto-Post-Plan setting for your (demo) installation id.
- Confirm via API or by opening issues that the setting is respected in plan comment workflow.

## Notes
- Installation id is mocked for demo UI, wire to real auth/session for production.
- Add security and finer-grained controls as needed in subsequent PRs.

Closes #347