### PR TITLE
Fix ripgrep tool misreporting errors

### DIFF
--- a/lib/tools/RipgrepSearchTool.ts
+++ b/lib/tools/RipgrepSearchTool.ts
@@ -156,6 +156,10 @@ async function fnHandler(
 
       // Handle ripgrep exit codes
       if (exitCode === 1) {
+        if (stderr.trim()) {
+          // Docker exec failed (e.g., container not running) rather than no matches
+          throw new Error(`Ripgrep search failed: ${stderr}`)
+        }
         return "No matching results found."
       }
       if (exitCode === 2) {


### PR DESCRIPTION
## Summary
- improve exit code handling in `RipgrepSearchTool` so container execution
  failures surface as errors instead of "No matching results found"

## Testing
- `npx jest` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_6864d356f4d083339661756d944d598c