### PR TITLE
Add settings page

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,43 @@
+import Image from "next/image"
+import { redirect } from "next/navigation"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { getGithubUser } from "@/lib/github/users"
+
+export const dynamic = "force-dynamic"
+
+export default async function SettingsPage() {
+  const user = await getGithubUser()
+
+  if (!user) {
+    redirect("/redirect?redirect=/settings")
+  }
+
+  return (
+    <main className="container mx-auto p-4 space-y-6">
+      <h1 className="text-2xl font-bold">Settings</h1>
+      <Card className="max-w-md">
+        <CardHeader>
+          <CardTitle>Profile</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center gap-4">
+            {user.avatar_url && (
+              <Image
+                src={user.avatar_url}
+                alt={user.login}
+                width={64}
+                height={64}
+                className="rounded-full"
+              />
+            )}
+            <div>
+              <p className="text-lg font-semibold">{user.name ?? user.login}</p>
+              <p className="text-sm text-muted-foreground">{user.login}</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </main>
+  )
+}

--- a/components/layout/DynamicNavigation.tsx
+++ b/components/layout/DynamicNavigation.tsx
@@ -135,6 +135,14 @@ export default function DynamicNavigation({
           >
             <Link href="/contribute">Contribute</Link>
           </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            asChild
+            className="flex items-center"
+          >
+            <Link href="/settings">Settings</Link>
+          </Button>
           <form action={signOutAndRedirect}>
             <Button
               type="submit"

--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,14 @@ import MiniCssExtractPlugin from "mini-css-extract-plugin"
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
+      },
+    ],
+  },
   async headers() {
     return [
       {


### PR DESCRIPTION
## Summary
- add placeholder settings page that shows user data
- add Settings link in authenticated navigation

## Testing
- `pnpm lint`
- `pnpm test`


Closes #397 

------
https://chatgpt.com/codex/tasks/task_e_68400a2161608333abc9d1a83f4f9887