### PR TITLE
Refactor DataTable: Destructure for Composability

### DIFF
--- a/components/common/DataTable.tsx
+++ b/components/common/DataTable.tsx
@@ -1,3 +1,4 @@
+import React from "react"
 import {
   Table,
   TableBody,
@@ -6,33 +7,32 @@ import {
   TableRow,
 } from "@/components/ui/table"
 
-interface DataTableProps<T> {
-  title: string
-  items: T[]
-  renderRow: (item: T) => React.ReactNode
+interface DataTableProps {
+  header: React.ReactNode
   emptyMessage?: string
+  children: React.ReactNode
 }
 
-export default function DataTable<T>({
-  title,
-  items,
-  renderRow,
+export default function DataTable({
+  header,
   emptyMessage = "No items found.",
-}: DataTableProps<T>) {
-  if (items.length === 0) {
+  children,
+}: DataTableProps) {
+  // Determine if children has any non-null, non-false child rows
+  const isEmpty =
+    !children ||
+    (Array.isArray(children) && children.length === 0) ||
+    (Array.isArray(children) && children.every(child => !child))
+
+  if (isEmpty) {
     return <p className="text-center py-4">{emptyMessage}</p>
   }
 
   return (
     <div className="rounded-md border">
       <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead className="w-full">{title}</TableHead>
-            <TableHead className="w-[150px] text-right">Actions</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>{items.map((item) => renderRow(item))}</TableBody>
+        <TableHeader>{header}</TableHeader>
+        <TableBody>{children}</TableBody>
       </Table>
     </div>
   )

--- a/components/issues/IssueTable.tsx
+++ b/components/issues/IssueTable.tsx
@@ -1,5 +1,6 @@
-import DataTable from "@/components/common/DataTable"
 import IssueRow from "@/components/issues/IssueRow"
+import DataTable from "@/components/common/DataTable"
+import { TableRow, TableHead } from "@/components/ui/table"
 import { getIssueListWithStatus } from "@/lib/github/issues"
 
 export default async function IssueTable({
@@ -13,15 +14,20 @@ export default async function IssueTable({
       per_page: 100,
     })
 
+    const header = (
+      <TableRow>
+        <TableHead className="w-full">Title</TableHead>
+        <TableHead className="w-12 text-center">Status</TableHead>
+        <TableHead className="w-[150px] text-right">Actions</TableHead>
+      </TableRow>
+    )
+
     return (
-      <DataTable
-        title="Issues"
-        items={issues}
-        renderRow={(issue) => (
+      <DataTable header={header} emptyMessage="No open issues found.">
+        {issues.map((issue) => (
           <IssueRow key={issue.id} issue={issue} repoFullName={repoFullName} />
-        )}
-        emptyMessage="No open issues found."
-      />
+        ))}
+      </DataTable>
     )
   } catch (error) {
     return (

--- a/components/pull-requests/PullRequestTable.tsx
+++ b/components/pull-requests/PullRequestTable.tsx
@@ -1,5 +1,6 @@
-import DataTable from "@/components/common/DataTable"
 import PullRequestRow from "@/components/pull-requests/PullRequestRow"
+import DataTable from "@/components/common/DataTable"
+import { TableRow, TableHead } from "@/components/ui/table"
 import { getPullRequestList } from "@/lib/github/pullRequests"
 
 export default async function PullRequestTable({
@@ -13,12 +14,19 @@ export default async function PullRequestTable({
     repoFullName: `${username}/${repoName}`,
   })
 
+  const header = (
+    <TableRow>
+      <TableHead className="w-full">Title</TableHead>
+      <TableHead className="w-12 text-center">Status</TableHead>
+      <TableHead className="w-[150px] text-right">Actions</TableHead>
+    </TableRow>
+  )
+
   return (
-    <DataTable
-      title="Pull Requests"
-      items={pullRequests}
-      renderRow={(pr) => <PullRequestRow key={pr.id} pr={pr} />}
-      emptyMessage="No pull requests found."
-    />
+    <DataTable header={header} emptyMessage="No pull requests found.">
+      {pullRequests.map((pr) => (
+        <PullRequestRow key={pr.id} pr={pr} />
+      ))}
+    </DataTable>
   )
 }


### PR DESCRIPTION
## Summary
This PR refactors the `DataTable` component to make it more composable and flexible:

- **DataTable API:** No longer requires `title`, `items`, or `renderRow` props. Instead, it accepts a `header` node, children, and an optional `emptyMessage`.
- **IssueTable/PullRequestTable:** Both now build their own column headers (with `TableRow`/`TableHead`) and map row items to children, allowing much more flexible rendering and less coupling. 
- **No usages** of `title`, `items`, or `renderRow` props remain in the codebase.

## Motivation
Previously, every change to row rendering or header required changes in `DataTable` itself. Now, `DataTable` serves as a light wrapper around the standard table UI and accepts composition, making it much easier to extend or customize tables for different resource types.

## Notes
- All usages updated (IssueTable, PullRequestTable)
- No changes needed to row components
- Old prop API is completely removed

---
Closes #<ISSUE_NUMBER_PLACEHOLDER>

Closes #556