### PR TITLE
Fetch PR reviews & line comments with GraphQL for alignmentCheck workflow

### DIFF
--- a/lib/github/pullRequests.ts
+++ b/lib/github/pullRequests.ts
@@ -181,6 +181,88 @@ export async function getPullRequestReviews({
   return reviewsResponse.data
 }
 
+/**
+ * Fetch all reviews and (inline) review comments for a given Pull Request using GitHub GraphQL API.
+ * Returns detailed review objects: each with top-level comment plus their inline/file comments/threads.
+ */
+export async function getPullRequestReviewCommentsGraphQL({
+  repoFullName,
+  pullNumber,
+  reviewsLimit = 50,
+  commentsPerReview = 50,
+}: {
+  repoFullName: string
+  pullNumber: number
+  reviewsLimit?: number
+  commentsPerReview?: number
+}) {
+  const [owner, repo] = repoFullName.split("/")
+  const graphqlWithAuth = await getGraphQLClient()
+  if (!graphqlWithAuth) throw new Error("Could not initialize GraphQL client")
+  // GraphQL query for reviews and review comments
+  const query = `
+    query($owner: String!, $repo: String!, $pullNumber: Int!, $reviewsLimit: Int!, $commentsPerReview: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $pullNumber) {
+          reviews(first: $reviewsLimit) {
+            nodes {
+              id
+              author { login }
+              state
+              body
+              submittedAt
+              comments(first: $commentsPerReview) {
+                nodes {
+                  id
+                  author { login }
+                  body
+                  path
+                  position
+                  originalPosition
+                  diffHunk
+                  createdAt
+                  replyTo { id }
+                  pullRequestReview { id }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `
+  const variables = {
+    owner,
+    repo,
+    pullNumber,
+    reviewsLimit,
+    commentsPerReview,
+  }
+  const response = await graphqlWithAuth(query, variables)
+  // Defensive: Structure the response for easy UI/LLM consumption
+  const reviews =
+    response?.repository?.pullRequest?.reviews?.nodes?.map((r: any) => ({
+      id: r.id,
+      author: r.author?.login,
+      state: r.state,
+      body: r.body,
+      submittedAt: r.submittedAt,
+      comments: (r.comments?.nodes || []).map((c: any) => ({
+        id: c.id,
+        author: c.author?.login,
+        body: c.body,
+        file: c.path,
+        position: c.position,
+        originalPosition: c.originalPosition,
+        diffHunk: c.diffHunk,
+        createdAt: c.createdAt,
+        replyTo: c.replyTo?.id,
+        reviewId: c.pullRequestReview?.id,
+      })),
+    })) || []
+  return reviews
+}
+
 export async function getPullRequest({
   repoFullName,
   pullNumber,

--- a/lib/types/github.ts
+++ b/lib/types/github.ts
@@ -19,6 +19,8 @@ export type PullRequest = PullRequestSingle | PullRequestList[0]
 
 export type PullRequestReview =
   RestEndpointMethodTypes["pulls"]["listReviews"]["response"]["data"][0]
+export type PullRequestReviewComment =
+  RestEndpointMethodTypes["pulls"]["listReviewComments"]["response"]["data"][0]
 export type ListForRepoParams =
   RestEndpointMethodTypes["issues"]["listForRepo"]["parameters"]
 export type SearchCodeItem = components["schemas"]["code-search-result-item"]

--- a/lib/workflows/alignmentCheck.ts
+++ b/lib/workflows/alignmentCheck.ts
@@ -23,6 +23,7 @@ import {
   IssueComment,
   PullRequest,
   PullRequestReview,
+  PullRequestReviewComment,
 } from "@/lib/types/github"
 
 type Params = {
@@ -33,7 +34,7 @@ type Params = {
   diff?: string
   comments?: IssueComment[]
   reviews?: PullRequestReview[]
-  reviewThreads?: any[]
+  reviewThreads?: PullRequestReviewComment[]
   issueNumber?: number
   plan?: Plan
   issue?: GitHubIssue
@@ -101,16 +102,12 @@ export async function alignmentCheck({
       comments = await getPullRequestComments({ repoFullName, pullNumber })
     }
     // Fetch full review+threaded comments from GraphQL
-    let graphqlReviews: any[] = []
-    try {
-      graphqlReviews = await getPullRequestReviewCommentsGraphQL({
-        repoFullName,
-        pullNumber,
-      })
-    } catch (e) {
-      // fallback: set to []
-      graphqlReviews = []
-    }
+
+    const graphqlReviewsResponse = await getPullRequestReviewCommentsGraphQL({
+      repoFullName,
+      pullNumber,
+    })
+
     // If legacy reviews not provided, fallback to REST (top-level only)
     if (!reviews) {
       reviews = await getPullRequestReviews({ repoFullName, pullNumber })
@@ -188,7 +185,7 @@ export async function alignmentCheck({
       diff,
       comments,
       reviewSummaries: reviews,
-      reviewThreads: graphqlReviews,
+      reviewThreads: graphqlReviewsResponse,
       plan,
       issue,
     }

--- a/lib/workflows/alignmentCheck.ts
+++ b/lib/workflows/alignmentCheck.ts
@@ -7,8 +7,8 @@ import {
   getPullRequest,
   getPullRequestComments,
   getPullRequestDiff,
-  getPullRequestReviews,
   getPullRequestReviewCommentsGraphQL,
+  getPullRequestReviews,
 } from "@/lib/github/pullRequests"
 import { langfuse } from "@/lib/langfuse"
 import {
@@ -103,7 +103,10 @@ export async function alignmentCheck({
     // Fetch full review+threaded comments from GraphQL
     let graphqlReviews: any[] = []
     try {
-      graphqlReviews = await getPullRequestReviewCommentsGraphQL({ repoFullName, pullNumber })
+      graphqlReviews = await getPullRequestReviewCommentsGraphQL({
+        repoFullName,
+        pullNumber,
+      })
     } catch (e) {
       // fallback: set to []
       graphqlReviews = []


### PR DESCRIPTION
## Summary

- Adds `getPullRequestReviewCommentsGraphQL` helper to `lib/github/pullRequests.ts` using GitHub GraphQL API. This fetches PR review summaries **plus** all inline/line review comments for full review context.
- Updates `lib/workflows/alignmentCheck.ts` to fetch and use both REST and GraphQL review data. LLM context now receives both summary and threaded review comments for alignment checks.

### Implementation Details
- GraphQL query fetches up to 50 reviews, each with up to 50 inline comments.
- Fallback to REST summary reviews for legacy downstream compatibility.
- Still sends PR, diff, plan, issue, PR comments, **plus:**
  - `reviewSummaries` (from REST)
  - `reviewThreads` (from GraphQL, nested structure)

### Motivation
- Provides LLM with line-level review comments (not just summaries).
- Enables context-rich alignment checks and gives more actionable, referenceable review data.

Closes #<the issue number>.

Closes #489