### PR TITLE
Support multi-arch build for agent base image

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -70,9 +70,12 @@ A Python repo might need a Python image, etc.
 ### Building the Agent Base Image
 
 ```bash
-# Build the custom agent image with ripgrep pre-installed
+# Build the multi-architecture agent image with ripgrep pre-installed
 ./scripts/build-agent-image.sh
 ```
+
+The script uses **docker buildx** to build and push images for both `linux/amd64` and
+`linux/arm64` platforms.
 
 The image includes:
 

--- a/scripts/build-agent-image.sh
+++ b/scripts/build-agent-image.sh
@@ -8,16 +8,18 @@ set -e
 IMAGE_NAME="${AGENT_BASE_IMAGE:-ghcr.io/youngchingjui/agent-base}"
 IMAGE_TAG="latest"
 DOCKERFILE_PATH="docker/agent-base/Dockerfile"
-# Platforms to build for
 PLATFORMS="linux/amd64,linux/arm64"
 
 echo "Building custom agent base image: ${IMAGE_NAME}:${IMAGE_TAG}"
 
 # Build the Docker image for multiple architectures
+# Ensure you have a builder named "container-builder" 
+# using the driver "docker-container"
 docker buildx build \
   --platform "${PLATFORMS}" \
   -t "${IMAGE_NAME}:${IMAGE_TAG}" \
   -f "${DOCKERFILE_PATH}" \
+  --builder "container-builder" \
   --push \
   .
 

--- a/scripts/build-agent-image.sh
+++ b/scripts/build-agent-image.sh
@@ -8,11 +8,18 @@ set -e
 IMAGE_NAME="${AGENT_BASE_IMAGE:-ghcr.io/youngchingjui/agent-base}"
 IMAGE_TAG="latest"
 DOCKERFILE_PATH="docker/agent-base/Dockerfile"
+# Platforms to build for
+PLATFORMS="linux/amd64,linux/arm64"
 
 echo "Building custom agent base image: ${IMAGE_NAME}:${IMAGE_TAG}"
 
-# Build the Docker image
-docker build -t "${IMAGE_NAME}:${IMAGE_TAG}" -f "${DOCKERFILE_PATH}" .
+# Build the Docker image for multiple architectures
+docker buildx build \
+  --platform "${PLATFORMS}" \
+  -t "${IMAGE_NAME}:${IMAGE_TAG}" \
+  -f "${DOCKERFILE_PATH}" \
+  --push \
+  .
 
 echo "Image built successfully!"
 echo "Testing image..."
@@ -22,9 +29,7 @@ docker run --rm "${IMAGE_NAME}:${IMAGE_TAG}" rg --version
 docker run --rm "${IMAGE_NAME}:${IMAGE_TAG}" git --version
 docker run --rm "${IMAGE_NAME}:${IMAGE_TAG}" curl --version
 
-echo "Pushing image to repository..."
-docker push "${IMAGE_NAME}:${IMAGE_TAG}"
-
 echo "✅ Custom agent image is ready for use"
 echo "Image: ${IMAGE_NAME}:${IMAGE_TAG}"
-echo "Includes: ripgrep, git, curl" 
+echo "Platforms: ${PLATFORMS}"
+echo "Includes: ripgrep, git, curl"


### PR DESCRIPTION
## Summary
- build the agent base image for `linux/amd64` and `linux/arm64`
- document multi-architecture build in docker guide

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68663146014483339327a6bb60b41747