### PR TITLE
Add LLM evaluations page

### DIFF
--- a/app/playground/evals/page.tsx
+++ b/app/playground/evals/page.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+
+export default function EvalsPage() {
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <div>
+        <h1 className="text-3xl font-bold mb-2">LLM Evaluations</h1>
+        <p className="text-muted-foreground">
+          This page will run LLM-as-Judge evaluations on various workflows.
+        </p>
+      </div>
+      <p>
+        Evaluations will score each workflow run on custom questions and return
+        structured results.
+      </p>
+      <Link href="/playground">
+        <Button variant="secondary" size="sm">
+          Back to Playground
+        </Button>
+      </Link>
+    </div>
+  )
+}

--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -21,6 +21,8 @@ import DockerodeExecCard from "@/components/playground/DockerodeExecCard"
 import RipgrepSearchCard from "@/components/playground/RipgrepSearchCard"
 import SWRDemoCard from "@/components/playground/SWRDemoCard"
 import WriteFileCard from "@/components/playground/WriteFileCard"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
 
 export default async function PlaygroundPage() {
   const session = await auth()
@@ -34,6 +36,13 @@ export default async function PlaygroundPage() {
       <DockerodeExecCard />
       <WriteFileCard />
       {token ? <OAuthTokenCard token={token} /> : null}
+      <div>
+        <Link href="/playground/evals">
+          <Button variant="outline" size="sm">
+            LLM Evaluations
+          </Button>
+        </Link>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add a placeholder `/playground/evals` page for future LLM-as-Judge experiments
- add a link from the main playground page to the new evals page

## Testing
- `pnpm lint` *(fails: warnings about import order)*
- `pnpm lint:prettier` *(fails: code style issues in unrelated files)*
- `pnpm lint:tsc`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686e1657ff4083338408f6180432e85e