### PR TITLE
Add OpenAI completion in playground

### DIFF
--- a/lib/actions/openaiChat.ts
+++ b/lib/actions/openaiChat.ts
@@ -1,0 +1,22 @@
+"use server"
+
+import { openai } from "@/lib/openai"
+import { ChatCompletionMessageParam } from "openai/resources/chat/completions"
+
+export async function getChatCompletion({
+  systemPrompt,
+  userPrompt,
+}: {
+  systemPrompt: string
+  userPrompt: string
+}): Promise<string> {
+  const messages: ChatCompletionMessageParam[] = [
+    { role: "system", content: systemPrompt },
+    { role: "user", content: userPrompt },
+  ]
+  const res = await openai.chat.completions.create({
+    model: "gpt-4.1",
+    messages,
+  })
+  return res.choices[0]?.message?.content || ""
+}


### PR DESCRIPTION
## Summary
- allow chat completions on playground
- create `getChatCompletion` server action to call OpenAI with gpt-4.1
- show submit button in Messages card

## Testing
- `npx prettier -w lib/actions/openaiChat.ts components/agent-workflow/AgentWorkflowClient.tsx`
- `npx next lint` *(fails: Need to install next)*
- `npm test` *(fails: jest not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: numerous missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68661f9e8ed48333b93b1142d5d4cc39