### PR TITLE
Use real tools list in agent workflow page

### DIFF
--- a/app/agent-workflow/page.tsx
+++ b/app/agent-workflow/page.tsx
@@ -1,11 +1,26 @@
 "use server"
+const DEFAULT_TOOLS = [
+  "apply_patch",
+  "manage_branch",
+  "commit_changes",
+  "container_exec",
+  "create_pull_request",
+  "file_check",
+  "get_file_content",
+  "get_issue",
+  "create_issue_comment",
+  "ripgrep_search",
+  "sync_branch_to_remote",
+  "write_file",
+]
+
 
 import AgentWorkflowClient from "@/components/agent-workflow/AgentWorkflowClient"
 
 export default async function AgentWorkflowPage() {
   return (
     <div className="container mx-auto space-y-8 py-8">
-      <AgentWorkflowClient />
+      <AgentWorkflowClient defaultTools={DEFAULT_TOOLS} />
     </div>
   )
 }

--- a/components/agent-workflow/AgentWorkflowClient.tsx
+++ b/components/agent-workflow/AgentWorkflowClient.tsx
@@ -21,7 +21,7 @@ interface Message {
   content: string
 }
 
-export default function AgentWorkflowClient() {
+export default function AgentWorkflowClient({ defaultTools }: { defaultTools: string[] }) {
   const fakeRepos = ["repo-1", "repo-2", "repo-3"]
   const fakeBranches = ["main", "dev", "feature"]
   const fakeIssues = [
@@ -29,7 +29,7 @@ export default function AgentWorkflowClient() {
     { id: "2", title: "Issue 2" },
     { id: "3", title: "Issue 3" },
   ]
-  const fakeTools = ["Git", "Code Search", "Unit Test"]
+  const availableTools = defaultTools
 
   const [selectedRepo, setSelectedRepo] = useState<string>("")
   const [branches, setBranches] = useState<string[]>([])
@@ -259,7 +259,7 @@ export default function AgentWorkflowClient() {
             <CardTitle>Tools</CardTitle>
           </CardHeader>
           <CardContent className="space-y-2">
-            {fakeTools.map((tool) => (
+            {availableTools.map((tool) => (
               <label key={tool} className="flex items-center gap-2">
                 <Checkbox
                   checked={selectedTools.includes(tool)}


### PR DESCRIPTION
## Summary
- surface all available tools on the Agent Workflow page
- pass the tools list from the server component

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6865e7dbe730833393b78dcebe15c3c9