### PR TITLE
Add container launch to playground

### DIFF
--- a/components/agent-workflow/ContainerEnvironmentManager.tsx
+++ b/components/agent-workflow/ContainerEnvironmentManager.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useRouter } from "next/navigation"
 import { useEffect, useState } from "react"
 
 import { Button } from "@/components/ui/button"
@@ -12,7 +13,10 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
-import { getRunningContainers } from "@/lib/actions/docker"
+import {
+  getRunningContainers,
+  launchAgentBaseContainer,
+} from "@/lib/actions/docker"
 
 interface ContainerEnv {
   id: string
@@ -22,11 +26,18 @@ interface ContainerEnv {
 }
 
 export default function ContainerEnvironmentManager() {
+  const router = useRouter()
   const [containers, setContainers] = useState<ContainerEnv[]>([])
 
   const refreshContainers = async () => {
     const result = await getRunningContainers()
     setContainers(result)
+  }
+
+  const launchContainer = async () => {
+    await launchAgentBaseContainer()
+    await refreshContainers()
+    router.refresh()
   }
 
   useEffect(() => {
@@ -37,9 +48,14 @@ export default function ContainerEnvironmentManager() {
     <Card>
       <CardHeader className="flex items-center justify-between">
         <CardTitle>Running Containers</CardTitle>
-        <Button size="sm" onClick={refreshContainers}>
-          Refresh
-        </Button>
+        <div className="flex gap-2">
+          <Button size="sm" onClick={refreshContainers}>
+            Refresh
+          </Button>
+          <Button size="sm" onClick={launchContainer}>
+            Launch new container
+          </Button>
+        </div>
       </CardHeader>
       <CardContent className="space-y-4">
         <Table>

--- a/lib/actions/docker.ts
+++ b/lib/actions/docker.ts
@@ -1,7 +1,20 @@
 "use server"
 
-import { listRunningContainers, RunningContainer } from "@/lib/docker"
+import {
+  listRunningContainers,
+  RunningContainer,
+  startBasicContainer,
+} from "@/lib/docker"
 
 export async function getRunningContainers(): Promise<RunningContainer[]> {
   return await listRunningContainers()
+}
+
+export async function launchAgentBaseContainer() {
+  const name = `agent-${Date.now()}`
+  await startBasicContainer({
+    image: "ghcr.io/youngchingjui/agent-base",
+    name,
+  })
+  return name
 }

--- a/lib/actions/docker.ts
+++ b/lib/actions/docker.ts
@@ -3,7 +3,7 @@
 import {
   listRunningContainers,
   RunningContainer,
-  startBasicContainer,
+  startContainer,
 } from "@/lib/docker"
 
 export async function getRunningContainers(): Promise<RunningContainer[]> {
@@ -12,7 +12,7 @@ export async function getRunningContainers(): Promise<RunningContainer[]> {
 
 export async function launchAgentBaseContainer() {
   const name = `agent-${Date.now()}`
-  await startBasicContainer({
+  await startContainer({
     image: "ghcr.io/youngchingjui/agent-base",
     name,
   })

--- a/lib/docker.ts
+++ b/lib/docker.ts
@@ -27,6 +27,26 @@ export async function startDetachedContainer({
   return stdout.trim()
 }
 
+export async function startBasicContainer({
+  image,
+  name,
+  user = "1000:1000",
+}: {
+  image: string
+  name: string
+  user?: string
+}): Promise<string> {
+  const cmd = [
+    "docker run -d",
+    `--name ${name}`,
+    `-u ${user}`,
+    image,
+    "tail -f /dev/null",
+  ].join(" ")
+  const { stdout } = await execPromise(cmd)
+  return stdout.trim()
+}
+
 export async function execInContainer({
   name,
   command,

--- a/lib/docker.ts
+++ b/lib/docker.ts
@@ -3,47 +3,27 @@ import util from "util"
 
 const execPromise = util.promisify(exec)
 
-export async function startDetachedContainer({
+export async function startContainer({
   image,
+  name,
   hostDir,
-  name,
   user = "1000:1000",
 }: {
   image: string
-  hostDir: string
   name: string
+  hostDir?: string
   user?: string
 }): Promise<string> {
-  const cmd = [
-    "docker run -d",
-    `--name ${name}`,
-    `-u ${user}`,
-    `-v \"${hostDir}:/workspace\"`,
-    "-w /workspace",
-    image,
-    "tail -f /dev/null",
-  ].join(" ")
-  const { stdout } = await execPromise(cmd)
-  return stdout.trim()
-}
+  const cmdParts = ["docker run -d", `--name ${name}`, `-u ${user}`]
 
-export async function startBasicContainer({
-  image,
-  name,
-  user = "1000:1000",
-}: {
-  image: string
-  name: string
-  user?: string
-}): Promise<string> {
-  const cmd = [
-    "docker run -d",
-    `--name ${name}`,
-    `-u ${user}`,
-    image,
-    "tail -f /dev/null",
-  ].join(" ")
-  const { stdout } = await execPromise(cmd)
+  if (hostDir) {
+    // Mount the host directory to /workspace inside the container and set it as the working directory
+    cmdParts.push(`-v \"${hostDir}:/workspace\"`, "-w /workspace")
+  }
+
+  cmdParts.push(image, "tail -f /dev/null")
+
+  const { stdout } = await execPromise(cmdParts.join(" "))
   return stdout.trim()
 }
 

--- a/lib/utils/container.ts
+++ b/lib/utils/container.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from "uuid"
 
 import {
   execInContainer,
-  startDetachedContainer,
+  startContainer,
   stopAndRemoveContainer,
 } from "@/lib/docker"
 import { addWorktree, removeWorktree } from "@/lib/git"
@@ -110,8 +110,8 @@ export async function createContainerizedWorktree({
 
   const containerName = `agent-${workflowId}`.replace(/[^a-zA-Z0-9_.-]/g, "-")
 
-  // 4. Start detached container mounting the worktree
-  await startDetachedContainer({
+  // 4. Start container mounting the worktree
+  await startContainer({
     image,
     hostDir: worktreeDir,
     name: containerName,


### PR DESCRIPTION
## Summary
- allow launching agent-base container from playground
- add `startBasicContainer` helper
- expose `launchAgentBaseContainer` server action

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6865ff1676308333934114a0768a7143