### PR TITLE
Add local Task storage with CRUD

### DIFF
--- a/lib/neo4j/labels.ts
+++ b/lib/neo4j/labels.ts
@@ -6,6 +6,7 @@ export const Labels = {
   Event: "Event",
   Message: "Message",
   Plan: "Plan",
+  Task: "Task",
   WorkflowRun: "WorkflowRun",
 } as const
 

--- a/lib/neo4j/repositories/task.ts
+++ b/lib/neo4j/repositories/task.ts
@@ -1,0 +1,86 @@
+import { Integer, ManagedTransaction, Node } from "neo4j-driver"
+
+import { Task, taskSchema } from "@/lib/types/db/neo4j"
+
+export async function create(
+  tx: ManagedTransaction,
+  task: Omit<Task, "createdAt" | "githubIssueNumber"> & {
+    githubIssueNumber?: Integer
+  }
+): Promise<Task> {
+  const result = await tx.run<{ t: Node<Integer, Task, "Task"> }>(
+    `CREATE (t:Task {id: $id, repoFullName: $repoFullName, createdBy: $createdBy, createdAt: datetime(),
+      title: $title, body: $body, syncedToGithub: $syncedToGithub, githubIssueNumber: $githubIssueNumber}) RETURN t`,
+    {
+      id: task.id,
+      repoFullName: task.repoFullName,
+      createdBy: task.createdBy,
+      title: task.title ?? null,
+      body: task.body ?? null,
+      syncedToGithub: task.syncedToGithub,
+      githubIssueNumber: task.githubIssueNumber ?? null,
+    }
+  )
+  return taskSchema.parse(result.records[0].get("t").properties)
+}
+
+export async function get(
+  tx: ManagedTransaction,
+  id: string
+): Promise<Task | null> {
+  const result = await tx.run<{ t: Node<Integer, Task, "Task"> }>(
+    `MATCH (t:Task {id: $id}) RETURN t LIMIT 1`,
+    { id }
+  )
+  const raw = result.records[0]?.get("t")?.properties
+  return raw ? taskSchema.parse(raw) : null
+}
+
+export async function listForRepo(
+  tx: ManagedTransaction,
+  repoFullName: string
+): Promise<Task[]> {
+  const result = await tx.run<{ t: Node<Integer, Task, "Task"> }>(
+    `MATCH (t:Task {repoFullName: $repoFullName}) RETURN t ORDER BY t.createdAt DESC`,
+    { repoFullName }
+  )
+  return result.records.map((r) => taskSchema.parse(r.get("t").properties))
+}
+
+export async function update(
+  tx: ManagedTransaction,
+  id: string,
+  updates: {
+    title?: string | null
+    body?: string | null
+    syncedToGithub?: boolean
+    githubIssueNumber?: Integer | null
+  }
+): Promise<Task> {
+  const props: Record<string, unknown> = {}
+  if ("title" in updates) props.title = updates.title
+  if ("body" in updates) props.body = updates.body
+  if ("syncedToGithub" in updates) props.syncedToGithub = updates.syncedToGithub
+  if ("githubIssueNumber" in updates)
+    props.githubIssueNumber = updates.githubIssueNumber
+  const result = await tx.run<{ t: Node<Integer, Task, "Task"> }>(
+    `MATCH (t:Task {id: $id}) SET t += $props RETURN t`,
+    { id, props }
+  )
+  return taskSchema.parse(result.records[0].get("t").properties)
+}
+
+export async function remove(
+  tx: ManagedTransaction,
+  id: string
+): Promise<void> {
+  await tx.run(`MATCH (t:Task {id: $id}) DETACH DELETE t`, { id })
+}
+
+export const toAppTask = (db: Task): import("@/lib/types").Task => {
+  return {
+    ...db,
+    createdAt: db.createdAt.toStandardDate(),
+    githubIssueNumber: db.githubIssueNumber?.toNumber(),
+  }
+}

--- a/lib/neo4j/services/task.ts
+++ b/lib/neo4j/services/task.ts
@@ -1,0 +1,115 @@
+"use server"
+
+import { v4 as uuidv4 } from "uuid"
+
+import { n4j } from "@/lib/neo4j/client"
+import * as repo from "@/lib/neo4j/repositories/task"
+import { Task as AppTask } from "@/lib/types"
+
+export const toAppTask = repo.toAppTask
+
+export async function createTask({
+  id = uuidv4(),
+  repoFullName,
+  title,
+  body,
+  createdBy,
+}: {
+  id?: string
+  repoFullName: string
+  title?: string
+  body?: string
+  createdBy: string
+}): Promise<AppTask> {
+  const session = await n4j.getSession()
+  try {
+    const db = await session.executeWrite((tx) =>
+      repo.create(tx, {
+        id,
+        repoFullName,
+        title,
+        body,
+        createdBy,
+        syncedToGithub: false,
+      })
+    )
+    return toAppTask(db)
+  } finally {
+    await session.close()
+  }
+}
+
+export async function getTask(id: string): Promise<AppTask | null> {
+  const session = await n4j.getSession()
+  try {
+    const db = await session.executeRead((tx) => repo.get(tx, id))
+    return db ? toAppTask(db) : null
+  } finally {
+    await session.close()
+  }
+}
+
+export async function listTasksForRepo(
+  repoFullName: string
+): Promise<AppTask[]> {
+  const session = await n4j.getSession()
+  try {
+    const db = await session.executeRead((tx) =>
+      repo.listForRepo(tx, repoFullName)
+    )
+    return db.map(toAppTask)
+  } finally {
+    await session.close()
+  }
+}
+
+export async function updateTask({
+  id,
+  username,
+  title,
+  body,
+  syncedToGithub,
+  githubIssueNumber,
+}: {
+  id: string
+  username: string
+  title?: string | null
+  body?: string | null
+  syncedToGithub?: boolean
+  githubIssueNumber?: number | null
+}): Promise<AppTask> {
+  const session = await n4j.getSession()
+  try {
+    const existing = await session.executeRead((tx) => repo.get(tx, id))
+    if (!existing) throw new Error("Task not found")
+    if (existing.createdBy !== username)
+      throw new Error("Not authorized to edit task")
+    const db = await session.executeWrite((tx) =>
+      repo.update(tx, id, {
+        title,
+        body,
+        syncedToGithub,
+        githubIssueNumber:
+          githubIssueNumber !== undefined && githubIssueNumber !== null
+            ? (githubIssueNumber as any)
+            : null,
+      })
+    )
+    return toAppTask(db)
+  } finally {
+    await session.close()
+  }
+}
+
+export async function deleteTask(id: string, username: string): Promise<void> {
+  const session = await n4j.getSession()
+  try {
+    const existing = await session.executeRead((tx) => repo.get(tx, id))
+    if (!existing) return
+    if (existing.createdBy !== username)
+      throw new Error("Not authorized to delete task")
+    await session.executeWrite((tx) => repo.remove(tx, id))
+  } finally {
+    await session.close()
+  }
+}

--- a/lib/types/db/neo4j.ts
+++ b/lib/types/db/neo4j.ts
@@ -6,6 +6,7 @@ import {
   issueSchema as appIssueSchema,
   llmResponseSchema as appLLMResponseSchema,
   planSchema as appPlanSchema,
+  taskSchema as appTaskSchema,
   repoSettingsSchema as appRepoSettingsSchema,
   reviewCommentSchema as appReviewCommentSchema,
   settingsSchema as appSettingsSchema,
@@ -53,6 +54,13 @@ export const planSchema = appPlanSchema.merge(
   z.object({
     version: z.instanceof(Integer),
     createdAt: z.instanceof(DateTime),
+  })
+)
+
+export const taskSchema = appTaskSchema.merge(
+  z.object({
+    createdAt: z.instanceof(DateTime),
+    githubIssueNumber: z.instanceof(Integer).optional(),
   })
 )
 
@@ -139,6 +147,7 @@ export type LLMResponse = z.infer<typeof llmResponseSchema>
 export type LLMResponseWithPlan = z.infer<typeof llmResponseWithPlanSchema>
 export type MessageEvent = z.infer<typeof messageEventSchema>
 export type Plan = z.infer<typeof planSchema>
+export type Task = z.infer<typeof taskSchema>
 export type ReviewComment = z.infer<typeof reviewCommentSchema>
 export type StatusEvent = z.infer<typeof statusEventSchema>
 export type SystemPrompt = z.infer<typeof systemPromptSchema>

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -64,6 +64,18 @@ export const planMetaSchema = planSchema.omit({
   createdAt: true,
 })
 
+// Tasks stored locally per repo
+export const taskSchema = z.object({
+  id: z.string(),
+  repoFullName: z.string(),
+  createdBy: z.string(),
+  createdAt: z.date(),
+  title: z.string().optional(),
+  body: z.string().optional(),
+  syncedToGithub: z.boolean(),
+  githubIssueNumber: z.number().optional(),
+})
+
 // Events
 const eventTypes = z.enum([
   "error",
@@ -288,6 +300,7 @@ export type StatusEvent = z.infer<typeof statusEventSchema>
 export type SystemPrompt = z.infer<typeof systemPromptSchema>
 export type ToolCall = z.infer<typeof toolCallSchema>
 export type ToolCallResult = z.infer<typeof toolCallResultSchema>
+export type Task = z.infer<typeof taskSchema>
 export type UserMessage = z.infer<typeof userMessageSchema>
 export type WorkflowRun = z.infer<typeof workflowRunSchema>
 export type WorkflowRunState = z.infer<typeof workflowRunStateSchema>


### PR DESCRIPTION
## Summary
- add `Task` node label
- define `taskSchema` for local tasks in types and Neo4j models
- add repository helpers for creating, updating, listing and deleting tasks
- add service layer wrappers including authorization checks

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f148526208333b45375b442fe056b