### PR TITLE
Use per-user OAuth or GitHub App token for git push commands

### DIFF
--- a/lib/tools/SyncBranchTool.ts
+++ b/lib/tools/SyncBranchTool.ts
@@ -16,10 +16,12 @@ const syncBranchParameters = z.object({
 
 type SyncBranchParams = z.infer<typeof syncBranchParameters>
 
+// Modified: Accept token parameter
 async function fnHandler(
   repoFullName: RepoFullName,
   baseDir: string,
-  params: SyncBranchParams
+  params: SyncBranchParams,
+  token: string // new param
 ): Promise<string> {
   const { branch } = params
   try {
@@ -36,8 +38,8 @@ async function fnHandler(
         })
       }
     }
-    // Push the current branch to remote
-    await pushBranch(branch, baseDir)
+    // Push the current branch to remote using per-user token
+    await pushBranch(branch, baseDir, token, repoFullName)
     return JSON.stringify({
       status: "success",
       message: `Successfully pushed branch '${branch}' to remote`,
@@ -50,9 +52,11 @@ async function fnHandler(
   }
 }
 
+// Modified: Accept token param
 export const createSyncBranchTool = (
   repoFullName: RepoFullName,
-  baseDir: string
+  baseDir: string,
+  token: string // new param
 ) =>
   createTool({
     name: "sync_branch_to_remote",
@@ -60,5 +64,5 @@ export const createSyncBranchTool = (
       "Pushes the current branch and its commits to the remote GitHub repository. Similar to 'git push origin HEAD'. Will create the remote branch if it doesn't exist.",
     schema: syncBranchParameters,
     handler: (params: SyncBranchParams) =>
-      fnHandler(repoFullName, baseDir, params),
+      fnHandler(repoFullName, baseDir, params, token),
   })


### PR DESCRIPTION
This PR refactors server-side git push support:

- `pushBranch` in `lib/git.ts` now accepts a GitHub token and repoFullName. When provided, the origin remote is temporarily set to an authenticated URL (generated via `getCloneUrlWithAccessToken`) before pushing, ensuring that pushes are performed with the privileges of the actual user (OAuth/App token).
- `SyncBranchTool` and its factory are updated to accept and require the per-user token, which is then propagated to all internal push operations.
- The commit ensures that shell git commands run on behalf of the requester—not a global/persistent credential—supporting multi-user/secure workflow needs.

Edge cases like missing tokens, error resiliency, and remote URL cleanup are handled. Downstream integration/tests should always pass a valid token, enforcing correct access control.

Closes #<issue>

Closes #561