### PR TITLE
Bubble up directory creation errors as user-facing error events with full details

### DIFF
--- a/lib/workflows/resolveIssue.ts
+++ b/lib/workflows/resolveIssue.ts
@@ -4,7 +4,7 @@
 // They can also all access the same data, such as the issue, the codebase, etc.
 
 import { CoderAgent } from "@/lib/agents/coder"
-import { createDirectoryTree } from "@/lib/fs"
+import { createDirectoryTree, DirectoryCreationError } from "@/lib/fs"
 import { getIssueComments } from "@/lib/github/issues"
 import { checkRepoPermissions } from "@/lib/github/users"
 import { langfuse } from "@/lib/langfuse"
@@ -217,11 +217,16 @@ ${plan.content}
 
     return coderResult
   } catch (error) {
-    // Emit error event
-
+    // Emit detailed error event on directory creation error
+    let content: string
+    if (error instanceof DirectoryCreationError) {
+      content = `Directory creation failed for '${error.dirPath}': ${error.message}\nOriginal error: ${error.originalError?.stack || error.originalError}`
+    } else {
+      content = String(error)
+    }
     await createErrorEvent({
       workflowId,
-      content: String(error),
+      content,
     })
 
     throw error


### PR DESCRIPTION
- Added DirectoryCreationError in lib/fs.ts to wrap directory creation errors with path and root cause.
- getLocalRepoDir and writeFile now throw DirectoryCreationError on mkdir failure, preserving the origin.
- In lib/workflows/resolveIssue.ts, when caught, error event now details the failed path and the original stack/message for greater user transparency.
- Users will now directly see directory creation failure diagnostics on the workflow run UI.

Closes #<the issue number>. Please replace with actual issue number.

Closes #361