### PR TITLE
Add TypeScript error feedback in resolveIssue

### DIFF
--- a/lib/utils/typescript.ts
+++ b/lib/utils/typescript.ts
@@ -1,0 +1,19 @@
+import { exec } from "child_process"
+import { promisify } from "util"
+
+const execPromise = promisify(exec)
+
+/**
+ * Runs TypeScript type checking in the given directory.
+ * Returns null if the check passes, otherwise returns the error output.
+ */
+export async function runTypeCheck(dir: string): Promise<string | null> {
+  try {
+    await execPromise("pnpm lint:tsc", { cwd: dir })
+    return null
+  } catch (error: any) {
+    const stdout = error?.stdout ?? ""
+    const stderr = error?.stderr ?? ""
+    return `${stdout}${stderr}`.trim() || error.message || String(error)
+  }
+}


### PR DESCRIPTION
## Summary
- add util to run TypeScript checks
- loop on resolveIssue workflow to run `pnpm lint:tsc` after agent actions
- feed compiler errors back to the agent for fixes

## Testing
- `pnpm lint:tsc`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684b917db7d88333bcdf0e9ad4c0fb34