### PR TITLE
Add SWR workflow events demo

### DIFF
--- a/app/api/workflow-runs/[workflowId]/events/route.ts
+++ b/app/api/workflow-runs/[workflowId]/events/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { getWorkflowRunMessages } from "@/lib/neo4j/services/workflow"
+
+export const dynamic = "force-dynamic"
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { workflowId: string } }
+) {
+  try {
+    const events = await getWorkflowRunMessages(params.workflowId)
+    return NextResponse.json({ events })
+  } catch (err) {
+    console.error("Error fetching workflow events:", err)
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 })
+  }
+}

--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -20,6 +20,7 @@ import AgentWorkflowClient from "@/components/playground/AgentWorkflowClient"
 import DockerodeExecCard from "@/components/playground/DockerodeExecCard"
 import RipgrepSearchCard from "@/components/playground/RipgrepSearchCard"
 import SWRDemoCard from "@/components/playground/SWRDemoCard"
+import WorkflowEventsSWRCard from "@/components/playground/WorkflowEventsSWRCard"
 import WriteFileCard from "@/components/playground/WriteFileCard"
 
 export default async function PlaygroundPage() {
@@ -30,6 +31,7 @@ export default async function PlaygroundPage() {
     <div className="space-y-8 px-4 py-8 md:container md:mx-auto">
       <AgentWorkflowClient defaultTools={DEFAULT_TOOLS} />
       <SWRDemoCard />
+      <WorkflowEventsSWRCard />
       <RipgrepSearchCard />
       <DockerodeExecCard />
       <WriteFileCard />

--- a/components/playground/WorkflowEventsSWRCard.tsx
+++ b/components/playground/WorkflowEventsSWRCard.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import { useState } from "react"
+import useSWR from "swr"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { AnyEvent } from "@/lib/types"
+
+const fetcher = async (url: string): Promise<AnyEvent[]> => {
+  const res = await fetch(url)
+  if (!res.ok) throw new Error("Failed to fetch")
+  const json = await res.json()
+  return json.events as AnyEvent[]
+}
+
+export default function WorkflowEventsSWRCard() {
+  const [workflowId, setWorkflowId] = useState("")
+
+  const { data, isValidating, mutate } = useSWR(
+    workflowId ? `/api/workflow-runs/${workflowId}/events` : null,
+    fetcher,
+    {
+      refreshInterval: workflowId ? 2000 : 0,
+      keepPreviousData: true,
+    }
+  )
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Workflow Events (SWR)</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex gap-2">
+          <Input
+            placeholder="Workflow ID"
+            value={workflowId}
+            onChange={(e) => setWorkflowId(e.target.value)}
+          />
+          <Button
+            size="sm"
+            onClick={() => mutate()}
+            disabled={!workflowId || isValidating}
+          >
+            Refresh
+          </Button>
+        </div>
+        <div className="space-y-1 text-sm">
+          {data?.map((e) => (
+            <div key={e.id} className="font-mono">
+              <span className="font-semibold mr-1">{e.type}</span>
+              {e.content ?? ""}
+            </div>
+          ))}
+          {!data && workflowId && <div>Loading…</div>}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
## Summary
- implement `/api/workflow-runs/[workflowId]/events` for retrieving run events
- add `WorkflowEventsSWRCard` for polling workflow events via SWR
- include the new card on the Playground page

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686f1494b5a483338c1025172731b8d7