### PR TITLE
Fix agent image path

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -89,7 +89,7 @@ The image is automatically used by containerized workflows like `commentOnIssue`
 - Consistent tool environment
 - Pre-installed dependencies
 
-Image name: `issue-to-pr/agent-base:latest`
+Image name: `ghcr.io/youngchingjui/agent-base:latest`
 
 ## Neo4j Services
 

--- a/lib/utils/container.ts
+++ b/lib/utils/container.ts
@@ -29,7 +29,7 @@ export interface ContainerizedWorktreeOptions {
   branch?: string
   /** optional externally-supplied workflow run id */
   workflowId?: string
-  /** Docker image to use (default "issue-to-pr/agent-base") */
+  /** Docker image to use (default "ghcr.io/youngchingjui/agent-base") */
   image?: string
   /** Mount path inside container (default "/workspace") */
   mountPath?: string
@@ -92,7 +92,7 @@ export async function createContainerizedWorktree({
   repoFullName,
   branch = "main",
   workflowId = uuidv4(),
-  image = "issue-to-pr/agent-base",
+  image = "ghcr.io/youngchingjui/agent-base",
   mountPath = "/workspace",
 }: ContainerizedWorktreeOptions): Promise<ContainerizedWorktreeResult> {
   // 1. Ensure we have a clean local clone

--- a/lib/workflows/commentOnIssue.ts
+++ b/lib/workflows/commentOnIssue.ts
@@ -146,7 +146,7 @@ export default async function commentOnIssue(
       repoFullName: repo.full_name,
       branch: repo.default_branch,
       workflowId: jobId,
-      image: "issue-to-pr/agent-base", // Custom image with ripgrep pre-installed
+      image: "ghcr.io/youngchingjui/agent-base",
     }).catch((error) => {
       console.error("Failed to setup containerized environment:", {
         error,

--- a/scripts/build-agent-image.sh
+++ b/scripts/build-agent-image.sh
@@ -22,6 +22,9 @@ docker run --rm "${IMAGE_NAME}:${IMAGE_TAG}" rg --version
 docker run --rm "${IMAGE_NAME}:${IMAGE_TAG}" git --version
 docker run --rm "${IMAGE_NAME}:${IMAGE_TAG}" curl --version
 
+echo "Pushing image to repository..."
+docker push "${IMAGE_NAME}:${IMAGE_TAG}"
+
 echo "✅ Custom agent image is ready for use"
 echo "Image: ${IMAGE_NAME}:${IMAGE_TAG}"
 echo "Includes: ripgrep, git, curl" 


### PR DESCRIPTION
## Summary
- push the custom agent image to GHCR via `build-agent-image.sh`
- update docs to use `ghcr.io/youngchingjui/agent-base`
- default to new image name in container utilities
- use the GHCR image in `commentOnIssue`

## Testing
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6864ccdac7fc8333b461061e69570c84