### PR TITLE
fix: show resolveIssue workflow runs as 'running' until completion

### DIFF
--- a/lib/workflows/resolveIssue.ts
+++ b/lib/workflows/resolveIssue.ts
@@ -56,6 +56,12 @@ export const resolveIssue = async (params: ResolveIssueParams) => {
       postToGithub: createPR,
     })
 
+    // Emit workflow "running" state event
+    await createWorkflowStateEvent({
+      workflowId,
+      state: "running",
+    })
+
     await createStatusEvent({
       workflowId,
       content: `Starting workflow for issue #${issue.number} in ${repository.full_name}`,


### PR DESCRIPTION
- Ensures resolveIssue workflow emits a workflowState event with state 'running' immediately after initialization, matching other workflows (like commentOnIssue, reviewPullRequest)
- Fixes the bug where the workflow run appeared as 'completed' in the UI before actually finishing
- No schema or UI changes (only backend logic updated)

See issue: Workflow Runs list shows run as 'completed' when it's still running.

Closes #383