### PR TITLE
Improve agent workflow layout with grid

### DIFF
--- a/app/agent-workflow/page.tsx
+++ b/app/agent-workflow/page.tsx
@@ -62,131 +62,142 @@ export default function AgentWorkflowPage() {
         </p>
       </div>
 
-      {/* Repository and Branch Selection */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Repository Settings</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="flex flex-wrap gap-4">
-            <div>
-              <p className="mb-2 text-sm font-medium">Repository</p>
-              <Select value={selectedRepo} onValueChange={setSelectedRepo}>
-                <SelectTrigger className="w-[200px]">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {fakeRepos.map((repo) => (
-                    <SelectItem key={repo} value={repo}>
-                      {repo}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <div>
-              <p className="mb-2 text-sm font-medium">Branch</p>
-              <Select value={selectedBranch} onValueChange={setSelectedBranch}>
-                <SelectTrigger className="w-[200px]">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {fakeBranches.map((branch) => (
-                    <SelectItem key={branch} value={branch}>
-                      {branch}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Issue Input */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Issue</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <Textarea
-            value={issueText}
-            onChange={(e) => setIssueText(e.target.value)}
-            placeholder="Describe the issue or paste issue text here..."
-            rows={4}
-          />
-        </CardContent>
-      </Card>
-
-      {/* Messages */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Messages</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="flex flex-wrap items-end gap-4">
-            <div>
-              <p className="mb-2 text-sm font-medium">Role</p>
-              <Select
-                value={newMessageRole}
-                onValueChange={(val) =>
-                  setNewMessageRole(val as "system" | "user")
-                }
-              >
-                <SelectTrigger className="w-[120px]">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="user">User</SelectItem>
-                  <SelectItem value="system">System</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="flex-1 min-w-[200px]">
-              <p className="mb-2 text-sm font-medium">Message</p>
-              <Input
-                value={newMessage}
-                onChange={(e) => setNewMessage(e.target.value)}
-                placeholder="Enter message"
-              />
-            </div>
-            <Button type="button" onClick={addMessage} className="self-start">
-              Add
-            </Button>
-          </div>
-
-          <div className="space-y-2">
-            {messages.map((m, i) => (
-              <div key={i} className="rounded border p-3">
-                <div className="text-sm font-semibold capitalize">{m.role}</div>
-                <div className="text-sm text-muted-foreground">{m.content}</div>
+      <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
+        {/* Repository and Branch Selection */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Repository Settings</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex flex-wrap gap-4">
+              <div>
+                <p className="mb-2 text-sm font-medium">Repository</p>
+                <Select value={selectedRepo} onValueChange={setSelectedRepo}>
+                  <SelectTrigger className="w-[200px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {fakeRepos.map((repo) => (
+                      <SelectItem key={repo} value={repo}>
+                        {repo}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
-            ))}
-            {messages.length === 0 && (
-              <p className="text-sm text-muted-foreground">No messages yet.</p>
-            )}
-          </div>
-        </CardContent>
-      </Card>
+              <div>
+                <p className="mb-2 text-sm font-medium">Branch</p>
+                <Select
+                  value={selectedBranch}
+                  onValueChange={setSelectedBranch}
+                >
+                  <SelectTrigger className="w-[200px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {fakeBranches.map((branch) => (
+                      <SelectItem key={branch} value={branch}>
+                        {branch}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
 
-      {/* Tools */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Tools</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-2">
-          {fakeTools.map((tool) => (
-            <label key={tool} className="flex items-center gap-2">
-              <Checkbox
-                checked={selectedTools.includes(tool)}
-                onCheckedChange={() => toggleTool(tool)}
-                id={`tool-${tool}`}
-              />
-              <span>{tool}</span>
-            </label>
-          ))}
-        </CardContent>
-      </Card>
+        {/* Issue Input */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Issue</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Textarea
+              value={issueText}
+              onChange={(e) => setIssueText(e.target.value)}
+              placeholder="Describe the issue or paste issue text here..."
+              rows={4}
+            />
+          </CardContent>
+        </Card>
+
+        {/* Messages */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Messages</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex flex-wrap items-end gap-4">
+              <div>
+                <p className="mb-2 text-sm font-medium">Role</p>
+                <Select
+                  value={newMessageRole}
+                  onValueChange={(val) =>
+                    setNewMessageRole(val as "system" | "user")
+                  }
+                >
+                  <SelectTrigger className="w-[120px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="user">User</SelectItem>
+                    <SelectItem value="system">System</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex-1 min-w-[200px]">
+                <p className="mb-2 text-sm font-medium">Message</p>
+                <Input
+                  value={newMessage}
+                  onChange={(e) => setNewMessage(e.target.value)}
+                  placeholder="Enter message"
+                />
+              </div>
+              <Button type="button" onClick={addMessage} className="self-start">
+                Add
+              </Button>
+            </div>
+
+            <div className="space-y-2">
+              {messages.map((m, i) => (
+                <div key={i} className="rounded border p-3">
+                  <div className="text-sm font-semibold capitalize">
+                    {m.role}
+                  </div>
+                  <div className="text-sm text-muted-foreground">
+                    {m.content}
+                  </div>
+                </div>
+              ))}
+              {messages.length === 0 && (
+                <p className="text-sm text-muted-foreground">
+                  No messages yet.
+                </p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Tools */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Tools</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {fakeTools.map((tool) => (
+              <label key={tool} className="flex items-center gap-2">
+                <Checkbox
+                  checked={selectedTools.includes(tool)}
+                  onCheckedChange={() => toggleTool(tool)}
+                  id={`tool-${tool}`}
+                />
+                <span>{tool}</span>
+              </label>
+            ))}
+          </CardContent>
+        </Card>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- reflow layout on Agent Workflow page using a responsive grid
- keep the four cards in a grid to reduce wasted space

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6864f3d18a9c8333849882971570bb5a