### PR TITLE
Add local repo status indicator on playground

### DIFF
--- a/components/agent-workflow/AgentWorkflowClient.tsx
+++ b/components/agent-workflow/AgentWorkflowClient.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { CheckCircle2, Loader2 } from "lucide-react"
+import { FolderCheck, Loader2 } from "lucide-react"
 import { useEffect, useState, useTransition } from "react"
 
 import ContainerEnvironmentManager from "@/components/agent-workflow/ContainerEnvironmentManager"
@@ -246,7 +246,7 @@ export default function AgentWorkflowClient({
                     </SelectContent>
                   </Select>
                   {localRepoStatus?.exists && (
-                    <TooltipProvider>
+                    <TooltipProvider delayDuration={150}>
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <Button
@@ -255,11 +255,19 @@ export default function AgentWorkflowClient({
                             className="h-6 w-6"
                             onClick={copyLocalPath}
                           >
-                            <CheckCircle2 className="h-4 w-4 text-green-500" />
+                            <FolderCheck className="h-4 w-4 text-green-500" />
                           </Button>
                         </TooltipTrigger>
-                        <TooltipContent>
-                          Repo saved locally. Click to copy path.
+                        <TooltipContent className="max-w-xs text-center">
+                          <div className="text-sm">Repo saved locally.</div>
+                          {localRepoStatus?.path && (
+                            <div className="mt-1 break-all font-mono text-[10px] text-muted-foreground">
+                              {localRepoStatus.path}
+                            </div>
+                          )}
+                          <div className="mt-1 text-xs text-muted-foreground">
+                            Click to copy path
+                          </div>
                         </TooltipContent>
                       </Tooltip>
                     </TooltipProvider>

--- a/components/agent-workflow/AgentWorkflowClient.tsx
+++ b/components/agent-workflow/AgentWorkflowClient.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Loader2 } from "lucide-react"
+import { CheckCircle2, Loader2 } from "lucide-react"
 import { useEffect, useState, useTransition } from "react"
 
 import ContainerEnvironmentManager from "@/components/agent-workflow/ContainerEnvironmentManager"
@@ -17,9 +17,16 @@ import {
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import {
   getRepositoryBranches,
   getRepositoryIssues,
   getUserRepositories,
+  checkLocalRepoExists,
 } from "@/lib/actions/github"
 import { getChatCompletion } from "@/lib/actions/openaiChat"
 import {
@@ -27,6 +34,7 @@ import {
   SystemPromptTemplate,
 } from "@/lib/systemPrompts"
 import { GitHubIssue, RepoSelectorItem } from "@/lib/types/github"
+import { toast } from "@/lib/hooks/use-toast"
 
 interface Message {
   role: "system" | "user" | "assistant"
@@ -66,6 +74,10 @@ export default function AgentWorkflowClient({
   const [selectedTools, setSelectedTools] = useState<string[]>([])
   const [isRunning, setIsRunning] = useState(false)
   const [runResult, setRunResult] = useState<{ runId: string } | null>(null)
+  const [localRepoStatus, setLocalRepoStatus] = useState<
+    | { exists: boolean; path: string }
+    | null
+  >(null)
 
   // Load repositories on mount
   useEffect(() => {
@@ -83,16 +95,19 @@ export default function AgentWorkflowClient({
       setSelectedBranch("")
       setIssues([])
       setSelectedIssue("")
+      setLocalRepoStatus(null)
       return
     }
     setLoadingRepoData(true)
     const loadData = async () => {
-      const [br, is] = await Promise.all([
+      const [br, is, local] = await Promise.all([
         getRepositoryBranches(selectedRepo),
         getRepositoryIssues(selectedRepo),
+        checkLocalRepoExists(selectedRepo),
       ])
       setBranches(br)
       setIssues(is)
+      setLocalRepoStatus(local)
       setLoadingRepoData(false)
     }
     loadData()
@@ -181,6 +196,20 @@ export default function AgentWorkflowClient({
     setIsRunning(false)
   }
 
+  const copyLocalPath = async () => {
+    if (!localRepoStatus?.path) return
+    try {
+      await navigator.clipboard.writeText(localRepoStatus.path)
+      toast({ description: "Copied path to clipboard", duration: 2000 })
+    } catch (err) {
+      toast({
+        description: `Failed to copy: ${err}`,
+        variant: "destructive",
+        duration: 2000,
+      })
+    }
+  }
+
   return (
     <>
       <div>
@@ -200,21 +229,42 @@ export default function AgentWorkflowClient({
             <div className="flex flex-wrap gap-4">
               <div>
                 <p className="mb-2 text-sm font-medium">Repository</p>
-                <Select value={selectedRepo} onValueChange={setSelectedRepo}>
-                  <SelectTrigger className="w-[200px]">
-                    <SelectValue placeholder="Select repo" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {repos.map((repo) => (
-                      <SelectItem
-                        key={repo.nameWithOwner}
-                        value={repo.nameWithOwner}
-                      >
-                        {repo.nameWithOwner}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <div className="flex items-center gap-2">
+                  <Select value={selectedRepo} onValueChange={setSelectedRepo}>
+                    <SelectTrigger className="w-[200px]">
+                      <SelectValue placeholder="Select repo" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {repos.map((repo) => (
+                        <SelectItem
+                          key={repo.nameWithOwner}
+                          value={repo.nameWithOwner}
+                        >
+                          {repo.nameWithOwner}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {localRepoStatus?.exists && (
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-6 w-6"
+                            onClick={copyLocalPath}
+                          >
+                            <CheckCircle2 className="h-4 w-4 text-green-500" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          Repo saved locally. Click to copy path.
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  )}
+                </div>
               </div>
               {selectedRepo && (
                 <div>

--- a/components/agent-workflow/AgentWorkflowClient.tsx
+++ b/components/agent-workflow/AgentWorkflowClient.tsx
@@ -23,18 +23,18 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import {
+  checkLocalRepoExists,
   getRepositoryBranches,
   getRepositoryIssues,
   getUserRepositories,
-  checkLocalRepoExists,
 } from "@/lib/actions/github"
 import { getChatCompletion } from "@/lib/actions/openaiChat"
+import { toast } from "@/lib/hooks/use-toast"
 import {
   DEFAULT_SYSTEM_PROMPTS,
   SystemPromptTemplate,
 } from "@/lib/systemPrompts"
 import { GitHubIssue, RepoSelectorItem } from "@/lib/types/github"
-import { toast } from "@/lib/hooks/use-toast"
 
 interface Message {
   role: "system" | "user" | "assistant"
@@ -74,10 +74,10 @@ export default function AgentWorkflowClient({
   const [selectedTools, setSelectedTools] = useState<string[]>([])
   const [isRunning, setIsRunning] = useState(false)
   const [runResult, setRunResult] = useState<{ runId: string } | null>(null)
-  const [localRepoStatus, setLocalRepoStatus] = useState<
-    | { exists: boolean; path: string }
-    | null
-  >(null)
+  const [localRepoStatus, setLocalRepoStatus] = useState<{
+    exists: boolean
+    path: string
+  } | null>(null)
 
   // Load repositories on mount
   useEffect(() => {

--- a/lib/actions/github.ts
+++ b/lib/actions/github.ts
@@ -1,29 +1,33 @@
 "use server"
 
-import { listUserRepositoriesGraphQL } from "@/lib/github/users";
-import { listBranches } from "@/lib/github/repos";
-import { getIssueList } from "@/lib/github/issues";
-import { getLocalRepoDir } from "@/lib/fs";
-import { checkIfGitExists } from "@/lib/git";
-import { RepoSelectorItem, GitHubIssue } from "@/lib/types/github";
+import { getLocalRepoDir } from "@/lib/fs"
+import { checkIfGitExists } from "@/lib/git"
+import { getIssueList } from "@/lib/github/issues"
+import { listBranches } from "@/lib/github/repos"
+import { listUserRepositoriesGraphQL } from "@/lib/github/users"
+import { GitHubIssue, RepoSelectorItem } from "@/lib/types/github"
 
 export async function getUserRepositories(): Promise<RepoSelectorItem[]> {
-  return await listUserRepositoriesGraphQL();
+  return await listUserRepositoriesGraphQL()
 }
 
-export async function getRepositoryBranches(repoFullName: string): Promise<string[]> {
-  return await listBranches(repoFullName);
+export async function getRepositoryBranches(
+  repoFullName: string
+): Promise<string[]> {
+  return await listBranches(repoFullName)
 }
 
-export async function getRepositoryIssues(repoFullName: string): Promise<GitHubIssue[]> {
-  return await getIssueList({ repoFullName, state: "open" });
+export async function getRepositoryIssues(
+  repoFullName: string
+): Promise<GitHubIssue[]> {
+  return await getIssueList({ repoFullName, state: "open" })
 }
 
 export async function checkLocalRepoExists(repoFullName: string): Promise<{
-  exists: boolean;
-  path: string;
+  exists: boolean
+  path: string
 }> {
-  const dir = await getLocalRepoDir(repoFullName);
-  const exists = await checkIfGitExists(dir);
-  return { exists, path: dir };
+  const dir = await getLocalRepoDir(repoFullName)
+  const exists = await checkIfGitExists(dir)
+  return { exists, path: dir }
 }

--- a/lib/actions/github.ts
+++ b/lib/actions/github.ts
@@ -3,6 +3,8 @@
 import { listUserRepositoriesGraphQL } from "@/lib/github/users";
 import { listBranches } from "@/lib/github/repos";
 import { getIssueList } from "@/lib/github/issues";
+import { getLocalRepoDir } from "@/lib/fs";
+import { checkIfGitExists } from "@/lib/git";
 import { RepoSelectorItem, GitHubIssue } from "@/lib/types/github";
 
 export async function getUserRepositories(): Promise<RepoSelectorItem[]> {
@@ -15,4 +17,13 @@ export async function getRepositoryBranches(repoFullName: string): Promise<strin
 
 export async function getRepositoryIssues(repoFullName: string): Promise<GitHubIssue[]> {
   return await getIssueList({ repoFullName, state: "open" });
+}
+
+export async function checkLocalRepoExists(repoFullName: string): Promise<{
+  exists: boolean;
+  path: string;
+}> {
+  const dir = await getLocalRepoDir(repoFullName);
+  const exists = await checkIfGitExists(dir);
+  return { exists, path: dir };
 }


### PR DESCRIPTION
## Summary
- check if local git repo exists via new server action
- display status icon for locally cached repos in playground repo selector
- allow copying temp path when clicking the icon

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6866e67cfbd8833392a2cf28f4a3f4fa