### PR TITLE
Sort repo branches by activity with default first

### DIFF
--- a/lib/github/repos.ts
+++ b/lib/github/repos.ts
@@ -1,14 +1,72 @@
-import getOctokit from "@/lib/github";
+import { getGraphQLClient } from "@/lib/github";
 
 export async function listBranches(repoFullName: string): Promise<string[]> {
-  const octokit = await getOctokit();
-  if (!octokit) {
-    throw new Error("No octokit instance available");
+  const graphqlWithAuth = await getGraphQLClient();
+  if (!graphqlWithAuth) {
+    throw new Error("Could not initialize GraphQL client");
   }
+
   const [owner, repo] = repoFullName.split("/");
   if (!owner || !repo) {
     throw new Error("Invalid repository format. Expected 'owner/repo'");
   }
-  const { data } = await octokit.rest.repos.listBranches({ owner, repo, per_page: 100 });
-  return data.map((b) => b.name);
+
+  const query = `
+    query($owner: String!, $repo: String!, $perPage: Int!) {
+      repository(owner: $owner, name: $repo) {
+        defaultBranchRef { name }
+        refs(
+          refPrefix: "refs/heads/",
+          first: $perPage,
+          orderBy: { field: TAG_COMMIT_DATE, direction: DESC }
+        ) {
+          nodes {
+            name
+            target {
+              ... on Commit {
+                committedDate
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const variables = {
+    owner,
+    repo,
+    perPage: 50,
+  };
+
+  type BranchesResponse = {
+    repository: {
+      defaultBranchRef: { name: string } | null;
+      refs: {
+        nodes: Array<{
+          name: string;
+          target: { committedDate: string } | null;
+        }>;
+      };
+    } | null;
+  };
+
+  const response = await graphqlWithAuth<BranchesResponse>(query, variables);
+  const defaultBranch = response.repository?.defaultBranchRef?.name || "";
+  const branches = response.repository?.refs.nodes || [];
+
+  const names = branches
+    .map((b) => ({ name: b.name, date: b.target?.committedDate || "" }))
+    .sort((a, b) => {
+      const dateA = new Date(a.date).getTime() || 0;
+      const dateB = new Date(b.date).getTime() || 0;
+      return dateB - dateA;
+    })
+    .map((b) => b.name);
+
+  if (defaultBranch) {
+    const filtered = names.filter((n) => n !== defaultBranch);
+    return [defaultBranch, ...filtered];
+  }
+  return names;
 }


### PR DESCRIPTION
## Summary
- ensure GitHub branch list places the default branch first
- sort remaining branches by most recent commit date
- switch `listBranches` to GitHub GraphQL API

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6866255679e48333a7a253d71c6cc349