### PR TITLE
Add AI-generated PRs merged counter to landing page

### DIFF
--- a/app/api/ai-merged-prs-count/route.ts
+++ b/app/api/ai-merged-prs-count/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server"
+import { countAIMergedPRs } from "@/lib/github/pullRequests"
+
+// TODO: Change this to your real repo full name (e.g. 'yourorg/yourrepo')
+const REPO_FULL_NAME = process.env.PUBLIC_REPO_FULL_NAME || "yourorg/yourrepo"
+
+export async function GET() {
+  try {
+    const count = await countAIMergedPRs({ repoFullName: REPO_FULL_NAME })
+    return NextResponse.json({ count })
+  } catch (e) {
+    // error handling
+    return NextResponse.json({ count: 0, error: String(e) }, { status: 500 })
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,25 @@ import Hero from "@/components/landing-page/Hero"
 import Pricing from "@/components/landing-page/Pricing"
 import Steps from "@/components/landing-page/Steps"
 import GridBackground from "@/components/ui/grid-background"
+import { useEffect, useState } from "react"
+
+function AIMergedPRsTestimonial() {
+  const [count, setCount] = useState<number | null>(null)
+  useEffect(() => {
+    fetch("/api/ai-merged-prs-count")
+      .then(res => res.json())
+      .then(data => setCount(data.count))
+      .catch(() => setCount(0))
+  }, [])
+  if (count == null) return <div className="my-8 text-center text-2xl font-bold text-accent">Loading AI PRs merged ...</div>
+  return (
+    <div className="my-8 text-center text-2xl font-bold text-accent">
+      {count > 0
+        ? `${count} AI-generated PRs merged to production 🎉`
+        : "Be the first to merge an AI-generated PR!"}
+    </div>
+  )
+}
 
 export default function LandingPage() {
   return (
@@ -13,6 +32,7 @@ export default function LandingPage() {
       <main>
         <GridBackground>
           <Hero />
+          <AIMergedPRsTestimonial />
           <Features />
           <ContributePublic />
           <Steps />


### PR DESCRIPTION
Adds a visible counter on the front page for AI-generated PRs merged to production. This includes:
- Backend utility and API route to count merged PRs labeled 'AI generated' on 'main' branch.
- Frontend testimonial/counter component for the landing page.

Closes #94

Closes #441