### PR TITLE
feat: persist AlignmentAnalysis as new Neo4j node type, handle workflow/service/repository

### DIFF
--- a/app/api/workflow/alignment-check/route.ts
+++ b/app/api/workflow/alignment-check/route.ts
@@ -22,7 +22,11 @@ export async function POST(request: NextRequest) {
       pullNumber,
       openAIApiKey: openAIApiKey,
     })
-    return NextResponse.json({ success: true, result })
+    return NextResponse.json({
+      success: true,
+      content: result?.content ?? null,
+      alignmentAnalysisNodeId: result?.alignmentAnalysisNodeId ?? null,
+    })
   } catch (e) {
     // Log full error for debugging
     console.error("[alignmentCheck] Failed to analyze:", e)

--- a/lib/neo4j/repositories/alignmentAnalysis.ts
+++ b/lib/neo4j/repositories/alignmentAnalysis.ts
@@ -1,0 +1,73 @@
+import { ManagedTransaction, Integer } from "neo4j-driver"
+import { alignmentAnalysisSchema, AlignmentAnalysis } from "@/lib/types/db/neo4j"
+
+// Create an AlignmentAnalysis node
+export async function createAlignmentAnalysis(
+  tx: ManagedTransaction,
+  { id, content, workflowId, createdAt, planId, issueNumber, repoFullName }: AlignmentAnalysis
+): Promise<AlignmentAnalysis> {
+  const cypher = `
+    CREATE (a:AlignmentAnalysis {
+      id: $id,
+      content: $content,
+      workflowId: $workflowId,
+      createdAt: datetime($createdAt),
+      planId: $planId,
+      issueNumber: $issueNumber,
+      repoFullName: $repoFullName
+    })
+    RETURN a
+  `
+  const params = {
+    id,
+    content,
+    workflowId,
+    createdAt,
+    planId: planId || null,
+    issueNumber: issueNumber || null,
+    repoFullName: repoFullName || null,
+  }
+  const result = await tx.run<{ a: any }>(cypher, params)
+  const raw = result.records[0]?.get("a")?.properties
+  return alignmentAnalysisSchema.parse(raw)
+}
+
+// Optionally add relationships to Issue, Plan, WorkflowRun as needed
+export async function linkAlignmentAnalysisNode(
+  tx: ManagedTransaction,
+  { alignmentId, planId, issueNumber, repoFullName, workflowId } : {
+    alignmentId: string;
+    planId?: string;
+    issueNumber?: Integer;
+    repoFullName?: string;
+    workflowId?: string;
+  }
+): Promise<void> {
+  // Link to Plan
+  if(planId) {
+    await tx.run(
+      `MATCH (a:AlignmentAnalysis {id: $alignmentId}), (p:Plan {id: $planId})
+       MERGE (a)-[:ANALYZES]->(p)
+      `,
+      { alignmentId, planId }
+    )
+  }
+  // Link to Issue
+  if(issueNumber && repoFullName) {
+    await tx.run(
+      `MATCH (a:AlignmentAnalysis {id: $alignmentId}), (i:Issue {number: $issueNumber, repoFullName: $repoFullName})
+       MERGE (a)-[:ALIGNS]->(i)
+      `,
+      { alignmentId, issueNumber, repoFullName }
+    )
+  }
+  // Link to WorkflowRun
+  if(workflowId) {
+    await tx.run(
+      `MATCH (a:AlignmentAnalysis {id: $alignmentId}), (w:WorkflowRun {id: $workflowId})
+       MERGE (a)-[:FROM_WORKFLOW]->(w)
+      `,
+      { alignmentId, workflowId }
+    )
+  }
+}

--- a/lib/neo4j/services/alignmentAnalysis.ts
+++ b/lib/neo4j/services/alignmentAnalysis.ts
@@ -1,0 +1,47 @@
+import { v4 as uuidv4 } from "uuid"
+import { int } from "neo4j-driver"
+import { n4j } from "@/lib/neo4j/client"
+import { createAlignmentAnalysis, linkAlignmentAnalysisNode } from "@/lib/neo4j/repositories/alignmentAnalysis"
+
+/**
+ * Save AlignmentAnalysis node and link to Issue, Plan, WorkflowRun as available.
+ */
+export async function saveAlignmentAnalysisNode({
+  analysisContent,
+  workflowId,
+  relatedPlanId,
+  issueNumber,
+  repoFullName,
+}: {
+  analysisContent: string,
+  workflowId: string,
+  relatedPlanId?: string,
+  issueNumber?: number,
+  repoFullName?: string,
+}): Promise<string> {
+  const session = await n4j.getSession()
+  const alignmentId = uuidv4()
+  try {
+    await session.executeWrite(async (tx) => {
+      await createAlignmentAnalysis(tx, {
+        id: alignmentId,
+        content: analysisContent,
+        workflowId,
+        createdAt: new Date(),
+        planId: relatedPlanId,
+        issueNumber: issueNumber !== undefined ? int(issueNumber) : undefined,
+        repoFullName,
+      })
+      await linkAlignmentAnalysisNode(tx, {
+        alignmentId,
+        planId: relatedPlanId,
+        issueNumber: issueNumber !== undefined ? int(issueNumber) : undefined,
+        repoFullName,
+        workflowId,
+      })
+    })
+    return alignmentId
+  } finally {
+    await session.close()
+  }
+}

--- a/lib/types/db/neo4j.ts
+++ b/lib/types/db/neo4j.ts
@@ -15,7 +15,6 @@ import {
   workflowRunSchema as appWorkflowRunSchema,
   WorkflowRunState,
   workflowRunStateSchema,
-  workflowStateEventSchema as appWorkflowStateEventSchema,
   WorkflowType,
   workflowTypeEnum,
 } from "@/lib/types"
@@ -53,6 +52,18 @@ export const planSchema = appPlanSchema.merge(
     createdAt: z.instanceof(DateTime),
   })
 )
+
+// AlignmentAnalysis node and schema
+export const alignmentAnalysisSchema = z.object({
+  id: z.string(),
+  content: z.string(),
+  workflowId: z.string(),
+  createdAt: z.instanceof(DateTime),
+  planId: z.string().optional(),
+  issueNumber: z.instanceof(Integer).optional(),
+  repoFullName: z.string().optional(),
+})
+export type AlignmentAnalysis = z.infer<typeof alignmentAnalysisSchema>
 
 // Event schemas
 export const errorEventSchema = appErrorEventSchema


### PR DESCRIPTION
- Adds a new `AlignmentAnalysis` node type+schema in Neo4j, with fields: id, content, workflowId, createdAt, planId, issueNumber, repoFullName
- Implements repository and service modules for creating nodes and linking relationships (plan, issue, workflow)
- Modifies alignmentCheck workflow to persist analysis and return the node ID
- Changes alignment-check API route to include alignmentAnalysisNodeId in response
- Error handling ensures primary workflow continues if persistence fails
- Unit test for persist logic recommended separately

Closes #493