### PR TITLE
fix: right-align repo selector dropdown menu on desktop

### DIFF
--- a/components/layout/Breadcrumb.tsx
+++ b/components/layout/Breadcrumb.tsx
@@ -60,7 +60,7 @@ export default function Nav() {
                     <ChevronDown />
                   </DropdownMenuTrigger>
                 </BreadcrumbPage>
-                <DropdownMenuContent align="start">
+                <DropdownMenuContent align="end" className="left-0 md:left-auto md:right-0">
                   <DropdownMenuItem>
                     <Link href={`/${username}/${repo}/issues`}>issues</Link>
                   </DropdownMenuItem>


### PR DESCRIPTION
This PR ensures the repository selector dropdown on the /issues page is right-aligned with its trigger button on desktop, but left-aligned on mobile, matching the user interface expectations.

- Changed `<DropdownMenuContent>` in `components/layout/Breadcrumb.tsx` to use `align="end"` and responsive Tailwind classes (`left-0 md:left-auto md:right-0`).
- Desktop: dropdown menu is right-aligned with the button
- Mobile: dropdown remains left-aligned

No side effects expected for other menus. Visual alignment tested on varying viewport widths.

Closes #549