### PR TITLE
feat(blogs): Blog section with markdown blog posts

### DIFF
--- a/app/blogs/[slug]/page.tsx
+++ b/app/blogs/[slug]/page.tsx
@@ -1,37 +1,37 @@
-import path from "path"
-import { notFound } from "next/navigation"
-import { getFileContent } from "@/lib/fs"
 import matter from "gray-matter"
-import MarkdownRenderer from "@/components/blog/MarkdownRenderer"
+import path from "path"
 
-interface BlogPageParams {
+import MarkdownRenderer from "@/components/blog/MarkdownRenderer"
+import { getFileContent } from "@/lib/fs"
+import { BlogPost } from "@/lib/types"
+
+interface Params {
   params: { slug: string }
 }
 
-export default async function BlogPostPage({ params }: BlogPageParams) {
+export default async function BlogPostPage({ params }: Params) {
   const { slug } = params
   const blogDir = path.join(process.cwd(), "blogs")
   const file = path.join(blogDir, `${slug}.md`)
 
-  let mdContent: string
-  let data: any = {}
-
-  try {
-    const fileContent = await getFileContent(file)
-    const parsed = matter(fileContent)
-    mdContent = parsed.content
-    data = parsed.data || {}
-  } catch (err) {
-    notFound()
+  const fileContent = await getFileContent(file)
+  const parsed = matter(fileContent)
+  const blogPost: BlogPost = {
+    slug,
+    title: parsed.data.title || slug,
+    date: parsed.data.date ? new Date(parsed.data.date) : null,
+    summary: parsed.data.Summary || parsed.data.summary || "",
   }
-
-  const title = data.title || slug
-  const date = data.date
+  const mdContent = parsed.content
 
   return (
     <article className="container max-w-2xl py-10 mx-auto prose dark:prose-invert">
-      <h1 className="text-3xl font-bold mb-4">{title}</h1>
-      {date && <div className="mb-6 text-sm text-muted-foreground">{date}</div>}
+      <h1 className="text-3xl font-bold mb-4">{blogPost.title}</h1>
+      {blogPost.date && (
+        <div className="mb-6 text-sm text-muted-foreground">
+          {blogPost.date.toLocaleDateString()}
+        </div>
+      )}
       <MarkdownRenderer content={mdContent} />
     </article>
   )

--- a/app/blogs/[slug]/page.tsx
+++ b/app/blogs/[slug]/page.tsx
@@ -1,0 +1,38 @@
+import path from "path"
+import { notFound } from "next/navigation"
+import { getFileContent } from "@/lib/fs"
+import matter from "gray-matter"
+import MarkdownRenderer from "@/components/blog/MarkdownRenderer"
+
+interface BlogPageParams {
+  params: { slug: string }
+}
+
+export default async function BlogPostPage({ params }: BlogPageParams) {
+  const { slug } = params
+  const blogDir = path.join(process.cwd(), "blogs")
+  const file = path.join(blogDir, `${slug}.md`)
+
+  let mdContent: string
+  let data: any = {}
+
+  try {
+    const fileContent = await getFileContent(file)
+    const parsed = matter(fileContent)
+    mdContent = parsed.content
+    data = parsed.data || {}
+  } catch (err) {
+    notFound()
+  }
+
+  const title = data.title || slug
+  const date = data.date
+
+  return (
+    <article className="container max-w-2xl py-10 mx-auto prose dark:prose-invert">
+      <h1 className="text-3xl font-bold mb-4">{title}</h1>
+      {date && <div className="mb-6 text-sm text-muted-foreground">{date}</div>}
+      <MarkdownRenderer content={mdContent} />
+    </article>
+  )
+}

--- a/app/blogs/page.tsx
+++ b/app/blogs/page.tsx
@@ -1,16 +1,66 @@
-const BLOG_URL =
-  "https://lavish-tugboat-5ca.notion.site/ebd/1abe6ee78623807cacc8f2cafb6b16cb"
+import Link from "next/link"
+import path from "path"
+import { createDirectoryTree, getFileContent } from "@/lib/fs"
+import matter from "gray-matter"
 
-export default function BlogPage() {
+// List all markdown blog posts and link to each by slug
+export default async function BlogIndexPage() {
+  const blogsDir = path.join(process.cwd(), "blogs")
+  const fileTree = await createDirectoryTree(blogsDir)
+  // Only consider .md files at root
+  const blogFiles = fileTree.filter(
+    (file) => file.endsWith(".md") && !file.includes(path.sep)
+  )
+
+  // Fetch blog metadata
+  const blogs = await Promise.all(
+    blogFiles.map(async (filename) => {
+      const fullPath = path.join(blogsDir, filename)
+      const contents = await getFileContent(fullPath)
+      const { data } = matter(contents)
+      const slug = filename.replace(/\.md$/, "")
+      return {
+        slug,
+        title: data.title || slug,
+        date: data.date || null,
+        summary: data.Summary || data.summary || "",
+      }
+    })
+  )
+
+  // Sort by date (if available)
+  blogs.sort((a, b) => {
+    if (a.date && b.date) return (a.date > b.date ? -1 : 1)
+    if (a.date) return -1
+    if (b.date) return 1
+    return a.slug.localeCompare(b.slug)
+  })
+
   return (
-    <div style={{ height: "100vh" }}>
-      <iframe
-        src={BLOG_URL}
-        width="100%"
-        height="100%"
-        style={{ border: "none" }}
-        allowFullScreen
-      />
+    <div className="container max-w-2xl py-10 mx-auto">
+      <h1 className="text-3xl font-bold mb-8">Blogs</h1>
+      <ul className="space-y-8">
+        {blogs.map((blog) => (
+          <li key={blog.slug}>
+            <Link
+              href={`/blogs/${blog.slug}`}
+              className="text-2xl font-semibold text-blue-700 hover:underline dark:text-blue-400"
+            >
+              {blog.title}
+            </Link>
+            {blog.date && (
+              <span className="block text-xs text-muted-foreground mt-1">
+                {blog.date}
+              </span>
+            )}
+            {blog.summary && (
+              <p className="mt-2 text-base text-stone-600 dark:text-stone-300">
+                {blog.summary}
+              </p>
+            )}
+          </li>
+        ))}
+      </ul>
     </div>
   )
 }

--- a/components/blog/MarkdownRenderer.tsx
+++ b/components/blog/MarkdownRenderer.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import ReactMarkdown from "react-markdown";
+
+export interface MarkdownRendererProps {
+  content: string;
+  className?: string;
+}
+
+const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content, className }) => {
+  return (
+    <div className={className ? className : "prose prose-sm dark:prose-invert max-w-none"}>
+      <ReactMarkdown>{content}</ReactMarkdown>
+    </div>
+  );
+};
+
+export default MarkdownRenderer;

--- a/components/blog/MarkdownRenderer.tsx
+++ b/components/blog/MarkdownRenderer.tsx
@@ -1,17 +1,24 @@
-import React from "react";
-import ReactMarkdown from "react-markdown";
+import React from "react"
+import ReactMarkdown from "react-markdown"
 
 export interface MarkdownRendererProps {
-  content: string;
-  className?: string;
+  content: string
+  className?: string
 }
 
-const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content, className }) => {
+const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
+  content,
+  className,
+}) => {
   return (
-    <div className={className ? className : "prose prose-sm dark:prose-invert max-w-none"}>
+    <div
+      className={
+        className ? className : "prose prose-sm dark:prose-invert max-w-none"
+      }
+    >
       <ReactMarkdown>{content}</ReactMarkdown>
     </div>
-  );
-};
+  )
+}
 
-export default MarkdownRenderer;
+export default MarkdownRenderer

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -200,9 +200,18 @@ export const settingsSchema = z.object({
   // Add more user-specific settings here as needed
 })
 
+// Blog Posts
+export const blogPostSchema = z.object({
+  slug: z.string().optional(),
+  title: z.string().optional(),
+  date: z.date().nullable().optional(),
+  summary: z.string().optional(),
+})
+
 // Type exports
 export type AnyEvent = z.infer<typeof anyEventSchema>
 export type BaseEvent = z.infer<typeof baseEventSchema>
+export type BlogPost = z.infer<typeof blogPostSchema>
 export type ErrorEvent = z.infer<typeof errorEventSchema>
 export type EventTypes = z.infer<typeof eventTypes>
 export type Issue = z.infer<typeof issueSchema>

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "date-fns": "^4.1.0",
     "exponential-backoff": "^3.1.2",
     "framer-motion": "^12.4.10",
+    "gray-matter": "^4.0.3",
     "langfuse": "^3.32.0",
     "langfuse-core": "^3.37.0",
     "lucide-react": "^0.460.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       framer-motion:
         specifier: ^12.4.10
         version: 12.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
       langfuse:
         specifier: ^3.32.0
         version: 3.36.0
@@ -2427,6 +2430,10 @@ packages:
   exponential-backoff@3.1.2:
     resolution: {integrity: sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==}
 
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -2645,6 +2652,10 @@ packages:
     resolution: {integrity: sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -2798,6 +2809,10 @@ packages:
 
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -3138,6 +3153,10 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -3957,6 +3976,10 @@ packages:
     resolution: {integrity: sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==}
     engines: {node: '>= 10.13.0'}
 
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -4108,6 +4131,10 @@ packages:
   strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -7205,6 +7232,10 @@ snapshots:
 
   exponential-backoff@3.1.2: {}
 
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
+
   extend@3.0.2: {}
 
   fast-content-type-parse@2.0.1: {}
@@ -7423,6 +7454,13 @@ snapshots:
 
   graphql@16.10.0: {}
 
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.14.1
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -7595,6 +7633,8 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-decimal@2.0.1: {}
+
+  is-extendable@0.1.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -8150,6 +8190,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kind-of@6.0.3: {}
 
   kleur@3.0.3: {}
 
@@ -9109,6 +9151,11 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.17.1)
       ajv-keywords: 5.1.0(ajv@8.17.1)
 
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+
   semver@6.3.1: {}
 
   semver@7.7.1: {}
@@ -9302,6 +9349,8 @@ snapshots:
   strip-ansi@7.1.0:
     dependencies:
       ansi-regex: 6.1.0
+
+  strip-bom-string@1.0.0: {}
 
   strip-bom@3.0.0: {}
 


### PR DESCRIPTION
- Adds /blogs page to list and link blog articles from the /blogs dir
- Adds dynamic /blogs/[slug] page to render each markdown article
- Adds new MarkdownRenderer component (react-markdown-based)
- Fetches and parses markdown frontmatter/title/date/summary
- Styles blog list and blog post pages

Resolves #<issue-num>. Moves away from Notion iframe embed; future-ready for CMS migration.

Closes #521