### PR TITLE
Add workflow builder info card

### DIFF
--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -23,6 +23,12 @@ import SWRDemoCard from "@/components/playground/SWRDemoCard"
 import WriteFileCard from "@/components/playground/WriteFileCard"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
 
 export default async function PlaygroundPage() {
   const session = await auth()
@@ -30,6 +36,29 @@ export default async function PlaygroundPage() {
 
   return (
     <div className="space-y-8 px-4 py-8 md:container md:mx-auto">
+      <Card className="max-w-2xl">
+        <CardHeader>
+          <CardTitle>Custom Workflow Builder</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm text-muted-foreground">
+          <p>
+            The playground lets you manually connect tools with an agent and run
+            the workflow inside a container environment. Use it to experiment
+            with different prompts and tool selections.
+          </p>
+          <ol className="list-decimal space-y-1 pl-4">
+            <li>Select a repository, branch, and issue.</li>
+            <li>Edit the system prompt and user messages.</li>
+            <li>Choose which tools the agent can access.</li>
+            <li>Configure or launch a container environment.</li>
+            <li>Start the run to see real-time progress and results.</li>
+          </ol>
+          <p>
+            When the run completes, review the output and decide whether to
+            publish the generated content to GitHub.
+          </p>
+        </CardContent>
+      </Card>
       <AgentWorkflowClient defaultTools={DEFAULT_TOOLS} />
       <SWRDemoCard />
       <RipgrepSearchCard />


### PR DESCRIPTION
## Summary
- document the custom workflow builder on the `/playground` page

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686f1a6ed8b08333953be1f009b40ccb