### PR TITLE
Auto-populate tools in AgentWorkflow page

### DIFF
--- a/app/agent-workflow/page.tsx
+++ b/app/agent-workflow/page.tsx
@@ -1,11 +1,18 @@
 "use server"
 
+import fs from "fs/promises"
+import path from "path"
 import AgentWorkflowClient from "@/components/agent-workflow/AgentWorkflowClient"
 
 export default async function AgentWorkflowPage() {
+  const toolsDir = path.join(process.cwd(), "lib", "tools")
+  const entries = await fs.readdir(toolsDir)
+  const toolNames = entries
+    .filter((f) => f.endsWith(".ts") && f !== "helper.ts")
+    .map((f) => f.replace(/\.ts$/, ""))
   return (
     <div className="container mx-auto space-y-8 py-8">
-      <AgentWorkflowClient />
+      <AgentWorkflowClient tools={toolNames} />
     </div>
   )
 }

--- a/components/agent-workflow/AgentWorkflowClient.tsx
+++ b/components/agent-workflow/AgentWorkflowClient.tsx
@@ -21,10 +21,13 @@ interface Message {
   content: string
 }
 
-export default function AgentWorkflowClient() {
+export default function AgentWorkflowClient({
+  tools = [],
+}: {
+  tools?: string[]
+}) {
   const fakeRepos = ["repo-1", "repo-2", "repo-3"]
   const fakeBranches = ["main", "dev", "feature"]
-  const fakeTools = ["Git", "Code Search", "Unit Test"]
 
   const [selectedRepo, setSelectedRepo] = useState(fakeRepos[0])
   const [selectedBranch, setSelectedBranch] = useState(fakeBranches[0])
@@ -202,7 +205,7 @@ export default function AgentWorkflowClient() {
             <CardTitle>Tools</CardTitle>
           </CardHeader>
           <CardContent className="space-y-2">
-            {fakeTools.map((tool) => (
+            {tools.map((tool) => (
               <label key={tool} className="flex items-center gap-2">
                 <Checkbox
                   checked={selectedTools.includes(tool)}


### PR DESCRIPTION
## Summary
- detect tools from `/lib/tools` on the server
- pass the tool names to `AgentWorkflowClient`
- display the real tool list instead of placeholder names

## Testing
- `npm run lint:eslint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865c93884ec83339d160958c9d3d321