### PR TITLE
feat: Allow manual entry of Title field when creating new task

### DIFF
--- a/components/issues/NewTaskInput.tsx
+++ b/components/issues/NewTaskInput.tsx
@@ -5,6 +5,8 @@ import { useEffect, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
 import {
   Tooltip,
   TooltipContent,
@@ -139,6 +141,17 @@ export default function NewTaskInput({ repoFullName }: Props) {
 
   return (
     <form onSubmit={handleSubmit} className="mb-6 grid gap-4 border-muted pb-6">
+      <div className="grid gap-2">
+        <Label htmlFor="title">Title</Label>
+        <Input
+          id="title"
+          type="text"
+          placeholder="Title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          disabled={loading}
+        />
+      </div>
       <div className="grid gap-2">
         <Textarea
           id="description"

--- a/components/issues/NewTaskInput.tsx
+++ b/components/issues/NewTaskInput.tsx
@@ -4,9 +4,9 @@ import { HelpCircle } from "lucide-react"
 import { useEffect, useState } from "react"
 
 import { Button } from "@/components/ui/button"
-import { Textarea } from "@/components/ui/textarea"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
 import {
   Tooltip,
   TooltipContent,
@@ -166,7 +166,7 @@ export default function NewTaskInput({ repoFullName }: Props) {
       </div>
       <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
         <Button type="submit" disabled={loading}>
-          {loading ? "Creating..." : "Start Task"}
+          {loading ? "Creating..." : "Create Github Issue"}
         </Button>
         <TooltipProvider>
           <Tooltip>


### PR DESCRIPTION
This PR adds a Title input field to the New Task form, allowing users to manually specify a title for each new task. 
- Users can now enter a title directly above the description.
- The previous logic that falls back to LLM-generated or default titles if left blank is still in place.
- No changes were made to the backend logic; only the frontend UI and state handling were affected.

Closes #<issue-number>

Closes #559