### PR TITLE
Show OAuth token on Playground with copy popover

### DIFF
--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -14,11 +14,17 @@ const DEFAULT_TOOLS = [
   "write_file",
 ]
 
+import { auth } from "@/auth"
 import AgentWorkflowClient from "@/components/agent-workflow/AgentWorkflowClient"
+import OAuthTokenCard from "@/components/auth/OAuthTokenCard"
 
 export default async function PlaygroundPage() {
+  const session = await auth()
+  const token = session?.token?.access_token as string | undefined
+
   return (
     <div className="space-y-8 px-4 py-8 md:container md:mx-auto">
+      {token ? <OAuthTokenCard token={token} /> : null}
       <AgentWorkflowClient defaultTools={DEFAULT_TOOLS} />
     </div>
   )

--- a/components/auth/OAuthTokenCard.tsx
+++ b/components/auth/OAuthTokenCard.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import { useState } from "react"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+
+export default function OAuthTokenCard({ token }: { token: string }) {
+  const [open, setOpen] = useState(false)
+
+  const copyToken = async () => {
+    try {
+      await navigator.clipboard.writeText(token)
+    } finally {
+      setOpen(true)
+      setTimeout(() => setOpen(false), 1200)
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>OAuth Token</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>
+            <div
+              onClick={copyToken}
+              className="cursor-pointer select-all rounded border bg-muted p-2 font-mono text-sm break-all"
+            >
+              {token}
+            </div>
+          </PopoverTrigger>
+          <PopoverContent side="top" className="w-auto text-sm text-center">
+            OAuth token copied
+          </PopoverContent>
+        </Popover>
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
## Summary
- add `OAuthTokenCard` client component to display OAuth token and copy it to clipboard via popover
- show OAuth token card on `/playground` when authenticated
- fix TypeScript error in playground page

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm run lint:tsc`


------
https://chatgpt.com/codex/tasks/task_e_6868a6bc99d883339a029c94aa8793be