### PR TITLE
Show icons on issues list for Plan and PR readiness

### DIFF
--- a/components/issues/IssueRow.tsx
+++ b/components/issues/IssueRow.tsx
@@ -7,10 +7,32 @@ import DataRow from "@/components/common/DataRow"
 import CreatePRController from "@/components/issues/controllers/CreatePRController"
 import GenerateResolutionPlanController from "@/components/issues/controllers/GenerateResolutionPlanController"
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu"
-import { GitHubIssue } from "@/lib/types/github"
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
+import type { IssueWithStatus } from "@/lib/github/issues"
+
+function PlanIcon() {
+  // Inline SVG for a plan (document) icon
+  return (
+    <svg height="18" viewBox="0 0 20 20" width="18" fill="none" className="inline align-text-bottom mr-0.5 text-blue-600">
+      <rect x="3" y="2" width="14" height="16" rx="2" stroke="#2563EB" strokeWidth="1.5" fill="#DBEAFE" />
+      <path d="M7 6h6M7 10h6M7 14h3" stroke="#2563EB" strokeWidth="1.3" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+function PRIcon() {
+  // Inline SVG for a PR (pull request, link-style) icon
+  return (
+    <svg height="18" viewBox="0 0 20 20" width="18" fill="none" className="inline align-text-bottom text-green-600">
+      <rect x="4.5" y="3.5" width="4" height="4" rx="2" stroke="#22C55E" strokeWidth="1.5" fill="#DCFCE7" />
+      <rect x="11.5" y="12.5" width="4" height="4" rx="2" stroke="#22C55E" strokeWidth="1.5" fill="#DCFCE7" />
+      <path d="M12.5 7v1.5c0 2-1.5 3.5-3.5 3.5H6" stroke="#22C55E" strokeWidth="1.3" />
+    </svg>
+  )
+}
 
 interface IssueRowProps {
-  issue: GitHubIssue
+  issue: IssueWithStatus
   repoFullName: string
 }
 
@@ -56,9 +78,43 @@ export default function IssueRow({ issue, repoFullName }: IssueRowProps) {
   const [username, repo] = repoFullName.split("/")
   const localIssueUrl = `/${username}/${repo}/issues/${issue.number}`
 
+  // Render status indicators for plan and PR
+  function StatusIndicators() {
+    return (
+      <TooltipProvider>
+        <div className="flex flex-row gap-2">
+          {issue.hasPlan && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>
+                  <PlanIcon />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Plan ready</TooltipContent>
+            </Tooltip>
+          )}
+          {issue.hasPR && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>
+                  <PRIcon />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">PR ready</TooltipContent>
+            </Tooltip>
+          )}
+        </div>
+      </TooltipProvider>
+    )
+  }
+
   return (
     <DataRow
-      title={issue.title}
+      title={
+        <>
+          {issue.title} <StatusIndicators />
+        </>
+      }
       number={issue.number}
       url={localIssueUrl}
       user={issue.user?.login}

--- a/components/issues/IssueTable.tsx
+++ b/components/issues/IssueTable.tsx
@@ -1,6 +1,6 @@
 import DataTable from "@/components/common/DataTable"
 import IssueRow from "@/components/issues/IssueRow"
-import { getIssueList } from "@/lib/github/issues"
+import { getIssueListWithStatus } from "@/lib/github/issues"
 
 export default async function IssueTable({
   repoFullName,
@@ -8,7 +8,7 @@ export default async function IssueTable({
   repoFullName: string
 }) {
   try {
-    const issues = await getIssueList({
+    const issues = await getIssueListWithStatus({
       repoFullName,
       per_page: 100,
     })


### PR DESCRIPTION
This PR implements the following features:

- Backend aggregation (`getIssueListWithStatus`) now adds `hasPlan` and `hasPR` boolean flags for each issue.
- On the issues list page, each issue row now renders icons to visually show if a Plan is ready and/or if a Pull Request is ready, with tooltips for clarity.
- UI/UX improvement similar to GitHub issue lists with status badges.

No external icon assets required: SVGs are inlined into the code for stability and portability.

Closes #474