### PR TITLE
Add planandresolve workflow API and orchestration for new issues

### DIFF
--- a/app/api/workflow/planandresolve/route.ts
+++ b/app/api/workflow/planandresolve/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from "next/server"
+import { v4 as uuidv4 } from "uuid"
+import { z } from "zod"
+
+import { getRepoFromString } from "@/lib/github/content"
+import { getIssue } from "@/lib/github/issues"
+import commentOnIssue from "@/lib/workflows/commentOnIssue"
+import { resolveIssue } from "@/lib/workflows/resolveIssue"
+
+const PlanAndResolveRequestSchema = z.object({
+  issueNumber: z.number(),
+  repoFullName: z.string(),
+  apiKey: z.string(),
+  postToGithub: z.boolean().default(false),
+  createPR: z.boolean().default(false),
+})
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const { issueNumber, repoFullName, apiKey, postToGithub, createPR } =
+      PlanAndResolveRequestSchema.parse(body)
+
+    // Generate a unique job ID
+    const jobId = uuidv4()
+
+    // Start the plan and resolve workflow as a background job (fire-and-forget)
+    ;(async () => {
+      try {
+        // 1. Get full repository details and issue
+        const fullRepo = await getRepoFromString(repoFullName)
+
+        // 2. commentOnIssue: Generate plan and capture planId
+        const commentResult = await commentOnIssue(
+          issueNumber,
+          fullRepo,
+          apiKey,
+          jobId,
+          postToGithub
+        )
+        if (!commentResult || !commentResult.planId) {
+          console.error(
+            "PlanAndResolve: No planId returned from commentOnIssue. Aborting resolveIssue."
+          )
+          return
+        }
+        // 3. Reload issue data for resolve
+        const issue = await getIssue({
+          fullName: repoFullName,
+          issueNumber,
+        })
+        // 4. resolveIssue: Use planId just created
+        await resolveIssue({
+          issue,
+          repository: fullRepo,
+          apiKey,
+          jobId,
+          createPR,
+          planId: commentResult.planId,
+        })
+      } catch (error) {
+        console.error("PlanAndResolve background workflow error:", error)
+      }
+    })()
+
+    return NextResponse.json(
+      {
+        jobId,
+        status: "plan and resolve started",
+      },
+      { status: 202 }
+    )
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        {
+          error: "Invalid request data",
+          details: error.errors,
+        },
+        { status: 400 }
+      )
+    }
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    )
+  }
+}

--- a/lib/workflows/commentOnIssue.ts
+++ b/lib/workflows/commentOnIssue.ts
@@ -262,8 +262,8 @@ export default async function commentOnIssue(
       state: "completed",
     })
 
-    // Return the comment
-    return { status: "complete", issueComment: response }
+    // Return the comment plus planId for downstream consumption
+    return { status: "complete", issueComment: response, planId: lastAssistantMessage.id }
   } catch (error) {
     const githubError = error as GitHubError
     console.error("Error in commentOnIssue workflow:", {


### PR DESCRIPTION
## Changes
- Adds new API route `/api/workflow/planandresolve` to orchestrate commentOnIssue and resolveIssue workflows (backgrounded, fire-and-forget)
- Updates `commentOnIssue` to return the generated `planId` for later use
- Refactors `resolveIssue` to accept an optional `planId`, enabling workflows to resolve a specific plan
- Webhook now calls `planandresolve` API for new issue events, passing all necessary context and handling with the GitHub App session token

### Additional
- Error handling is applied to not block the frontend
- Plan-and-resolve orchestration is robust to failures and logs errors
- Other application workflows can build on this composition pattern

Closes issue: "Automatically launch resolveIssue after commentOnIssue"

Closes #440