### PR TITLE
Add helper to get OpenAI key

### DIFF
--- a/lib/neo4j/services/user.ts
+++ b/lib/neo4j/services/user.ts
@@ -43,3 +43,10 @@ export async function setUserOpenAIApiKey(apiKey: string): Promise<void> {
     await session.close()
   }
 }
+
+export async function getUserOpenAIApiKey(): Promise<string | null> {
+  const settings = await getUserSettings()
+  if (!settings) return null
+  const key = settings.openAIApiKey?.trim()
+  return key ? key : null
+}


### PR DESCRIPTION
## Summary
- add `getUserOpenAIApiKey` helper for Neo4j service

## Testing
- `pnpm exec jest`

------
https://chatgpt.com/codex/tasks/task_e_686629146ddc8333b6d34fd99237f995