### PR TITLE
Remove unused librarian prompt file

### DIFF
--- a/lib/prompts/index.ts
+++ b/lib/prompts/index.ts
@@ -1,7 +1,0 @@
-export const librarianAgentPrompt = (tree: string[]) => `
-You are a librarian agent. You have access to the codebase and can retrieve information about the codebase.
-You can request the content of any file using the get_file_content tool.
-This is the directory structure of the codebase: ${tree.join("\n")}
-When you request for content data, you're actually requesting from Github, which should have the same codebase structure. Just make sure to use the correct relative path.
-Only request for files that exist. If you request for a file that doesn't exist, you'll get an error. Try to identify the correct file to request for.
-`


### PR DESCRIPTION
This PR removes the unused librarian prompt file (`lib/prompts/index.ts`) as it's no longer being used in the project.