### PR TITLE
Automatically add 'AI generated' label to pull requests created by CreatePRTool

### DIFF
--- a/lib/github/pullRequests.ts
+++ b/lib/github/pullRequests.ts
@@ -212,7 +212,7 @@ export async function addLabelsToPullRequest({
   pullNumber: number
   labels: string[]
 }): Promise<void> {
-  const octokit = await getOctokit();
+  const octokit = await getOctokit()
   if (!octokit) {
     throw new Error("No octokit found")
   }

--- a/lib/github/pullRequests.ts
+++ b/lib/github/pullRequests.ts
@@ -202,3 +202,28 @@ export async function getPullRequest({
 
   return response.data
 }
+
+export async function addLabelsToPullRequest({
+  repoFullName,
+  pullNumber,
+  labels,
+}: {
+  repoFullName: string
+  pullNumber: number
+  labels: string[]
+}): Promise<void> {
+  const octokit = await getOctokit();
+  if (!octokit) {
+    throw new Error("No octokit found")
+  }
+  const [owner, repo] = repoFullName.split("/")
+  if (!owner || !repo) {
+    throw new Error("Invalid repository format. Expected 'owner/repo'")
+  }
+  await octokit.issues.addLabels({
+    owner,
+    repo,
+    issue_number: pullNumber,
+    labels,
+  })
+}

--- a/lib/tools/CreatePRTool.ts
+++ b/lib/tools/CreatePRTool.ts
@@ -1,9 +1,9 @@
 import { z } from "zod"
 
 import {
+  addLabelsToPullRequest,
   createPullRequest,
   getPullRequestOnBranch,
-  addLabelsToPullRequest,
 } from "@/lib/github/pullRequests"
 import { createTool } from "@/lib/tools/helper"
 import { GitHubRepository } from "@/lib/types/github"
@@ -45,7 +45,7 @@ async function fnHandler(
       body,
       issueNumber,
     })
-    let labelWarning = null
+    let labelWarning: string | undefined
     try {
       // Add the "AI generated" label
       await addLabelsToPullRequest({
@@ -53,8 +53,8 @@ async function fnHandler(
         pullNumber: pr.data.number,
         labels: ["AI generated"],
       })
-    } catch (labelError: any) {
-      labelWarning = `Warning: PR created, but failed to add 'AI generated' label: ${labelError?.message || labelError}`
+    } catch (labelError) {
+      labelWarning = `Warning: PR created, but failed to add 'AI generated' label: ${String(labelError)}`
       // Optionally, could log here too
     }
     return JSON.stringify({


### PR DESCRIPTION
This PR implements auto-labelling of pull requests created by the CreatePRTool with the label 'AI generated'.

- Adds `addLabelsToPullRequest` in `lib/github/pullRequests.ts`, using the GitHub issues API to label the PR by its number.
- Updates the CreatePRTool to automatically attempt to add the 'AI generated' label after successful PR creation.
- Updates the tool description/documentation for clarity.
- If the label addition fails, PR creation still succeeds and a warning is returned (and can be surfaced/logged).

This helps flag AI-generated PRs for later tracking and review.

Closes #405