### PR TITLE
Rename Agent Workflow page to Playground

### DIFF
--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -17,7 +17,7 @@ const DEFAULT_TOOLS = [
 
 import AgentWorkflowClient from "@/components/agent-workflow/AgentWorkflowClient"
 
-export default async function AgentWorkflowPage() {
+export default async function PlaygroundPage() {
   return (
     <div className="container mx-auto space-y-8 py-8">
       <AgentWorkflowClient defaultTools={DEFAULT_TOOLS} />

--- a/components/agent-workflow/AgentWorkflowClient.tsx
+++ b/components/agent-workflow/AgentWorkflowClient.tsx
@@ -100,9 +100,9 @@ export default function AgentWorkflowClient({ defaultTools }: { defaultTools: st
   return (
     <div className="container mx-auto space-y-8 py-8">
       <div>
-        <h1 className="text-3xl font-bold">Agent Workflow Builder</h1>
+        <h1 className="text-3xl font-bold">Playground</h1>
         <p className="mt-2 text-gray-600">
-          Configure options and messages for your agent workflow.
+          Configure options and messages for your agent.
         </p>
       </div>
 

--- a/components/layout/DynamicNavigation.tsx
+++ b/components/layout/DynamicNavigation.tsx
@@ -148,7 +148,7 @@ export default function DynamicNavigation({
             <Link href="/workflow-runs">Workflows</Link>
           </Button>
           <Button variant="ghost" size="sm" asChild className="flex items-center">
-            <Link href="/agent-workflow">Agent Workflow</Link>
+            <Link href="/playground">Playground</Link>
           </Button>
           <Button variant="ghost" size="sm" asChild className="flex items-center">
             <Link href="/issues">Issues</Link>
@@ -172,7 +172,7 @@ export default function DynamicNavigation({
           <SheetContent side="left" className="sm:hidden w-64 p-4">
             <nav className="mt-4 flex flex-col gap-4">
               <Link href="/workflow-runs">Workflows</Link>
-              <Link href="/agent-workflow">Agent Workflow</Link>
+              <Link href="/playground">Playground</Link>
               <Link href="/issues">Issues</Link>
               <Link href="/contribute">Contribute</Link>
               <Link href="/settings">Settings</Link>


### PR DESCRIPTION
## Summary
- rename `app/agent-workflow` route to `app/playground`
- update navigation links to the new Playground page
- rename page component and heading text

## Testing
- `pnpm run check:all` *(fails: Code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_6865f3a2995c8333a1596eac10b8d5d5