### PR TITLE
Add server action to list running Docker containers

### DIFF
--- a/components/agent-workflow/ContainerEnvironmentManager.tsx
+++ b/components/agent-workflow/ContainerEnvironmentManager.tsx
@@ -1,104 +1,62 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { getRunningContainers } from "@/lib/actions/docker"
 
 interface ContainerEnv {
   id: string
   name: string
   image: string
-  mounts: string[]
-  workdir: string
-  running: boolean
+  status: string
 }
 
 export default function ContainerEnvironmentManager() {
-  const [containers, setContainers] = useState<ContainerEnv[]>([
-    {
-      id: "1",
-      name: "agent-env-1",
-      image: "ubuntu:latest",
-      mounts: ["/workspace", "/data"],
-      workdir: "/workspace",
-      running: true,
-    },
-    {
-      id: "2",
-      name: "agent-env-2",
-      image: "node:20",
-      mounts: ["/app"],
-      workdir: "/app",
-      running: false,
-    },
-  ])
-  const [activeId, setActiveId] = useState<string>(containers[0].id)
+  const [containers, setContainers] = useState<ContainerEnv[]>([])
 
-  const toggleContainer = (id: string) => {
-    setContainers((prev) =>
-      prev.map((c) => (c.id === id ? { ...c, running: !c.running } : c))
-    )
+  const refreshContainers = async () => {
+    const result = await getRunningContainers()
+    setContainers(result)
   }
 
-  const startNewContainer = () => {
-    const newId = Date.now().toString()
-    const newContainer: ContainerEnv = {
-      id: newId,
-      name: `agent-env-${containers.length + 1}`,
-      image: "ubuntu:latest",
-      mounts: ["/workspace"],
-      workdir: "/workspace",
-      running: true,
-    }
-    setContainers((prev) => [...prev, newContainer])
-    setActiveId(newId)
-  }
+  useEffect(() => {
+    refreshContainers()
+  }, [])
 
   return (
     <Card>
       <CardHeader className="flex items-center justify-between">
-        <CardTitle>Container Environments</CardTitle>
-        <Button size="sm" onClick={startNewContainer}>
-          Start New Container
+        <CardTitle>Running Containers</CardTitle>
+        <Button size="sm" onClick={refreshContainers}>
+          Refresh
         </Button>
       </CardHeader>
       <CardContent className="space-y-4">
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead className="w-12">Active</TableHead>
               <TableHead>Name</TableHead>
               <TableHead>Image</TableHead>
-              <TableHead>Mounts</TableHead>
-              <TableHead>Workdir</TableHead>
               <TableHead>Status</TableHead>
-              <TableHead className="text-right">Action</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {containers.map((c) => (
               <TableRow key={c.id}>
-                <TableCell>
-                  <input
-                    type="radio"
-                    name="activeContainer"
-                    checked={activeId === c.id}
-                    onChange={() => setActiveId(c.id)}
-                  />
-                </TableCell>
                 <TableCell>{c.name}</TableCell>
                 <TableCell>{c.image}</TableCell>
-                <TableCell>{c.mounts.join(", ")}</TableCell>
-                <TableCell>{c.workdir}</TableCell>
-                <TableCell>{c.running ? "Running" : "Stopped"}</TableCell>
-                <TableCell className="text-right">
-                  <Button size="sm" onClick={() => toggleContainer(c.id)}>
-                    {c.running ? "Shut Down" : "Start"}
-                  </Button>
-                </TableCell>
+                <TableCell>{c.status}</TableCell>
               </TableRow>
             ))}
+            {containers.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={3} className="text-center text-sm text-muted-foreground">
+                  No running containers
+                </TableCell>
+              </TableRow>
+            )}
           </TableBody>
         </Table>
       </CardContent>

--- a/lib/actions/docker.ts
+++ b/lib/actions/docker.ts
@@ -1,0 +1,7 @@
+"use server"
+
+import { listRunningContainers, RunningContainer } from "@/lib/docker"
+
+export async function getRunningContainers(): Promise<RunningContainer[]> {
+  return await listRunningContainers()
+}

--- a/lib/docker.ts
+++ b/lib/docker.ts
@@ -72,3 +72,32 @@ export async function isContainerRunning(name: string): Promise<boolean> {
     return false
   }
 }
+
+export interface RunningContainer {
+  id: string
+  name: string
+  image: string
+  status: string
+}
+
+/**
+ * List currently running Docker containers.
+ */
+export async function listRunningContainers(): Promise<RunningContainer[]> {
+  try {
+    const { stdout } = await execPromise("docker ps --format '{{json .}}'")
+    const lines = stdout.trim().split("\n").filter(Boolean)
+    return lines.map((line) => {
+      const data = JSON.parse(line) as Record<string, string>
+      return {
+        id: data.ID,
+        name: data.Names,
+        image: data.Image,
+        status: data.Status,
+      }
+    })
+  } catch (error) {
+    console.error("[ERROR] Failed to list running containers:", error)
+    return []
+  }
+}


### PR DESCRIPTION
## Summary
- add helper to list running Docker containers
- expose `getRunningContainers` server action
- show running containers with a refresh button in the playground

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6865f7fab7a883338cac69815b967058