### PR TITLE
test: Add GetFileContent tool unit test for file not found and success cases

### DIFF
--- a/__tests__/lib/tools/GetFileContent.test.ts
+++ b/__tests__/lib/tools/GetFileContent.test.ts
@@ -1,40 +1,39 @@
-import { createGetFileContentTool } from '@/lib/tools/GetFileContent';
-import path from 'path';
+import { createGetFileContentTool } from "@/lib/tools/GetFileContent"
 
 // Helper to get a guaranteed missing file name
 function getMissingFileName() {
-  return `___definitely_missing_file_${Date.now()}.txt`;
+  return `___definitely_missing_file_${Date.now()}.txt`
 }
 
-describe('GetFileContent tool', () => {
-  const baseDir = process.cwd();
+describe("GetFileContent tool", () => {
+  const baseDir = process.cwd()
 
-  it('returns a string error message when file does not exist, and does not throw', async () => {
-    const tool = createGetFileContentTool(baseDir);
-    const fakePath = getMissingFileName();
+  it("returns a string error message when file does not exist, and does not throw", async () => {
+    const tool = createGetFileContentTool(baseDir)
+    const fakePath = getMissingFileName()
 
     // Call tool handler directly
-    let result;
-    let errorCaught = null;
+    let result: unknown
+    let errorCaught: unknown
     try {
-      result = await tool.handler({ relativePath: fakePath });
+      result = await tool.handler({ relativePath: fakePath })
     } catch (err) {
-      errorCaught = err;
+      errorCaught = err
     }
 
-    expect(errorCaught).toBeNull();
-    expect(typeof result).toBe('string');
-    expect(result).toMatch(/no such file|ENOENT|not found/i); // Node ENOENT msg
-  });
+    expect(errorCaught).toBeNull()
+    expect(typeof result).toBe("string")
+    expect(result).toMatch(/no such file|ENOENT|not found/i) // Node ENOENT msg
+  })
 
-  it('returns contents for a real file', async () => {
-    const tool = createGetFileContentTool(baseDir);
-    const existing = 'README.md';
-    const result = await tool.handler({ relativePath: existing });
+  it("returns contents for a real file", async () => {
+    const tool = createGetFileContentTool(baseDir)
+    const existing = "README.md"
+    const result = await tool.handler({ relativePath: existing })
 
-    expect(typeof result).toBe('string');
-    expect(result.length).toBeGreaterThan(1);
+    expect(typeof result).toBe("string")
+    expect(result.length).toBeGreaterThan(1)
     // Should contain recognizable README text:
-    expect(result).toMatch(/issue-to-pr|github|readme/i);
-  });
-});
+    expect(result).toMatch(/issue-to-pr|github|readme/i)
+  })
+})

--- a/__tests__/lib/tools/GetFileContent.test.ts
+++ b/__tests__/lib/tools/GetFileContent.test.ts
@@ -1,0 +1,40 @@
+import { createGetFileContentTool } from '@/lib/tools/GetFileContent';
+import path from 'path';
+
+// Helper to get a guaranteed missing file name
+function getMissingFileName() {
+  return `___definitely_missing_file_${Date.now()}.txt`;
+}
+
+describe('GetFileContent tool', () => {
+  const baseDir = process.cwd();
+
+  it('returns a string error message when file does not exist, and does not throw', async () => {
+    const tool = createGetFileContentTool(baseDir);
+    const fakePath = getMissingFileName();
+
+    // Call tool handler directly
+    let result;
+    let errorCaught = null;
+    try {
+      result = await tool.handler({ relativePath: fakePath });
+    } catch (err) {
+      errorCaught = err;
+    }
+
+    expect(errorCaught).toBeNull();
+    expect(typeof result).toBe('string');
+    expect(result).toMatch(/no such file|ENOENT|not found/i); // Node ENOENT msg
+  });
+
+  it('returns contents for a real file', async () => {
+    const tool = createGetFileContentTool(baseDir);
+    const existing = 'README.md';
+    const result = await tool.handler({ relativePath: existing });
+
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(1);
+    // Should contain recognizable README text:
+    expect(result).toMatch(/issue-to-pr|github|readme/i);
+  });
+});


### PR DESCRIPTION
## Description

This PR adds a new unit test to cover the behavior of the `GetFileContent` tool when retrieving a file that does not exist (should return an error string, not throw) and when retrieving a real file. This ensures that the tool handles missing files gracefully, as intended.

- Fails gracefully and returns a string message for ENOENT (not found) errors
- Returns contents for an existing file

Closes #<issue_number> (please fill with your issue number)


Closes #407