### PR TITLE
Run all repo workflow shell commands and tools in per-repo Docker containers

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -1,6 +1,4 @@
 import { runInRepoContainer } from "@/lib/dockerExec"
-import util from "util"
-import path from "path"
 
 export const PNPM_TSC_COMMAND = "pnpm lint:tsc"
 
@@ -26,7 +24,9 @@ export async function runTsCheck(
   const repoFullName = parts.slice(-3, -1).join("/")
   const projectCwd = parts.slice(0, -1).join("/")
   const cmd = `npx tsc --noEmit \"${filePath}\"`
-  const { stdout, stderr, code } = await runInRepoContainer(repoFullName, cmd, { cwd: projectCwd })
+  const { stdout, stderr, code } = await runInRepoContainer(repoFullName, cmd, {
+    cwd: projectCwd,
+  })
   if (code === 0) {
     return { pass: true, output: stdout }
   }

--- a/lib/dockerExec.ts
+++ b/lib/dockerExec.ts
@@ -1,0 +1,87 @@
+/*
+ * Run shell commands in a per-repo Docker container. If the container is not running, builds/starts it.
+ * Ensures all shell commands (tools, git, setup, lint, tsc, etc.) are run inside the container, 
+ * never on the host.
+ */
+
+import { exec as execCb } from "child_process"
+import util from "util"
+import path from "path"
+
+const execPromise = util.promisify(execCb)
+
+/**
+ * Converts a repo name (owner/repo) to a valid docker container name
+ * (useful to standardize everywhere, and avoid issues with illegal chars).
+ */
+export function repoFullNameToContainerName(repoFullName: string) {
+  // Docker container names must only have [a-zA-Z0-9][a-zA-Z0-9_.-]
+  // We'll use owner__repo, lower-cased
+  return (
+    "repo-" + repoFullName.replace(/[^a-zA-Z0-9]/g, "_").toLowerCase()
+  )
+}
+
+/**
+ * Asserts that the container for this repo is running. If not, starts or creates it.
+ * (This just starts it for now; in a real deployment, image build, volume mount, etc., must occur elsewhere)
+ */
+async function ensureContainerRunning(repoFullName: string, volumePath: string) {
+  const containerName = repoFullNameToContainerName(repoFullName)
+  // Check if running
+  try {
+    const { stdout } = await execPromise(
+      `docker ps --filter "name=^/${containerName}$" --format "{{.Names}}"`
+    )
+    if (stdout.trim() === containerName) return
+  } catch (e) {}
+  // Try to start if exists
+  try {
+    await execPromise(`docker start ${containerName}`)
+    return
+  } catch (e) {}
+  // If not found, create and run (using a basic node image; replace as needed)
+  // The container mounts the repo's volumePath to /workspace inside container
+  await execPromise(
+    `docker run -d --rm --name ${containerName} -v "${volumePath}:/workspace" -w /workspace node:20 tail -f /dev/null`
+  )
+}
+
+/**
+ * Runs a shell command inside the repo's Docker container.
+ * @param repoFullName e.g. "youngchingjui/issue-to-pr"
+ * @param command      The shell command to run (single-line string)
+ * @param options      { cwd? } -- cwd is relative to the workspace in container
+ * @returns            { stdout, stderr, code }
+ */
+export async function runInRepoContainer(
+  repoFullName: string,
+  command: string,
+  options?: { cwd?: string }
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  // Determine repo working dir (outside the container)
+  // This should be the same temp dir created per repo
+  const getLocalRepoDir =
+    (await import("./fs")).getLocalRepoDir as (repoFullName: string) => Promise<string>
+  const volumePath = await getLocalRepoDir(repoFullName)
+
+  // Ensure the container is running and set up
+  await ensureContainerRunning(repoFullName, volumePath)
+
+  const containerName = repoFullNameToContainerName(repoFullName)
+  // If cwd provided, respect it (otherwise /workspace)
+  const execCwd = options?.cwd ? path.posix.join("/workspace", options.cwd) : "/workspace"
+
+  // Compose docker exec command, always with /bin/bash -c "cd CWD && your cmd"
+  const dockerCmd = `docker exec -w "${execCwd}" ${containerName} bash -c ${JSON.stringify(command)}`
+  try {
+    const { stdout, stderr } = await execPromise(dockerCmd)
+    return { stdout, stderr, code: 0 }
+  } catch (err: any) {
+    return {
+      stdout: err?.stdout || "",
+      stderr: err?.stderr || err?.message || "Command failed in container.",
+      code: typeof err?.code === "number" ? err.code : 1,
+    }
+  }
+}

--- a/lib/git.ts
+++ b/lib/git.ts
@@ -2,8 +2,9 @@
 // All git operations are executed within their repository's Docker container via runInRepoContainer
 import { promises as fs } from "fs"
 import path from "path"
-import { getCloneUrlWithAccessToken } from "@/lib/utils/utils-common"
+
 import { runInRepoContainer } from "@/lib/dockerExec"
+import { getCloneUrlWithAccessToken } from "@/lib/utils/utils-common"
 
 function getRepoFullNameFromPath(dir: string): string {
   // Simple heuristic: the last two path components
@@ -14,7 +15,11 @@ function getRepoFullNameFromPath(dir: string): string {
 
 export async function checkIfGitExists(dir: string): Promise<boolean> {
   try {
-    const { stdout } = await runInRepoContainer(getRepoFullNameFromPath(dir), "test -d .git && echo git_exists", { cwd: "." })
+    const { stdout } = await runInRepoContainer(
+      getRepoFullNameFromPath(dir),
+      "test -d .git && echo git_exists",
+      { cwd: "." }
+    )
     return stdout.trim() === "git_exists"
   } catch {
     return false
@@ -23,43 +28,74 @@ export async function checkIfGitExists(dir: string): Promise<boolean> {
 
 export async function updateToLatest(dir: string): Promise<string> {
   const command = `git fetch && git pull`
-  const { stdout, stderr, code } = await runInRepoContainer(getRepoFullNameFromPath(dir), command, { cwd: "." })
+  const { stdout, stderr, code } = await runInRepoContainer(
+    getRepoFullNameFromPath(dir),
+    command,
+    { cwd: "." }
+  )
   if (code !== 0) throw new Error(stderr || "Failed to update repo")
   return stdout
 }
 
-export async function checkIfLocalBranchExists(branchName: string, cwd: string | undefined = undefined): Promise<boolean> {
+export async function checkIfLocalBranchExists(
+  branchName: string,
+  cwd: string | undefined = undefined
+): Promise<boolean> {
   const repoFullName = cwd ? getRepoFullNameFromPath(cwd) : undefined
   if (!repoFullName) throw new Error("Cannot determine repoFullName from cwd")
   const command = `git branch | grep ${branchName}`
-  const { stdout, stderr, code } = await runInRepoContainer(repoFullName, command, { cwd: "." })
+  const { stdout, stderr, code } = await runInRepoContainer(
+    repoFullName,
+    command,
+    { cwd: "." }
+  )
   // grep returns code 1 if not found
   if (code === 1) return false
   if (code !== 0) throw new Error(stderr || "Failed to check branch")
   return !!stdout && stdout.trim().length > 0
 }
 
-export async function createBranch(branchName: string, cwd: string | undefined = undefined): Promise<string> {
+export async function createBranch(
+  branchName: string,
+  cwd: string | undefined = undefined
+): Promise<string> {
   const repoFullName = cwd ? getRepoFullNameFromPath(cwd) : undefined
   if (!repoFullName) throw new Error("Cannot determine repoFullName from cwd")
   const command = `git checkout -b ${branchName}`
-  const { stdout, stderr, code } = await runInRepoContainer(repoFullName, command, { cwd: "." })
+  const { stdout, stderr, code } = await runInRepoContainer(
+    repoFullName,
+    command,
+    { cwd: "." }
+  )
   if (code !== 0) throw new Error(stderr || `Failed to create branch`)
   return stdout
 }
 
-export async function pushBranch(branchName: string, cwd: string | undefined = undefined, token?: string, repoFullName?: string): Promise<string> {
-  let oldRemoteUrl: string | null = null
+export async function pushBranch(
+  branchName: string,
+  cwd: string | undefined = undefined,
+  token?: string,
+  repoFullName?: string
+): Promise<string> {
+  const oldRemoteUrl: string | null = null
   try {
     if (token && repoFullName && cwd) {
       // Set authenticated remote inside container
       const authenticatedUrl = getCloneUrlWithAccessToken(repoFullName, token)
-      await runInRepoContainer(repoFullName, `git remote set-url origin \"${authenticatedUrl}\"`, { cwd })
+      await runInRepoContainer(
+        repoFullName,
+        `git remote set-url origin \"${authenticatedUrl}\"`,
+        { cwd }
+      )
     }
     if (!repoFullName && cwd) repoFullName = getRepoFullNameFromPath(cwd)
     if (!repoFullName) throw new Error("No repoFullName")
     const command = `git push origin ${branchName}`
-    const { stdout, stderr, code } = await runInRepoContainer(repoFullName, command, { cwd })
+    const { stdout, stderr, code } = await runInRepoContainer(
+      repoFullName,
+      command,
+      { cwd }
+    )
     if (code !== 0) throw new Error(stderr || `Failed to push branch`)
     return stdout
   } finally {
@@ -67,14 +103,24 @@ export async function pushBranch(branchName: string, cwd: string | undefined = u
   }
 }
 
-async function executeGitCommand(command: string, dir: string): Promise<string> {
+async function executeGitCommand(
+  command: string,
+  dir: string
+): Promise<string> {
   const repoFullName = getRepoFullNameFromPath(dir)
-  const { stdout, stderr, code } = await runInRepoContainer(repoFullName, command, { cwd: "." })
+  const { stdout, stderr, code } = await runInRepoContainer(
+    repoFullName,
+    command,
+    { cwd: "." }
+  )
   if (code !== 0) throw new Error(stderr || `Failed to execute git command`)
   return stdout
 }
 
-export async function checkoutBranchQuietly(branchName: string, dir: string): Promise<string> {
+export async function checkoutBranchQuietly(
+  branchName: string,
+  dir: string
+): Promise<string> {
   const command = `git checkout -q ${branchName}`
   return executeGitCommand(command, dir)
 }
@@ -89,7 +135,10 @@ export async function fetchLatest(dir: string): Promise<string> {
   return executeGitCommand(command, dir)
 }
 
-export async function resetToOrigin(branchName: string, dir: string): Promise<string> {
+export async function resetToOrigin(
+  branchName: string,
+  dir: string
+): Promise<string> {
   const command = `git reset --hard origin/${branchName}`
   return executeGitCommand(command, dir)
 }
@@ -107,12 +156,19 @@ export async function cleanCheckout(branchName: string, dir: string) {
   }
 }
 
-export async function cloneRepo(cloneUrl: string, dir: string | undefined = undefined): Promise<string> {
+export async function cloneRepo(
+  cloneUrl: string,
+  dir: string | undefined = undefined
+): Promise<string> {
   if (!dir) throw new Error("Target directory is required for cloning.")
   // Perform clone from within the repo's future container
   const repoFullName = getRepoFullNameFromPath(dir)
   const command = `git clone ${cloneUrl} .`
-  const { stdout, stderr, code } = await runInRepoContainer(repoFullName, command, { cwd: "." })
+  const { stdout, stderr, code } = await runInRepoContainer(
+    repoFullName,
+    command,
+    { cwd: "." }
+  )
   if (code !== 0) throw new Error(stderr || `Failed to clone repo`)
   return stdout
 }
@@ -127,7 +183,11 @@ export async function getLocalFileContent(filePath: string): Promise<string> {
 export async function getDiff(dir: string): Promise<string> {
   const repoFullName = getRepoFullNameFromPath(dir)
   const command = `git diff`
-  const { stdout, stderr, code } = await runInRepoContainer(repoFullName, command, { cwd: "." })
+  const { stdout, stderr, code } = await runInRepoContainer(
+    repoFullName,
+    command,
+    { cwd: "." }
+  )
   if (code !== 0) throw new Error(stderr || `Failed to get diff`)
   return stdout
 }
@@ -147,7 +207,10 @@ export async function cleanupRepo(dir: string): Promise<void> {
   const fsPromises = fs
   const repoFullName = getRepoFullNameFromPath(dir)
   try {
-    await fsPromises.rm(path.join(dir, ".git"), { recursive: true, force: true })
+    await fsPromises.rm(path.join(dir, ".git"), {
+      recursive: true,
+      force: true,
+    })
     await fsPromises.rm(dir, { recursive: true, force: true })
   } catch (error) {
     console.error(`[ERROR] Failed to cleanup repository: ${error}`)
@@ -155,7 +218,10 @@ export async function cleanupRepo(dir: string): Promise<void> {
   }
 }
 
-export async function ensureValidRepo(dir: string, cloneUrl: string): Promise<void> {
+export async function ensureValidRepo(
+  dir: string,
+  cloneUrl: string
+): Promise<void> {
   const gitExists = await checkIfGitExists(dir)
   if (!gitExists) {
     await cloneRepo(cloneUrl, dir)
@@ -163,36 +229,58 @@ export async function ensureValidRepo(dir: string, cloneUrl: string): Promise<vo
   }
   const isValid = await checkRepoIntegrity(dir)
   if (!isValid) {
-    console.warn("[WARNING] Repository corruption detected, cleaning up and re-cloning")
+    console.warn(
+      "[WARNING] Repository corruption detected, cleaning up and re-cloning"
+    )
     await cleanupRepo(dir)
     await cloneRepo(cloneUrl, dir)
   }
 }
 
-export async function stageFile(filePath: string, cwd: string | undefined = undefined): Promise<string> {
+export async function stageFile(
+  filePath: string,
+  cwd: string | undefined = undefined
+): Promise<string> {
   const repoFullName = cwd ? getRepoFullNameFromPath(cwd) : undefined
   if (!repoFullName) throw new Error("Cannot determine repoFullName from cwd")
   const command = `git add \"${filePath}\"`
-  const { stdout, stderr, code } = await runInRepoContainer(repoFullName, command, { cwd })
+  const { stdout, stderr, code } = await runInRepoContainer(
+    repoFullName,
+    command,
+    { cwd }
+  )
   if (code !== 0) throw new Error(stderr || `Failed to stage file`)
   return stdout
 }
 
-export async function createCommit(message: string, cwd: string | undefined = undefined): Promise<string> {
+export async function createCommit(
+  message: string,
+  cwd: string | undefined = undefined
+): Promise<string> {
   const repoFullName = cwd ? getRepoFullNameFromPath(cwd) : undefined
   if (!repoFullName) throw new Error("Cannot determine repoFullName from cwd")
   const safeMsg = message.replace(/"/g, '\\"')
   const command = `git commit -m \"${safeMsg}\"`
-  const { stdout, stderr, code } = await runInRepoContainer(repoFullName, command, { cwd })
+  const { stdout, stderr, code } = await runInRepoContainer(
+    repoFullName,
+    command,
+    { cwd }
+  )
   if (code !== 0) throw new Error(stderr || `Failed to create commit`)
   return stdout
 }
 
-export async function getCommitHash(cwd: string | undefined = undefined): Promise<string> {
+export async function getCommitHash(
+  cwd: string | undefined = undefined
+): Promise<string> {
   const repoFullName = cwd ? getRepoFullNameFromPath(cwd) : undefined
   if (!repoFullName) throw new Error("Cannot determine repoFullName from cwd")
   const command = "git rev-parse HEAD"
-  const { stdout, stderr, code } = await runInRepoContainer(repoFullName, command, { cwd })
+  const { stdout, stderr, code } = await runInRepoContainer(
+    repoFullName,
+    command,
+    { cwd }
+  )
   if (code !== 0) throw new Error(stderr || `Failed to get commit hash`)
   return stdout.trim()
 }
@@ -200,7 +288,11 @@ export async function getCommitHash(cwd: string | undefined = undefined): Promis
 export async function getCurrentBranch(repoPath: string): Promise<string> {
   const repoFullName = getRepoFullNameFromPath(repoPath)
   const command = "git rev-parse --abbrev-ref HEAD"
-  const { stdout, stderr, code } = await runInRepoContainer(repoFullName, command, { cwd: "." })
+  const { stdout, stderr, code } = await runInRepoContainer(
+    repoFullName,
+    command,
+    { cwd: "." }
+  )
   if (code !== 0) throw new Error(stderr || `Failed to get current branch`)
   return stdout.trim()
 }

--- a/lib/tools/FileCheckTool.ts
+++ b/lib/tools/FileCheckTool.ts
@@ -1,51 +1,131 @@
 import { z } from "zod"
-import { createTool } from "@/lib/tools/helper"
+
 import { runInRepoContainer } from "@/lib/dockerExec"
+import { createTool } from "@/lib/tools/helper"
 
 const ALLOWED_COMMANDS = new Set<string>([
-  "eslint","tsc","jshint","jslint","prettier","sonarjs",
-  "pylint","flake8","pyflakes","mypy","black","isort","bandit","pydocstyle","pyright",
-  "checkstyle","pmd","spotbugs","errorprone","sonarjava","archunit",
-  "stylecop","fxcop","roslyn","sonarcsharp",
-  "clang-tidy","cppcheck","cpplint","clang","coverity","splint",
-  "golint","go","staticcheck","gosimple","errcheck","ineffassign","govet","revive",
-  "rubocop","reek","brakeman","flog","flay",
-  "phpcs","phpstan","psalm","phpmd",
-  "swiftlint","swiftformat",
-  "detekt","ktlint",
-  "clippy","rustfmt","cargo","cargo-audit","cargo-deny",
-  "scalastyle","scapegoat","wartremover","scalafix",
-  "shellcheck","shfmt",
-  "perlcritic","perltidy",
-  "stylelint","htmlhint","csslint","lighthouse",
-  "sqlfluff","sqlint","sqlcheck",
-  "dartanalyzer","dart",
-  "oclint","infer",
+  "eslint",
+  "tsc",
+  "jshint",
+  "jslint",
+  "prettier",
+  "sonarjs",
+  "pylint",
+  "flake8",
+  "pyflakes",
+  "mypy",
+  "black",
+  "isort",
+  "bandit",
+  "pydocstyle",
+  "pyright",
+  "checkstyle",
+  "pmd",
+  "spotbugs",
+  "errorprone",
+  "sonarjava",
+  "archunit",
+  "stylecop",
+  "fxcop",
+  "roslyn",
+  "sonarcsharp",
+  "clang-tidy",
+  "cppcheck",
+  "cpplint",
+  "clang",
+  "coverity",
+  "splint",
+  "golint",
+  "go",
+  "staticcheck",
+  "gosimple",
+  "errcheck",
+  "ineffassign",
+  "govet",
+  "revive",
+  "rubocop",
+  "reek",
+  "brakeman",
+  "flog",
+  "flay",
+  "phpcs",
+  "phpstan",
+  "psalm",
+  "phpmd",
+  "swiftlint",
+  "swiftformat",
+  "detekt",
+  "ktlint",
+  "clippy",
+  "rustfmt",
+  "cargo",
+  "cargo-audit",
+  "cargo-deny",
+  "scalastyle",
+  "scapegoat",
+  "wartremover",
+  "scalafix",
+  "shellcheck",
+  "shfmt",
+  "perlcritic",
+  "perltidy",
+  "stylelint",
+  "htmlhint",
+  "csslint",
+  "lighthouse",
+  "sqlfluff",
+  "sqlint",
+  "sqlcheck",
+  "dartanalyzer",
+  "dart",
+  "oclint",
+  "infer",
   "credo",
   "hlint",
   "luacheck",
   "lintr",
   "codenarc",
   "elvis",
-  "ftnchek","fortranlint",
+  "ftnchek",
+  "fortranlint",
   "mlint",
-  "verilator","vhdl-linter",
-  "sonarqube","codacy","codeclimate","lgtm","deepsource",
+  "verilator",
+  "vhdl-linter",
+  "sonarqube",
+  "codacy",
+  "codeclimate",
+  "lgtm",
+  "deepsource",
 ])
 
 const fileCheckParameters = z.object({
-  cliCommand: z.string().describe("Full CLI command to run a READ-ONLY code-quality check (eslint, tsc, prettier, etc.). The command must not mutate code (no --fix, --write, etc.). Include the file path(s) to check when applicable. Multi-line commands not allowed.")
+  cliCommand: z
+    .string()
+    .describe(
+      "Full CLI command to run a READ-ONLY code-quality check (eslint, tsc, prettier, etc.). The command must not mutate code (no --fix, --write, etc.). Include the file path(s) to check when applicable. Multi-line commands not allowed."
+    ),
 })
 
 // The baseDir should be a subpath within the repo – repoFullName can be deduced
-const handler = async (baseDir: string, params: z.infer<typeof fileCheckParameters>) => {
+const handler = async (
+  baseDir: string,
+  params: z.infer<typeof fileCheckParameters>
+) => {
   const { cliCommand } = params
   if (/\r|\n/.test(cliCommand)) {
-    return { stdout: "", stderr: "Multi-line commands are not allowed.", exitCode: 1 }
+    return {
+      stdout: "",
+      stderr: "Multi-line commands are not allowed.",
+      exitCode: 1,
+    }
   }
   const firstToken = cliCommand.trim().split(/\s+/)[0]?.toLowerCase()
   if (!firstToken || !ALLOWED_COMMANDS.has(firstToken)) {
-    return { stdout: "", stderr: "Command not allowed. Must be a read-only code-quality tool.", exitCode: 1 }
+    return {
+      stdout: "",
+      stderr: "Command not allowed. Must be a read-only code-quality tool.",
+      exitCode: 1,
+    }
   }
 
   // Determine repoFullName from path (works as all code checkers operate in repo context)
@@ -56,7 +136,11 @@ const handler = async (baseDir: string, params: z.infer<typeof fileCheckParamete
 
   const sanitizedCommand = cliCommand.replace(/[^a-zA-Z0-9_\-.:/\\ \t]/g, "")
 
-  const { stdout, stderr, code } = await runInRepoContainer(repoFullName, sanitizedCommand, { cwd: "." })
+  const { stdout, stderr, code } = await runInRepoContainer(
+    repoFullName,
+    sanitizedCommand,
+    { cwd: "." }
+  )
   return { stdout, stderr, exitCode: code }
 }
 
@@ -65,5 +149,6 @@ export const createFileCheckTool = (baseDir: string) =>
     name: "file_check",
     description: `Run a READ-ONLY code-quality CLI command (e.g., eslint, tsc, prettier) on specified file(s). The agent MUST: 1. Provide the full CLI command in 'cliCommand'. 2. Only use commands that check code; NEVER use other types of CLI commands. 3. Derive the command from the project's existing scripts/config when possible.`,
     schema: fileCheckParameters,
-    handler: (params: z.infer<typeof fileCheckParameters>) => handler(baseDir, params),
+    handler: (params: z.infer<typeof fileCheckParameters>) =>
+      handler(baseDir, params),
   })

--- a/lib/tools/FileCheckTool.ts
+++ b/lib/tools/FileCheckTool.ts
@@ -1,217 +1,69 @@
-import { exec } from "child_process"
-import { promisify } from "util"
 import { z } from "zod"
-
 import { createTool } from "@/lib/tools/helper"
+import { runInRepoContainer } from "@/lib/dockerExec"
 
-// Allow-listed CLI commands that are considered safe, **read-only** code-quality tools.
-// Grouped by language but flattened into a single Set for quick lookup.
 const ALLOWED_COMMANDS = new Set<string>([
-  // JavaScript / TypeScript
-  "eslint",
-  "tsc",
-  "jshint",
-  "jslint",
-  "prettier",
-  "sonarjs",
-  // Python
-  "pylint",
-  "flake8",
-  "pyflakes",
-  "mypy",
-  "black",
-  "isort",
-  "bandit",
-  "pydocstyle",
-  "pyright",
-  // Java
-  "checkstyle",
-  "pmd",
-  "spotbugs",
-  "errorprone",
-  "sonarjava",
-  "archunit",
-  // C# / .NET
-  "stylecop",
-  "fxcop",
-  "roslyn",
-  "sonarcsharp",
-  // C / C++
-  "clang-tidy",
-  "cppcheck",
-  "cpplint",
-  "clang",
-  "coverity",
-  "splint",
-  // Go
-  "golint",
-  "go",
-  "staticcheck",
-  "gosimple",
-  "errcheck",
-  "ineffassign",
-  "govet",
-  "revive",
-  // Ruby
-  "rubocop",
-  "reek",
-  "brakeman",
-  "flog",
-  "flay",
-  // PHP
-  "phpcs",
-  "phpstan",
-  "psalm",
-  "phpmd",
-  // Swift
-  "swiftlint",
-  "swiftformat",
-  // Kotlin
-  "detekt",
-  "ktlint",
-  // Rust
-  "clippy",
-  "rustfmt",
-  "cargo",
-  "cargo-audit",
-  "cargo-deny",
-  // Scala
-  "scalastyle",
-  "scapegoat",
-  "wartremover",
-  "scalafix",
-  // Shell
-  "shellcheck",
-  "shfmt",
-  // Perl
-  "perlcritic",
-  "perltidy",
-  // HTML/CSS
-  "stylelint",
-  "htmlhint",
-  "csslint",
-  "lighthouse",
-  // SQL
-  "sqlfluff",
-  "sqlint",
-  "sqlcheck",
-  // Dart
-  "dartanalyzer",
-  "dart",
-  // Objective-C
-  "oclint",
-  "infer",
-  // Elixir
+  "eslint","tsc","jshint","jslint","prettier","sonarjs",
+  "pylint","flake8","pyflakes","mypy","black","isort","bandit","pydocstyle","pyright",
+  "checkstyle","pmd","spotbugs","errorprone","sonarjava","archunit",
+  "stylecop","fxcop","roslyn","sonarcsharp",
+  "clang-tidy","cppcheck","cpplint","clang","coverity","splint",
+  "golint","go","staticcheck","gosimple","errcheck","ineffassign","govet","revive",
+  "rubocop","reek","brakeman","flog","flay",
+  "phpcs","phpstan","psalm","phpmd",
+  "swiftlint","swiftformat",
+  "detekt","ktlint",
+  "clippy","rustfmt","cargo","cargo-audit","cargo-deny",
+  "scalastyle","scapegoat","wartremover","scalafix",
+  "shellcheck","shfmt",
+  "perlcritic","perltidy",
+  "stylelint","htmlhint","csslint","lighthouse",
+  "sqlfluff","sqlint","sqlcheck",
+  "dartanalyzer","dart",
+  "oclint","infer",
   "credo",
-  // Haskell
   "hlint",
-  // Lua
   "luacheck",
-  // R
   "lintr",
-  // Groovy
   "codenarc",
-  // Erlang
   "elvis",
-  // Fortran
-  "ftnchek",
-  "fortranlint",
-  // Matlab
+  "ftnchek","fortranlint",
   "mlint",
-  // VHDL/Verilog
-  "verilator",
-  "vhdl-linter",
-  // General / Multi-language
-  "sonarqube",
-  "codacy",
-  "codeclimate",
-  "lgtm",
-  "deepsource",
+  "verilator","vhdl-linter",
+  "sonarqube","codacy","codeclimate","lgtm","deepsource",
 ])
 
-// Input schema (what the LLM Agent provides)
 const fileCheckParameters = z.object({
-  cliCommand: z
-    .string()
-    .describe(
-      "Full CLI command to run a READ-ONLY code-quality check (eslint, tsc, prettier, etc.). The command must not mutate code (no --fix, --write, etc.). Include the file path(s) to check when applicable. Multi-line commands not allowed."
-    ),
+  cliCommand: z.string().describe("Full CLI command to run a READ-ONLY code-quality check (eslint, tsc, prettier, etc.). The command must not mutate code (no --fix, --write, etc.). Include the file path(s) to check when applicable. Multi-line commands not allowed.")
 })
 
-const execPromise = promisify(exec)
-
-async function handler(
-  baseDir: string,
-  params: z.infer<typeof fileCheckParameters>
-) {
+// The baseDir should be a subpath within the repo – repoFullName can be deduced
+const handler = async (baseDir: string, params: z.infer<typeof fileCheckParameters>) => {
   const { cliCommand } = params
-
-  // Reject multi-line commands early. Only single-line commands are allowed.
   if (/\r|\n/.test(cliCommand)) {
-    return {
-      stdout: "",
-      stderr: "Multi-line commands are not allowed.",
-      exitCode: 1,
-    }
+    return { stdout: "", stderr: "Multi-line commands are not allowed.", exitCode: 1 }
   }
-
-  // Extract the first token (the command itself) to validate against allow-list.
   const firstToken = cliCommand.trim().split(/\s+/)[0]?.toLowerCase()
-
   if (!firstToken || !ALLOWED_COMMANDS.has(firstToken)) {
-    return {
-      stdout: "",
-      stderr: "Command not allowed. Must be a read-only code-quality tool.",
-      exitCode: 1,
-    }
+    return { stdout: "", stderr: "Command not allowed. Must be a read-only code-quality tool.", exitCode: 1 }
   }
 
-  // Basic sanitisation to remove potentially dangerous characters (except space and tab).
+  // Determine repoFullName from path (works as all code checkers operate in repo context)
+  const repoFullName = (() => {
+    const parts = baseDir.split(require("path").sep).filter(Boolean)
+    return parts.slice(-2).join("/")
+  })()
+
   const sanitizedCommand = cliCommand.replace(/[^a-zA-Z0-9_\-.:/\\ \t]/g, "")
 
-  try {
-    const { stdout, stderr } = await execPromise(sanitizedCommand, {
-      cwd: baseDir,
-      maxBuffer: 1024 * 1024,
-    })
-
-    return { stdout, stderr, exitCode: 0 }
-  } catch (error: unknown) {
-    if (!error || typeof error !== "object") {
-      return {
-        stdout: "",
-        stderr: String(error ?? "Unknown error"),
-        exitCode: -1,
-      }
-    }
-
-    const err = error as {
-      stdout?: string
-      stderr?: string
-      code?: number
-      message?: string
-    }
-
-    return {
-      stdout: err.stdout || "",
-      stderr: err.stderr || err.message || "Code quality check failed.",
-      exitCode: typeof err.code === "number" ? err.code : 1,
-    }
-  }
+  const { stdout, stderr, code } = await runInRepoContainer(repoFullName, sanitizedCommand, { cwd: "." })
+  return { stdout, stderr, exitCode: code }
 }
 
 export const createFileCheckTool = (baseDir: string) =>
   createTool({
     name: "file_check",
-    description: `
-      Run a READ-ONLY code-quality CLI command (e.g., eslint, tsc, prettier) on specified file(s).
-      The agent MUST:
-      1. Provide the full CLI command in 'cliCommand'.
-      2. Only use commands that check code; NEVER use other types of CLI commands.
-      3. Derive the command from the project's existing scripts/config when possible.
-    `,
+    description: `Run a READ-ONLY code-quality CLI command (e.g., eslint, tsc, prettier) on specified file(s). The agent MUST: 1. Provide the full CLI command in 'cliCommand'. 2. Only use commands that check code; NEVER use other types of CLI commands. 3. Derive the command from the project's existing scripts/config when possible.`,
     schema: fileCheckParameters,
-    handler: (params: z.infer<typeof fileCheckParameters>) =>
-      handler(baseDir, params),
-    // The handler already conforms to fileCheckResult shape.
+    handler: (params: z.infer<typeof fileCheckParameters>) => handler(baseDir, params),
   })

--- a/lib/tools/RipgrepSearchTool.ts
+++ b/lib/tools/RipgrepSearchTool.ts
@@ -1,6 +1,7 @@
 import { z } from "zod"
-import { createTool } from "@/lib/tools/helper"
+
 import { runInRepoContainer } from "@/lib/dockerExec"
+import { createTool } from "@/lib/tools/helper"
 
 const name = "ripgrep_search"
 const description = `Searches for code in the local file system using ripgrep. Returns snippets of code containing the search term with 3 lines of context before and after each match. Note: These are just snippets - to fully understand the code's context, you should use a file reading tool to examine the complete file contents.
@@ -10,11 +11,33 @@ The tool supports both literal (fixed-string) and regex search modes. By default
 - mode: "regex" — disables -F, allows regex pattern searches, may return ripgrep errors if regex is malformed.`
 
 const searchParameters = z.object({
-  query: z.string().describe("The search query to use for searching code. Example: 'functionName' to find all occurrences of 'functionName' in the codebase."),
-  ignoreCase: z.boolean().nullable().describe("Ignore case sensitivity. Default is false, meaning the search is case-sensitive. Use true to find matches regardless of case, e.g., 'function' will match 'Function'."),
-  hidden: z.boolean().nullable().describe("Include hidden files. Default is false, meaning hidden files are ignored. Use true to include files like '.env'."),
-  follow: z.boolean().nullable().describe("Follow symbolic links. Default is false, meaning symlinks are not followed. Use true to include files linked by symlinks in the search."),
-  mode: z.enum(["literal", "regex"]).optional().describe('Search mode: "literal" (default, safer) or "regex"'),
+  query: z
+    .string()
+    .describe(
+      "The search query to use for searching code. Example: 'functionName' to find all occurrences of 'functionName' in the codebase."
+    ),
+  ignoreCase: z
+    .boolean()
+    .nullable()
+    .describe(
+      "Ignore case sensitivity. Default is false, meaning the search is case-sensitive. Use true to find matches regardless of case, e.g., 'function' will match 'Function'."
+    ),
+  hidden: z
+    .boolean()
+    .nullable()
+    .describe(
+      "Include hidden files. Default is false, meaning hidden files are ignored. Use true to include files like '.env'."
+    ),
+  follow: z
+    .boolean()
+    .nullable()
+    .describe(
+      "Follow symbolic links. Default is false, meaning symlinks are not followed. Use true to include files linked by symlinks in the search."
+    ),
+  mode: z
+    .enum(["literal", "regex"])
+    .optional()
+    .describe('Search mode: "literal" (default, safer) or "regex"'),
 })
 
 type RipgrepSearchParameters = z.infer<typeof searchParameters>
@@ -49,7 +72,11 @@ const fnHandler = async (baseDir: string, params: RipgrepSearchParameters) => {
     const parts = baseDir.split(require("path").sep).filter(Boolean)
     return parts.slice(-2).join("/")
   })()
-  const { stdout, stderr, code } = await runInRepoContainer(repoFullName, command, { cwd: "." })
+  const { stdout, stderr, code } = await runInRepoContainer(
+    repoFullName,
+    command,
+    { cwd: "." }
+  )
   if (code === 1) return "No matching results found."
   if (code !== 0) throw new Error(stderr || `Ripgrep failed`)
   return stdout

--- a/lib/tools/RipgrepSearchTool.ts
+++ b/lib/tools/RipgrepSearchTool.ts
@@ -1,10 +1,6 @@
-import { exec } from "child_process"
-import { promisify } from "util"
 import { z } from "zod"
-
 import { createTool } from "@/lib/tools/helper"
-
-const execPromise = promisify(exec)
+import { runInRepoContainer } from "@/lib/dockerExec"
 
 const name = "ripgrep_search"
 const description = `Searches for code in the local file system using ripgrep. Returns snippets of code containing the search term with 3 lines of context before and after each match. Note: These are just snippets - to fully understand the code's context, you should use a file reading tool to examine the complete file contents.
@@ -14,100 +10,49 @@ The tool supports both literal (fixed-string) and regex search modes. By default
 - mode: "regex" — disables -F, allows regex pattern searches, may return ripgrep errors if regex is malformed.`
 
 const searchParameters = z.object({
-  query: z
-    .string()
-    .describe(
-      "The search query to use for searching code. Example: 'functionName' to find all occurrences of 'functionName' in the codebase."
-    ),
-  ignoreCase: z
-    .boolean()
-    .nullable()
-    .describe(
-      "Ignore case sensitivity. Default is false, meaning the search is case-sensitive. Use true to find matches regardless of case, e.g., 'function' will match 'Function'."
-    ),
-  hidden: z
-    .boolean()
-    .nullable()
-    .describe(
-      "Include hidden files. Default is false, meaning hidden files are ignored. Use true to include files like '.env'."
-    ),
-  follow: z
-    .boolean()
-    .nullable()
-    .describe(
-      "Follow symbolic links. Default is false, meaning symlinks are not followed. Use true to include files linked by symlinks in the search."
-    ),
-  mode: z
-    .enum(["literal", "regex"])
-    .optional()
-    .describe('Search mode: "literal" (default, safer) or "regex"'),
+  query: z.string().describe("The search query to use for searching code. Example: 'functionName' to find all occurrences of 'functionName' in the codebase."),
+  ignoreCase: z.boolean().nullable().describe("Ignore case sensitivity. Default is false, meaning the search is case-sensitive. Use true to find matches regardless of case, e.g., 'function' will match 'Function'."),
+  hidden: z.boolean().nullable().describe("Include hidden files. Default is false, meaning hidden files are ignored. Use true to include files like '.env'."),
+  follow: z.boolean().nullable().describe("Follow symbolic links. Default is false, meaning symlinks are not followed. Use true to include files linked by symlinks in the search."),
+  mode: z.enum(["literal", "regex"]).optional().describe('Search mode: "literal" (default, safer) or "regex"'),
 })
 
 type RipgrepSearchParameters = z.infer<typeof searchParameters>
 
 function shellEscapeSingleQuotes(str: string): string {
-  // Replace every ' with '\'' and wrap the string in single quotes
-  // This safely escapes single quotes for POSIX shells
   return "'" + str.replace(/'/g, "'\\''") + "'"
 }
 
-async function fnHandler(
-  baseDir: string,
-  params: RipgrepSearchParameters
-): Promise<string> {
+const fnHandler = async (baseDir: string, params: RipgrepSearchParameters) => {
   const { query, ignoreCase, hidden, follow, mode } = params
 
-  // Set default values if parameters are null
   const isIgnoreCase = ignoreCase ?? false
   const includeHidden = hidden ?? false
   const followSymlinks = follow ?? false
-  const searchMode = mode ?? "literal" // backward compatibility to old calls
+  const searchMode = mode ?? "literal"
 
   if (!query || typeof query !== "string" || query.length === 0) {
     throw new Error("Query string cannot be empty.")
   }
 
-  // Robustly escape the user's query for the shell
   const quotedQuery = shellEscapeSingleQuotes(query)
-
-  // Construct ripgrep command
-  let command = `cd "${baseDir}" && rg --line-number --max-filesize 200K -C 3 --heading -n `
-
+  let command = `rg --line-number --max-filesize 200K -C 3 --heading -n `
   if (searchMode === "literal") {
-    command += "-F " // use literal/fixed-string mode
+    command += "-F "
   }
-
   command += `${quotedQuery} ./`
-
   if (isIgnoreCase) command += " -i"
   if (includeHidden) command += " --hidden"
   if (followSymlinks) command += " -L"
 
-  try {
-    const { stdout } = await execPromise(command)
-    return stdout
-  } catch (error) {
-    // Ripgrep conventions: exit 1 = no matches, exit 2 = error
-    if (error && typeof error === "object" && "code" in error) {
-      const code = error.code
-      if (code === 1) {
-        return "No matching results found."
-      } else if (
-        code === 2 &&
-        "stderr" in error &&
-        typeof error.stderr === "string" &&
-        error.stderr.includes("regex parse error")
-      ) {
-        return `Ripgrep regex error: ${error.stderr}`
-      } else if (code === 2) {
-        throw new Error(`Ripgrep search failed: ${error}`)
-      } else {
-        console.error("Unexpected ripgrep exit code:", error)
-        throw new Error(`Unexpected ripgrep exit code: ${code}`)
-      }
-    }
-    throw error
-  }
+  const repoFullName = (() => {
+    const parts = baseDir.split(require("path").sep).filter(Boolean)
+    return parts.slice(-2).join("/")
+  })()
+  const { stdout, stderr, code } = await runInRepoContainer(repoFullName, command, { cwd: "." })
+  if (code === 1) return "No matching results found."
+  if (code !== 0) throw new Error(stderr || `Ripgrep failed`)
+  return stdout
 }
 
 export const createRipgrepSearchTool = (baseDir: string) =>

--- a/lib/utils/setupEnv.ts
+++ b/lib/utils/setupEnv.ts
@@ -4,9 +4,15 @@ function normalizeCommands(cmd?: string[] | string): string[] {
   if (!cmd) return []
   if (typeof cmd === "string") {
     if (cmd.includes("\n"))
-      return cmd.split("\n").map((x) => x.trim()).filter(Boolean)
+      return cmd
+        .split("\n")
+        .map((x) => x.trim())
+        .filter(Boolean)
     if (cmd.includes(";"))
-      return cmd.split(";").map((x) => x.trim()).filter(Boolean)
+      return cmd
+        .split(";")
+        .map((x) => x.trim())
+        .filter(Boolean)
     return [cmd.trim()]
   }
   return cmd.map((x) => x.trim()).filter(Boolean)
@@ -18,7 +24,10 @@ function normalizeCommands(cmd?: string[] | string): string[] {
  * @param baseDir Path to repo dir (should map to /workspace in container for this repo)
  * @param setupCommands Shell command(s) to run, single or array
  */
-export async function setupEnv(baseDir: string, setupCommands?: string[] | string): Promise<string> {
+export async function setupEnv(
+  baseDir: string,
+  setupCommands?: string[] | string
+): Promise<string> {
   const commands = normalizeCommands(setupCommands)
   if (!commands.length) {
     return "No setup commands provided – skipping environment setup."
@@ -31,15 +40,25 @@ export async function setupEnv(baseDir: string, setupCommands?: string[] | strin
   })()
   for (const cmd of commands) {
     try {
-      const { stdout, stderr, code } = await runInRepoContainer(repoFullName, cmd, { cwd: "." })
-      outputLogs.push([`$ ${cmd}`, stdout?.trim(), stderr?.trim()].filter(Boolean).join("\n"))
+      const { stdout, stderr, code } = await runInRepoContainer(
+        repoFullName,
+        cmd,
+        { cwd: "." }
+      )
+      outputLogs.push(
+        [`$ ${cmd}`, stdout?.trim(), stderr?.trim()].filter(Boolean).join("\n")
+      )
       if (code !== 0) throw new Error(stderr || `Setup command failed (${cmd})`)
     } catch (err: any) {
       const stdout = err?.stdout?.toString?.() ?? ""
       const stderr = err?.stderr?.toString?.() ?? ""
       const baseMessage = `Setup command failed (${cmd}): ${String(err)}`
-      throw new Error([baseMessage, stdout.trim(), stderr.trim()].filter(Boolean).join("\n"))
+      throw new Error(
+        [baseMessage, stdout.trim(), stderr.trim()].filter(Boolean).join("\n")
+      )
     }
   }
-  return outputLogs.length ? outputLogs.join("\n") : "Environment setup completed successfully. (no output)"
+  return outputLogs.length
+    ? outputLogs.join("\n")
+    : "Environment setup completed successfully. (no output)"
 }

--- a/lib/utils/setupEnv.ts
+++ b/lib/utils/setupEnv.ts
@@ -1,81 +1,45 @@
-import { exec as execCallback } from "node:child_process"
+import { runInRepoContainer } from "@/lib/dockerExec"
 
-import { promisify } from "util"
-const execPromise = promisify(execCallback)
-
-/**
- * Normalize a string or array of shell commands into an array of trimmed commands.
- */
 function normalizeCommands(cmd?: string[] | string): string[] {
   if (!cmd) return []
   if (typeof cmd === "string") {
-    // Support splitting commands provided via textarea (new-lines or semicolons)
     if (cmd.includes("\n"))
-      return cmd
-        .split("\n")
-        .map((x) => x.trim())
-        .filter(Boolean)
+      return cmd.split("\n").map((x) => x.trim()).filter(Boolean)
     if (cmd.includes(";"))
-      return cmd
-        .split(";")
-        .map((x) => x.trim())
-        .filter(Boolean)
+      return cmd.split(";").map((x) => x.trim()).filter(Boolean)
     return [cmd.trim()]
   }
   return cmd.map((x) => x.trim()).filter(Boolean)
 }
 
 /**
- * Sets up the environment after repository checkout by running the provided shell commands.
- *
- * It purposely avoids any side-effects such as creating Neo4j events. Instead, it:
- *   • returns a confirmation message when the setup completes successfully.
- *   • throws an Error when any command fails so the caller can handle/report it.
- *
- * @param baseDir        Absolute path to the project directory where commands should be executed.
- * @param setupCommands  Shell command(s) to run. Can be a single string or an array.
- * @returns              A human-readable confirmation message on success.
- * @throws               If any command exits with a non-zero status or the spawn fails.
+ * Sets up the environment after repository checkout by running the provided shell commands (now in Docker).
+ * Returns confirmation message or throws an Error on failure.
+ * @param baseDir Path to repo dir (should map to /workspace in container for this repo)
+ * @param setupCommands Shell command(s) to run, single or array
  */
-export async function setupEnv(
-  baseDir: string,
-  setupCommands?: string[] | string
-): Promise<string> {
+export async function setupEnv(baseDir: string, setupCommands?: string[] | string): Promise<string> {
   const commands = normalizeCommands(setupCommands)
-
-  // Nothing to execute – simply return.
   if (!commands.length) {
     return "No setup commands provided – skipping environment setup."
   }
-
   const outputLogs: string[] = []
-
+  // Deduce repo name
+  const repoFullName = (() => {
+    const p = baseDir.split(require("path").sep).filter(Boolean)
+    return p.slice(-2).join("/")
+  })()
   for (const cmd of commands) {
     try {
-      const { stdout, stderr } = await execPromise(cmd, { cwd: baseDir })
-
-      // Capture outputs for the final result so the caller can surface them if desired.
-      outputLogs.push(
-        [`$ ${cmd}`, stdout?.trim(), stderr?.trim()].filter(Boolean).join("\n")
-      )
-    } catch (err: unknown) {
-      // If exec fails we still want to surface stdout/stderr that may help debugging.
-      const errorObj = err as {
-        stdout?: string | Buffer
-        stderr?: string | Buffer
-      }
-      const stdout = errorObj.stdout?.toString() ?? ""
-      const stderr = errorObj.stderr?.toString() ?? ""
+      const { stdout, stderr, code } = await runInRepoContainer(repoFullName, cmd, { cwd: "." })
+      outputLogs.push([`$ ${cmd}`, stdout?.trim(), stderr?.trim()].filter(Boolean).join("\n"))
+      if (code !== 0) throw new Error(stderr || `Setup command failed (${cmd})`)
+    } catch (err: any) {
+      const stdout = err?.stdout?.toString?.() ?? ""
+      const stderr = err?.stderr?.toString?.() ?? ""
       const baseMessage = `Setup command failed (${cmd}): ${String(err)}`
-
-      throw new Error(
-        [baseMessage, stdout.trim(), stderr.trim()].filter(Boolean).join("\n")
-      )
+      throw new Error([baseMessage, stdout.trim(), stderr.trim()].filter(Boolean).join("\n"))
     }
   }
-
-  // If there were no logs (e.g., commands produced no output), still return a confirmation message.
-  return outputLogs.length
-    ? outputLogs.join("\n")
-    : "Environment setup completed successfully. (no output)"
+  return outputLogs.length ? outputLogs.join("\n") : "Environment setup completed successfully. (no output)"
 }


### PR DESCRIPTION
This PR implements per-repo Docker containerization for all workflow CLI, git, setup, and code-quality tool commands. 

- Adds abstraction `runInRepoContainer` in lib/dockerExec.ts, which automatically starts/uses a long-lived docker container per repo.
- Refactors all runner logic (git, FileCheckTool, RipgrepTool, setupEnv, cli) to execute *inside* the appropriate Docker container using `docker exec`, never on the host shell.
- Ensures complete isolation and reproducibility. No workflow command can escape the controlled docker environment, improving security and reliability for agent-based workflows.
- Containerized working directory mounts to the corresponding temp repo folder automatically.

Closes #<ISSUE-NUMBER> (setup environment in lightweight docker container instead of tmp folder).

Closes #372