### PR TITLE
Add feedback button and popover form for LLM responses (UI only, MVP)

### DIFF
--- a/components/workflow-runs/events/LLMResponseEvent.tsx
+++ b/components/workflow-runs/events/LLMResponseEvent.tsx
@@ -1,23 +1,51 @@
-"use server"
+"use client";
 
-import { ExternalLink } from "lucide-react"
-import Link from "next/link"
-import ReactMarkdown from "react-markdown"
+import { useState } from "react";
+import { ExternalLink } from "lucide-react";
+import Link from "next/link";
+import ReactMarkdown from "react-markdown";
 
-import { PostToGitHubButton } from "@/components/issues/actions/PostToGitHubButton"
-import { Button } from "@/components/ui/button"
-import { CollapsibleContent } from "@/components/ui/collapsible-content"
-import { EventTime } from "@/components/workflow-runs/events"
-import { CopyMarkdownButton } from "@/components/workflow-runs/events/CopyMarkdownButton"
-import { Issue, LLMResponse, LLMResponseWithPlan } from "@/lib/types"
+import { PostToGitHubButton } from "@/components/issues/actions/PostToGitHubButton";
+import { Button } from "@/components/ui/button";
+import { CollapsibleContent } from "@/components/ui/collapsible-content";
+import { EventTime } from "@/components/workflow-runs/events";
+import { CopyMarkdownButton } from "@/components/workflow-runs/events/CopyMarkdownButton";
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "@/components/ui/popover";
+import { Issue, LLMResponse, LLMResponseWithPlan } from "@/lib/types";
 
 // Some LLM response event nodes will also be a Plan node
 export interface Props {
-  event: LLMResponse | LLMResponseWithPlan
-  issue?: Issue
+  event: LLMResponse | LLMResponseWithPlan;
+  issue?: Issue;
 }
 
-export async function LLMResponseEvent({ event, issue }: Props) {
+export function LLMResponseEvent({ event, issue }: Props) {
+  // Feedback popover state
+  const [feedback, setFeedback] = useState("");
+  const [showThankYou, setShowThankYou] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setShowThankYou(true);
+    setFeedback("");
+    // auto-close after 2s
+    setTimeout(() => {
+      setShowThankYou(false);
+      setOpen(false);
+    }, 1600);
+  }
+
+  function handleCancel() {
+    setFeedback("");
+    setOpen(false);
+    setShowThankYou(false);
+  }
+
   const headerContent = (
     <div className="flex items-center justify-between w-full">
       <div className="flex items-center gap-2">
@@ -41,9 +69,42 @@ export async function LLMResponseEvent({ event, issue }: Props) {
           </>
         )}
         <CopyMarkdownButton content={event.content} />
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>
+            <Button variant="ghost" size="sm">Feedback</Button>
+          </PopoverTrigger>
+          <PopoverContent align="end">
+            {showThankYou ? (
+              <div className="text-center text-green-600 font-medium py-6">Thank you for your feedback!</div>
+            ) : (
+              <form onSubmit={handleSubmit} className="flex flex-col gap-2 w-64">
+                <label htmlFor="feedback-text" className="text-xs font-semibold text-muted-foreground">Feedback on this response:</label>
+                <textarea
+                  className="border rounded-md p-2 text-sm focus:outline-none focus:ring focus:border-primary bg-background resize-none"
+                  id="feedback-text"
+                  rows={3}
+                  maxLength={500}
+                  value={feedback}
+                  onChange={(e) => setFeedback(e.target.value)}
+                  placeholder="What did you like or dislike about this response?"
+                  required
+                  autoFocus
+                />
+                <div className="flex items-center justify-end gap-2 mt-1">
+                  <Button type="button" variant="ghost" size="sm" onClick={handleCancel}>
+                    Cancel
+                  </Button>
+                  <Button type="submit" size="sm" disabled={!feedback.trim()}>
+                    Submit
+                  </Button>
+                </div>
+              </form>
+            )}
+          </PopoverContent>
+        </Popover>
       </div>
     </div>
-  )
+  );
 
   return (
     <CollapsibleContent
@@ -54,5 +115,5 @@ export async function LLMResponseEvent({ event, issue }: Props) {
         <ReactMarkdown>{event.content}</ReactMarkdown>
       </div>
     </CollapsibleContent>
-  )
+  );
 }


### PR DESCRIPTION
- Adds a Feedback button to every LLMResponseEvent in workflow runs.
- Clicking the button opens a popover for free-text user feedback on the LLM response.
- Form is UI only (no persistence), and after submission shows a thank you message.
- Uses existing Popover and Button components for consistency.
- Refactors LLMResponseEvent to be a client component to support UI state.

Closes #367