### PR TITLE
Add codex page

### DIFF
--- a/app/api/github/branches/route.ts
+++ b/app/api/github/branches/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+
+import { listBranches } from "@/lib/github/git"
+
+export const dynamic = "force-dynamic"
+
+const RequestSchema = z.object({
+  repoFullName: z.string(),
+})
+
+export async function POST(request: Request) {
+  try {
+    const { repoFullName } = RequestSchema.parse(await request.json())
+    const branches = await listBranches(repoFullName)
+    return NextResponse.json({ branches })
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: "Invalid request", details: err.errors },
+        { status: 400 }
+      )
+    }
+    console.error("Failed to fetch branches:", err)
+    return NextResponse.json(
+      { error: "Failed to fetch branches" },
+      { status: 500 }
+    )
+  }
+}

--- a/app/codex/CodexForm.tsx
+++ b/app/codex/CodexForm.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+
+interface RepoOption {
+  id: number
+  full_name: string
+}
+
+interface Props {
+  repositories: RepoOption[]
+}
+
+export default function CodexForm({ repositories }: Props) {
+  const [repo, setRepo] = useState<string>("")
+  const [branch, setBranch] = useState<string>("")
+  const [branches, setBranches] = useState<string[]>([])
+  const [instructions, setInstructions] = useState<string>("")
+
+  useEffect(() => {
+    if (repo) {
+      fetch("/api/github/branches", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ repoFullName: repo }),
+      })
+        .then((res) => res.json())
+        .then((data) => {
+          setBranches(data.branches || [])
+        })
+        .catch((err) => {
+          console.error(err)
+          setBranches([])
+        })
+    } else {
+      setBranches([])
+      setBranch("")
+    }
+  }, [repo])
+
+  return (
+    <div className="space-y-4">
+      <Select onValueChange={setRepo} value={repo}>
+        <SelectTrigger>
+          <SelectValue placeholder="Select repository" />
+        </SelectTrigger>
+        <SelectContent>
+          {repositories.map((r) => (
+            <SelectItem key={r.id} value={r.full_name}>
+              {r.full_name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Select onValueChange={setBranch} value={branch} disabled={!repo}>
+        <SelectTrigger>
+          <SelectValue placeholder="Select branch" />
+        </SelectTrigger>
+        <SelectContent>
+          {branches.map((b) => (
+            <SelectItem key={b} value={b}>
+              {b}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Textarea
+        value={instructions}
+        onChange={(e) => setInstructions(e.target.value)}
+        placeholder="Describe the changes you'd like to make"
+        rows={10}
+      />
+    </div>
+  )
+}

--- a/app/codex/page.tsx
+++ b/app/codex/page.tsx
@@ -1,0 +1,96 @@
+import { formatDistanceToNow } from "date-fns"
+import Link from "next/link"
+import { Suspense } from "react"
+
+import TableSkeleton from "@/components/layout/TableSkeleton"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent } from "@/components/ui/card"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { getAuthenticatedUserRepositories } from "@/lib/github/content"
+import { listWorkflowRuns } from "@/lib/neo4j/services/workflow"
+
+import CodexForm from "./CodexForm"
+
+export default async function CodexPage() {
+  const { repositories } = await getAuthenticatedUserRepositories({
+    per_page: 100,
+  })
+  const runs = await listWorkflowRuns()
+
+  return (
+    <main className="container mx-auto p-4 space-y-8">
+      <h1 className="text-3xl font-bold">Codex</h1>
+      <CodexForm
+        repositories={repositories.map((r) => ({
+          id: r.id,
+          full_name: r.full_name,
+        }))}
+      />
+      <div>
+        <h2 className="text-2xl font-semibold mb-4">Workflow Runs</h2>
+        <Suspense fallback={<TableSkeleton />}>
+          <Card className="max-w-screen-xl mx-auto rounded">
+            <CardContent>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="py-4 text-base font-medium">
+                      Name
+                    </TableHead>
+                    <TableHead className="py-4 text-base font-medium">
+                      Status
+                    </TableHead>
+                    <TableHead className="py-4 text-base font-medium">
+                      Started
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {runs.map((workflow) => (
+                    <TableRow key={workflow.id}>
+                      <TableCell className="py-4">
+                        <Link
+                          href={`/workflow-runs/${workflow.id}`}
+                          className="text-blue-600 hover:underline font-medium"
+                        >
+                          {workflow.id.slice(0, 8)}
+                        </Link>
+                      </TableCell>
+                      <TableCell>
+                        <Badge
+                          variant={
+                            workflow.state === "completed"
+                              ? "default"
+                              : workflow.state === "error"
+                                ? "destructive"
+                                : "secondary"
+                          }
+                        >
+                          {workflow.state}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="py-4 text-muted-foreground">
+                        {workflow.createdAt
+                          ? formatDistanceToNow(workflow.createdAt, {
+                              addSuffix: true,
+                            })
+                          : "N/A"}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        </Suspense>
+      </div>
+    </main>
+  )
+}

--- a/components/layout/DynamicNavigation.tsx
+++ b/components/layout/DynamicNavigation.tsx
@@ -133,6 +133,14 @@ export default function DynamicNavigation({
             asChild
             className="flex items-center"
           >
+            <Link href="/codex">Codex</Link>
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            asChild
+            className="flex items-center"
+          >
             <Link href="/contribute">Contribute</Link>
           </Button>
           <form action={signOutAndRedirect}>

--- a/lib/github/git.ts
+++ b/lib/github/git.ts
@@ -75,3 +75,21 @@ export async function createBranch(
     }
   }
 }
+
+export async function listBranches(fullRepo: string): Promise<string[]> {
+  const octokit = await getOctokit()
+  if (!octokit) {
+    throw new Error("No octokit found")
+  }
+  const [owner, repo] = fullRepo.split("/")
+  if (!owner || !repo) {
+    throw new Error("Invalid repository format. Expected 'owner/repo'")
+  }
+
+  const { data } = await octokit.repos.listBranches({
+    owner,
+    repo,
+    per_page: 100,
+  })
+  return data.map((b) => b.name)
+}


### PR DESCRIPTION
## Summary
- add helper to list repo branches
- expose new `/api/github/branches` endpoint
- create client form for repo/branch selection and instruction input
- build `/codex` page showing the form and latest workflow runs
- link Codex in navigation

## Testing
- `pnpm lint:eslint`
- `pnpm lint:prettier`
- `pnpm lint:tsc`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68400abb48788333bcaf2c9bef9c0ed7