### PR TITLE
Load repos in playground via server actions

### DIFF
--- a/lib/actions/github.ts
+++ b/lib/actions/github.ts
@@ -1,0 +1,18 @@
+"use server"
+
+import { listUserRepositoriesGraphQL } from "@/lib/github/users";
+import { listBranches } from "@/lib/github/repos";
+import { getIssueList } from "@/lib/github/issues";
+import { RepoSelectorItem, GitHubIssue } from "@/lib/types/github";
+
+export async function getUserRepositories(): Promise<RepoSelectorItem[]> {
+  return await listUserRepositoriesGraphQL();
+}
+
+export async function getRepositoryBranches(repoFullName: string): Promise<string[]> {
+  return await listBranches(repoFullName);
+}
+
+export async function getRepositoryIssues(repoFullName: string): Promise<GitHubIssue[]> {
+  return await getIssueList({ repoFullName, state: "open" });
+}

--- a/lib/github/repos.ts
+++ b/lib/github/repos.ts
@@ -1,0 +1,14 @@
+import getOctokit from "@/lib/github";
+
+export async function listBranches(repoFullName: string): Promise<string[]> {
+  const octokit = await getOctokit();
+  if (!octokit) {
+    throw new Error("No octokit instance available");
+  }
+  const [owner, repo] = repoFullName.split("/");
+  if (!owner || !repo) {
+    throw new Error("Invalid repository format. Expected 'owner/repo'");
+  }
+  const { data } = await octokit.rest.repos.listBranches({ owner, repo, per_page: 100 });
+  return data.map((b) => b.name);
+}


### PR DESCRIPTION
## Summary
- create GitHub server actions for repo data
- add helper to list branches
- populate repo card in playground using server actions

## Testing
- `pnpm test`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6865fe8f70bc83338a15ea7cd6dcf247