### PR TITLE
Add 'workflow' scope to GitHub OAuth and update authentication docs

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -32,7 +32,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       authorization: {
         url: "https://github.com/login/oauth/authorize",
         params: {
-          scope: "read:user user:email repo",
+          scope: "read:user user:email repo workflow",
           redirect_uri: `${process.env.NEXT_PUBLIC_BASE_URL}/api/auth/callback/github-oauth`,
         },
       },

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -30,11 +30,15 @@ GithubProvider({
   clientSecret: process.env.GITHUB_OAUTH_SECRET,
   authorization: {
     params: {
-      scope: "read:user user:email repo",
+      scope: "read:user user:email repo workflow",
     },
   },
 })
 ```
+
+Required Permissions: `read:user`, `user:email`, `repo`, `workflow`
+
+> **Note**: After this scope change, existing users will need to re-authorize the app in GitHub to grant the new `workflow` permission. Without re-authorization, the application may not be able to perform actions on workflow files for previously authorized users.
 
 ### GitHub App Authentication
 


### PR DESCRIPTION
## What
- Add 'workflow' to the list of OAuth scopes for the GitHub OAuth provider in `auth.ts`.
- Update documentation (`docs/guides/authentication.md`) to reflect the new required scope and permissions.
- Add a note to docs: Existing users must reauthorize the app in GitHub for the new scope to take effect.

## Why
- Enables agents to manage `.github/workflows` files via the API on behalf of users, as requested.

## Impact
- Users who previously authorized the app will need to re-authenticate for the new scope.
- Documentation is now up-to-date with the required permissions.


Closes #415