### PR TITLE
Filter playground container list by agent image

### DIFF
--- a/lib/actions/docker.ts
+++ b/lib/actions/docker.ts
@@ -1,12 +1,14 @@
 "use server"
 
+import { AGENT_BASE_IMAGE } from "@/lib/docker"
 import {
   listRunningContainers,
   RunningContainer,
   startContainer,
 } from "@/lib/docker"
 
-const AGENT_BASE_IMAGE_PREFIX = "ghcr.io/youngchingjui/agent-base"
+// Use shared constant for the agent base image prefix
+const AGENT_BASE_IMAGE_PREFIX = AGENT_BASE_IMAGE
 
 export async function getRunningContainers(): Promise<RunningContainer[]> {
   const containers = await listRunningContainers()
@@ -16,7 +18,7 @@ export async function getRunningContainers(): Promise<RunningContainer[]> {
 export async function launchAgentBaseContainer() {
   const name = `agent-${Date.now()}`
   await startContainer({
-    image: "ghcr.io/youngchingjui/agent-base",
+    image: AGENT_BASE_IMAGE,
     name,
   })
   return name

--- a/lib/actions/docker.ts
+++ b/lib/actions/docker.ts
@@ -2,6 +2,9 @@
 
 import { listRunningContainers, RunningContainer } from "@/lib/docker"
 
+const AGENT_BASE_IMAGE_PREFIX = "ghcr.io/youngchingjui/agent-base"
+
 export async function getRunningContainers(): Promise<RunningContainer[]> {
-  return await listRunningContainers()
+  const containers = await listRunningContainers()
+  return containers.filter((c) => c.image.startsWith(AGENT_BASE_IMAGE_PREFIX))
 }

--- a/lib/docker.ts
+++ b/lib/docker.ts
@@ -3,6 +3,16 @@ import util from "util"
 
 const execPromise = util.promisify(exec)
 
+// Default image name and literal type
+const DEFAULT_AGENT_BASE_IMAGE = "ghcr.io/youngchingjui/agent-base" as const
+
+// Image name that can be overridden via environment variable
+export const AGENT_BASE_IMAGE: string =
+  process.env.AGENT_BASE_IMAGE ?? DEFAULT_AGENT_BASE_IMAGE
+
+// Literal type representing the default image (useful for narrowing)
+export type AgentBaseImage = typeof DEFAULT_AGENT_BASE_IMAGE
+
 export async function startContainer({
   image,
   name,

--- a/lib/utils/container.ts
+++ b/lib/utils/container.ts
@@ -2,6 +2,7 @@ import os from "os"
 import path from "path"
 import { v4 as uuidv4 } from "uuid"
 
+import { AGENT_BASE_IMAGE } from "@/lib/docker"
 import {
   execInContainer,
   startContainer,
@@ -92,7 +93,7 @@ export async function createContainerizedWorktree({
   repoFullName,
   branch = "main",
   workflowId = uuidv4(),
-  image = "ghcr.io/youngchingjui/agent-base",
+  image = AGENT_BASE_IMAGE,
   mountPath = "/workspace",
 }: ContainerizedWorktreeOptions): Promise<ContainerizedWorktreeResult> {
   // 1. Ensure we have a clean local clone

--- a/lib/workflows/commentOnIssue.ts
+++ b/lib/workflows/commentOnIssue.ts
@@ -1,5 +1,6 @@
 import { ThinkerAgent } from "@/lib/agents/thinker"
 import { AUTH_CONFIG } from "@/lib/auth/config"
+import { AGENT_BASE_IMAGE } from "@/lib/docker"
 import { isContainerRunning } from "@/lib/docker"
 import {
   createIssueComment,
@@ -147,7 +148,7 @@ export default async function commentOnIssue(
       repoFullName: repo.full_name,
       branch: repo.default_branch,
       workflowId: jobId,
-      image: "ghcr.io/youngchingjui/agent-base",
+      image: AGENT_BASE_IMAGE,
     }).catch((error) => {
       console.error("Failed to setup containerized environment:", {
         error,

--- a/scripts/build-agent-image.sh
+++ b/scripts/build-agent-image.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-IMAGE_NAME="ghcr.io/youngchingjui/agent-base"
+IMAGE_NAME="${AGENT_BASE_IMAGE:-ghcr.io/youngchingjui/agent-base}"
 IMAGE_TAG="latest"
 DOCKERFILE_PATH="docker/agent-base/Dockerfile"
 


### PR DESCRIPTION
## Summary
- restrict container listing on the playground to only show containers using the custom `agent-base` image

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68661ed0acb88333989e7a2c17b18770