### PR TITLE
Add repo automation settings UI

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -72,6 +72,23 @@ export default async function SettingsPage() {
           </div>
         </CardContent>
       </Card>
+
+      <Card className="max-w-md">
+        <CardHeader>
+          <CardTitle>Repository Settings</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground mb-1">
+            Manage automation options for a specific repository.
+          </p>
+          <a
+            href={`/${user.login}`}
+            className="underline hover:text-blue-600"
+          >
+            Select a repository
+          </a>
+        </CardContent>
+      </Card>
     </main>
   )
 }

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -81,10 +81,7 @@ export default async function SettingsPage() {
           <p className="text-sm text-muted-foreground mb-1">
             Manage automation options for a specific repository.
           </p>
-          <a
-            href={`/${user.login}`}
-            className="underline hover:text-blue-600"
-          >
+          <a href={`/${user.login}`} className="underline hover:text-blue-600">
             Select a repository
           </a>
         </CardContent>

--- a/components/settings/RepoSettingsForm.tsx
+++ b/components/settings/RepoSettingsForm.tsx
@@ -5,7 +5,6 @@ import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
-import { Switch } from "@/components/ui/switch"
 import {
   Select,
   SelectContent,
@@ -13,6 +12,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
 import { setRepositorySettings as saveRepoSettings } from "@/lib/neo4j/services/repository"
 import { Environment, environmentEnum, RepoSettings } from "@/lib/types"
@@ -100,29 +100,42 @@ export default function RepoSettingsForm({
       <div className="mb-4 space-y-2">
         <p className="font-medium">Issue Automation (UI only)</p>
         <div className="flex items-center justify-between">
-          <Label htmlFor="auto-run-comment" className="text-sm text-muted-foreground">
+          <Label
+            htmlFor="auto-run-comment"
+            className="text-sm text-muted-foreground"
+          >
             Auto-run commentOnIssue
           </Label>
           <Switch
             id="auto-run-comment"
             checked={settings.autoRunCommentOnIssue ?? false}
-            onCheckedChange={(val) => handleChange("autoRunCommentOnIssue", val)}
+            onCheckedChange={(val) =>
+              handleChange("autoRunCommentOnIssue", val)
+            }
             disabled
           />
         </div>
         <div className="flex items-center justify-between">
-          <Label htmlFor="post-issue-comment" className="text-sm text-muted-foreground">
+          <Label
+            htmlFor="post-issue-comment"
+            className="text-sm text-muted-foreground"
+          >
             Post comment to GitHub
           </Label>
           <Switch
             id="post-issue-comment"
             checked={settings.autoPostIssueCommentToGitHub ?? false}
-            onCheckedChange={(val) => handleChange("autoPostIssueCommentToGitHub", val)}
+            onCheckedChange={(val) =>
+              handleChange("autoPostIssueCommentToGitHub", val)
+            }
             disabled
           />
         </div>
         <div className="flex items-center justify-between">
-          <Label htmlFor="auto-run-resolve" className="text-sm text-muted-foreground">
+          <Label
+            htmlFor="auto-run-resolve"
+            className="text-sm text-muted-foreground"
+          >
             Auto-run resolveIssue
           </Label>
           <Switch
@@ -143,7 +156,9 @@ export default function RepoSettingsForm({
             disabled
           />
         </div>
-        <p className="text-xs text-muted-foreground">Workflow automation settings are coming soon.</p>
+        <p className="text-xs text-muted-foreground">
+          Workflow automation settings are coming soon.
+        </p>
       </div>
       {errMsg && <div className="mb-2 text-red-600">{errMsg}</div>}
       {successMsg && <div className="mb-2 text-green-700">{successMsg}</div>}

--- a/components/settings/RepoSettingsForm.tsx
+++ b/components/settings/RepoSettingsForm.tsx
@@ -4,6 +4,8 @@ import { Loader2 } from "lucide-react"
 import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
 import {
   Select,
   SelectContent,
@@ -94,6 +96,54 @@ export default function RepoSettingsForm({
           rows={4}
           disabled={loading}
         />
+      </div>
+      <div className="mb-4 space-y-2">
+        <p className="font-medium">Issue Automation (UI only)</p>
+        <div className="flex items-center justify-between">
+          <Label htmlFor="auto-run-comment" className="text-sm text-muted-foreground">
+            Auto-run commentOnIssue
+          </Label>
+          <Switch
+            id="auto-run-comment"
+            checked={settings.autoRunCommentOnIssue ?? false}
+            onCheckedChange={(val) => handleChange("autoRunCommentOnIssue", val)}
+            disabled
+          />
+        </div>
+        <div className="flex items-center justify-between">
+          <Label htmlFor="post-issue-comment" className="text-sm text-muted-foreground">
+            Post comment to GitHub
+          </Label>
+          <Switch
+            id="post-issue-comment"
+            checked={settings.autoPostIssueCommentToGitHub ?? false}
+            onCheckedChange={(val) => handleChange("autoPostIssueCommentToGitHub", val)}
+            disabled
+          />
+        </div>
+        <div className="flex items-center justify-between">
+          <Label htmlFor="auto-run-resolve" className="text-sm text-muted-foreground">
+            Auto-run resolveIssue
+          </Label>
+          <Switch
+            id="auto-run-resolve"
+            checked={settings.autoRunResolveIssue ?? false}
+            onCheckedChange={(val) => handleChange("autoRunResolveIssue", val)}
+            disabled
+          />
+        </div>
+        <div className="flex items-center justify-between">
+          <Label htmlFor="post-pr" className="text-sm text-muted-foreground">
+            Create PR on GitHub
+          </Label>
+          <Switch
+            id="post-pr"
+            checked={settings.autoPostPrToGitHub ?? false}
+            onCheckedChange={(val) => handleChange("autoPostPrToGitHub", val)}
+            disabled
+          />
+        </div>
+        <p className="text-xs text-muted-foreground">Workflow automation settings are coming soon.</p>
       </div>
       {errMsg && <div className="mb-2 text-red-600">{errMsg}</div>}
       {successMsg && <div className="mb-2 text-green-700">{successMsg}</div>}

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -218,15 +218,21 @@ export const repoSettingsSchema = z.object({
   autoRunCommentOnIssue: z
     .boolean()
     .optional()
-    .describe("Automatically run the commentOnIssue workflow when a new issue is created"),
+    .describe(
+      "Automatically run the commentOnIssue workflow when a new issue is created"
+    ),
   autoPostIssueCommentToGitHub: z
     .boolean()
     .optional()
-    .describe("Post the generated comment back to GitHub after commentOnIssue completes"),
+    .describe(
+      "Post the generated comment back to GitHub after commentOnIssue completes"
+    ),
   autoRunResolveIssue: z
     .boolean()
     .optional()
-    .describe("Automatically run the resolveIssue workflow when a new issue is created"),
+    .describe(
+      "Automatically run the resolveIssue workflow when a new issue is created"
+    ),
   autoPostPrToGitHub: z
     .boolean()
     .optional()

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -215,6 +215,22 @@ export const repoSettingsSchema = z.object({
     .describe(
       "Setup commands to run when the repository is cloned. e.g. ['npm install', 'pip install -r requirements.txt']"
     ),
+  autoRunCommentOnIssue: z
+    .boolean()
+    .optional()
+    .describe("Automatically run the commentOnIssue workflow when a new issue is created"),
+  autoPostIssueCommentToGitHub: z
+    .boolean()
+    .optional()
+    .describe("Post the generated comment back to GitHub after commentOnIssue completes"),
+  autoRunResolveIssue: z
+    .boolean()
+    .optional()
+    .describe("Automatically run the resolveIssue workflow when a new issue is created"),
+  autoPostPrToGitHub: z
+    .boolean()
+    .optional()
+    .describe("Create a pull request on GitHub after resolveIssue completes"),
   lastUpdated: z.date().optional(),
 })
 export type RepoSettings = z.infer<typeof repoSettingsSchema>


### PR DESCRIPTION
## Summary
- extend repo settings schema with issue automation fields
- show disabled automation controls on Repo Settings page
- link to repository settings from user settings page

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b3952bc708333bfb7161dc0f2c2e9