### PR TITLE
feat(utils): add linting helper function runLint and unit tests

### DIFF
--- a/__tests__/lib/utils/lint.test.ts
+++ b/__tests__/lib/utils/lint.test.ts
@@ -1,0 +1,40 @@
+import { runLint, LintResult } from "../../../lib/utils/lint";
+import { execSync } from "child_process";
+
+jest.mock("child_process");
+
+describe("runLint", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("returns OK and output on successful lint", () => {
+    (execSync as jest.Mock).mockReturnValue("Lint passed!");
+    const result = runLint();
+    expect(result).toEqual({ status: "OK", output: "Lint passed!" });
+  });
+
+  it("returns ERROR and error message on failed lint", () => {
+    (execSync as jest.Mock).mockImplementation(() => {
+      const err: any = new Error("Lint failed");
+      err.stdout = "Partial output";
+      err.stderr = "Missing semicolon";
+      throw err;
+    });
+    const result = runLint();
+    expect(result.status).toBe("ERROR");
+    expect(result.output).toEqual("Partial output");
+    expect(result.error).toEqual("Missing semicolon");
+  });
+
+  it("handles missing stderr and stdout", () => {
+    (execSync as jest.Mock).mockImplementation(() => {
+      const err: any = new Error("Process failed unexpectedly");
+      throw err;
+    });
+    const result = runLint();
+    expect(result.status).toBe("ERROR");
+    expect(result.output).toBe("");
+    expect(result.error).toContain("Process failed unexpectedly");
+  });
+});

--- a/lib/utils/lint.ts
+++ b/lib/utils/lint.ts
@@ -1,0 +1,25 @@
+import { execSync } from "child_process";
+
+export type LintResult =
+  | { status: "OK"; output: string }
+  | { status: "ERROR"; output: string; error: string };
+
+/**
+ * Runs the linter command synchronously ("pnpm run lint" by default).
+ * Will be made configurable in the future.
+ * Returns { status: "OK", output } on success,
+ * or { status: "ERROR", output, error } on failure.
+ */
+export function runLint(): LintResult {
+  try {
+    // The lint command may be overridden in the future for configurability
+    const output = execSync("pnpm run lint", { encoding: "utf-8" });
+    return { status: "OK", output };
+  } catch (err: any) {
+    return {
+      status: "ERROR",
+      output: err.stdout?.toString?.() ?? "",
+      error: err.stderr?.toString?.() ?? err.message,
+    };
+  }
+}


### PR DESCRIPTION
This PR introduces a utility for programmatically running linter checks:

- **/lib/utils/lint.ts**: Provides `runLint`, a helper function to execute `pnpm run lint` and returns results in `{ status: 'OK' | 'ERROR', ... }` shape.
- Handles both success and error cases gracefully, capturing relevant stdout/stderr for downstream consumption.
- Forward-looking comments for future configurability.

**Unit tests** (in `__tests__/lib/utils/lint.test.ts`) cover:
- Successful lint execution
- Linter failure with output
- Unexpected process error shapes

This sets groundwork for both internal and future tool-based consumption (#350).


Closes #465