### PR TITLE
Return structured errors from getIssue and improve issue page error handling

### DIFF
--- a/app/[username]/[repo]/issues/[issueId]/page.tsx
+++ b/app/[username]/[repo]/issues/[issueId]/page.tsx
@@ -1,6 +1,5 @@
 import { ChevronLeft } from "lucide-react"
 import Link from "next/link"
-import { notFound } from "next/navigation"
 import { Suspense } from "react"
 
 import IssueDetailsWrapper from "@/components/issues/IssueDetailsWrapper"
@@ -9,7 +8,6 @@ import IssueWorkflowRuns from "@/components/issues/IssueWorkflowRuns"
 import TableSkeleton from "@/components/layout/TableSkeleton"
 import { Button } from "@/components/ui/button"
 import { getIssue } from "@/lib/github/issues"
-import { GetIssueResult } from "@/lib/types/github"
 
 interface Props {
   params: {
@@ -24,7 +22,7 @@ export default async function IssueDetailsPage({ params }: Props) {
   const repoFullName = `${username}/${repo}`
   const issueNumber = parseInt(issueId)
 
-  const result: GetIssueResult = await getIssue({
+  const result = await getIssue({
     fullName: repoFullName,
     issueNumber,
   })
@@ -35,11 +33,13 @@ export default async function IssueDetailsPage({ params }: Props) {
         <div className="flex flex-col gap-4 max-w-2xl mx-auto items-center justify-center py-10">
           <h2 className="text-2xl font-bold text-red-500">Issue not found</h2>
           <p>
-            The issue you are looking for does not exist. It may have been deleted, or the link is incorrect.
+            The issue you are looking for does not exist. It may have been
+            deleted, or the link is incorrect.
           </p>
           <Link href={`/${username}/${repo}/issues`}>
             <Button variant="secondary">
-              <ChevronLeft className="h-4 w-4 mr-2" />Back to Issues
+              <ChevronLeft className="h-4 w-4 mr-2" />
+              Back to Issues
             </Button>
           </Link>
         </div>
@@ -52,11 +52,13 @@ export default async function IssueDetailsPage({ params }: Props) {
         <div className="flex flex-col gap-4 max-w-2xl mx-auto items-center justify-center py-10">
           <h2 className="text-2xl font-bold text-red-500">Access denied</h2>
           <p>
-            You do not have permission to view this issue. This may be a private or restricted repository.
+            You do not have permission to view this issue. This may be a private
+            or restricted repository.
           </p>
           <Link href={`/${username}/${repo}/issues`}>
             <Button variant="secondary">
-              <ChevronLeft className="h-4 w-4 mr-2" />Back to Issues
+              <ChevronLeft className="h-4 w-4 mr-2" />
+              Back to Issues
             </Button>
           </Link>
         </div>
@@ -67,16 +69,20 @@ export default async function IssueDetailsPage({ params }: Props) {
     return (
       <main className="container mx-auto p-4">
         <div className="flex flex-col gap-4 max-w-2xl mx-auto items-center justify-center py-10">
-          <h2 className="text-2xl font-bold text-red-500">Could not load this issue</h2>
+          <h2 className="text-2xl font-bold text-red-500">
+            Could not load this issue
+          </h2>
           <p>
-            Sorry, there was a problem loading this issue. Please try again later.
+            Sorry, there was a problem loading this issue. Please try again
+            later.
           </p>
-          {typeof result.error === "string"
-            ? (<p className="text-xs text-gray-500">{result.error}</p>)
-            : null}
+          {typeof result.error === "string" ? (
+            <p className="text-xs text-gray-500">{result.error}</p>
+          ) : null}
           <Link href={`/${username}/${repo}/issues`}>
             <Button variant="secondary">
-              <ChevronLeft className="h-4 w-4 mr-2" />Back to Issues
+              <ChevronLeft className="h-4 w-4 mr-2" />
+              Back to Issues
             </Button>
           </Link>
         </div>

--- a/app/[username]/[repo]/issues/[issueId]/page.tsx
+++ b/app/[username]/[repo]/issues/[issueId]/page.tsx
@@ -9,7 +9,7 @@ import IssueWorkflowRuns from "@/components/issues/IssueWorkflowRuns"
 import TableSkeleton from "@/components/layout/TableSkeleton"
 import { Button } from "@/components/ui/button"
 import { getIssue } from "@/lib/github/issues"
-import { GitHubIssue } from "@/lib/types/github"
+import { GetIssueResult } from "@/lib/types/github"
 
 interface Props {
   params: {
@@ -24,16 +24,68 @@ export default async function IssueDetailsPage({ params }: Props) {
   const repoFullName = `${username}/${repo}`
   const issueNumber = parseInt(issueId)
 
-  let issue: GitHubIssue
-  try {
-    issue = await getIssue({
-      fullName: repoFullName,
-      issueNumber,
-    })
-  } catch (error) {
-    console.error("Error fetching issue:", error)
-    notFound()
+  const result: GetIssueResult = await getIssue({
+    fullName: repoFullName,
+    issueNumber,
+  })
+
+  if (result.type === "not_found") {
+    return (
+      <main className="container mx-auto p-4">
+        <div className="flex flex-col gap-4 max-w-2xl mx-auto items-center justify-center py-10">
+          <h2 className="text-2xl font-bold text-red-500">Issue not found</h2>
+          <p>
+            The issue you are looking for does not exist. It may have been deleted, or the link is incorrect.
+          </p>
+          <Link href={`/${username}/${repo}/issues`}>
+            <Button variant="secondary">
+              <ChevronLeft className="h-4 w-4 mr-2" />Back to Issues
+            </Button>
+          </Link>
+        </div>
+      </main>
+    )
   }
+  if (result.type === "forbidden") {
+    return (
+      <main className="container mx-auto p-4">
+        <div className="flex flex-col gap-4 max-w-2xl mx-auto items-center justify-center py-10">
+          <h2 className="text-2xl font-bold text-red-500">Access denied</h2>
+          <p>
+            You do not have permission to view this issue. This may be a private or restricted repository.
+          </p>
+          <Link href={`/${username}/${repo}/issues`}>
+            <Button variant="secondary">
+              <ChevronLeft className="h-4 w-4 mr-2" />Back to Issues
+            </Button>
+          </Link>
+        </div>
+      </main>
+    )
+  }
+  if (result.type === "other_error") {
+    return (
+      <main className="container mx-auto p-4">
+        <div className="flex flex-col gap-4 max-w-2xl mx-auto items-center justify-center py-10">
+          <h2 className="text-2xl font-bold text-red-500">Could not load this issue</h2>
+          <p>
+            Sorry, there was a problem loading this issue. Please try again later.
+          </p>
+          {typeof result.error === "string"
+            ? (<p className="text-xs text-gray-500">{result.error}</p>)
+            : null}
+          <Link href={`/${username}/${repo}/issues`}>
+            <Button variant="secondary">
+              <ChevronLeft className="h-4 w-4 mr-2" />Back to Issues
+            </Button>
+          </Link>
+        </div>
+      </main>
+    )
+  }
+
+  // Success path: Render issue details
+  const issue = result.issue
 
   return (
     <main className="container mx-auto p-4">

--- a/lib/github/issues.ts
+++ b/lib/github/issues.ts
@@ -4,11 +4,11 @@ import getOctokit from "@/lib/github"
 import { getPRLinkedIssuesMap } from "@/lib/github/pullRequests"
 import { getPlanStatusForIssues } from "@/lib/neo4j/services/plan"
 import {
+  GetIssueResult,
   GitHubIssue,
   GitHubIssueComment,
   ListForRepoParams,
   RepoFullName,
-  GetIssueResult,
 } from "@/lib/types/github"
 
 export async function createIssue({
@@ -49,12 +49,17 @@ export async function getIssue({
       issue_number: issueNumber,
     })
     return { type: "success", issue: issue.data }
-  } catch (error: any) {
-    if (error?.status === 404) {
-      return { type: "not_found" }
+  } catch (error) {
+    if (!error) {
+      return { type: "other_error", error: "Unknown error" }
     }
-    if (error?.status === 403) {
-      return { type: "forbidden" }
+    if (typeof error === "object" && "status" in error) {
+      if (error.status === 404) {
+        return { type: "not_found" }
+      }
+      if (error.status === 403) {
+        return { type: "forbidden" }
+      }
     }
     return { type: "other_error", error }
   }

--- a/lib/types/github.ts
+++ b/lib/types/github.ts
@@ -28,7 +28,10 @@ export type SearchCodeItem = components["schemas"]["code-search-result-item"]
 // Repository-specific types
 export const repoFullNameSchema = z
   .string()
-  .regex(/^[^/]+\/[^/]+$/, '\''Repository name must be in the format "owner/repo"'\'')
+  .regex(
+    /^[^/]+\/[^/]+$/,
+    "'Repository name must be in the format 'owner/repo'"
+  )
   .transform((str) => {
     const [owner, repo] = str.split("/")
     return {

--- a/lib/types/github.ts
+++ b/lib/types/github.ts
@@ -28,7 +28,7 @@ export type SearchCodeItem = components["schemas"]["code-search-result-item"]
 // Repository-specific types
 export const repoFullNameSchema = z
   .string()
-  .regex(/^[^/]+\/[^/]+$/, 'Repository name must be in the format "owner/repo"')
+  .regex(/^[^/]+\/[^/]+$/, '\''Repository name must be in the format "owner/repo"'\'')
   .transform((str) => {
     const [owner, repo] = str.split("/")
     return {
@@ -71,3 +71,11 @@ export type RepoSelectorItem = {
   description: string | null
   updatedAt: string
 }
+
+// ---
+// Structured Result Type for getIssue
+export type GetIssueResult =
+  | { type: "success"; issue: GitHubIssue }
+  | { type: "not_found" }
+  | { type: "forbidden" }
+  | { type: "other_error"; error: unknown }


### PR DESCRIPTION
- Adds GetIssueResult union type to `lib/types/github.ts` for structured error responses from getIssue
- Refactors getIssue in `lib/github/issues.ts` to return success/forbidden/not_found/other_error types instead of raw exceptions
- Updates /[username]/[repo]/issues/[issueId]/page.tsx to display a user-friendly message depending on the error situation (issue not found, forbidden, other error)
- Ensures a clearer UX for common GitHub issue-retrieval failure scenarios

Fixes #<issue-number>: Return back better errors for missing issue, and show a more helpful UI when user cannot access a particular issue.

Closes #693