### PR TITLE
Add live workflow run event updates

### DIFF
--- a/app/workflow-runs/[traceId]/page.tsx
+++ b/app/workflow-runs/[traceId]/page.tsx
@@ -4,54 +4,10 @@ import { notFound } from "next/navigation"
 
 import BaseGitHubItemCard from "@/components/github/BaseGitHubItemCard"
 import { Button } from "@/components/ui/button"
-import {
-  ErrorEvent,
-  LLMResponseEvent,
-  StatusUpdate,
-  SystemPromptEvent,
-  ToolCallEvent,
-  ToolCallResultEvent,
-  UserMessageEvent,
-} from "@/components/workflow-runs/events"
+import WorkflowRunEventsFeed from "@/components/workflow-runs/WorkflowRunEventsFeed"
 import { getIssue } from "@/lib/github/issues"
 import { getWorkflowRunWithDetails } from "@/lib/neo4j/services/workflow"
-import { AnyEvent, Issue } from "@/lib/types"
 import { GetIssueResult } from "@/lib/types/github"
-
-function EventRenderer({
-  event,
-  issue,
-}: {
-  event: AnyEvent
-  issue?: Issue
-}): React.ReactNode {
-  // Basic event
-
-  switch (event.type) {
-    case "status":
-      return <StatusUpdate event={event} />
-    case "systemPrompt":
-      return <SystemPromptEvent event={event} />
-    case "userMessage":
-      return <UserMessageEvent event={event} />
-    case "llmResponse":
-    case "llmResponseWithPlan":
-      return <LLMResponseEvent event={event} issue={issue} />
-    case "toolCall":
-      return <ToolCallEvent event={event} />
-    case "toolCallResult":
-      return <ToolCallResultEvent event={event} />
-    case "workflowState":
-      return <StatusUpdate event={event} />
-    case "reviewComment":
-      return <UserMessageEvent event={event} />
-    case "error":
-      return <ErrorEvent event={event} />
-    default:
-      console.error(`Unrecognized event: ${JSON.stringify(event)}`)
-      return null
-  }
-}
 
 export default async function WorkflowRunDetailPage({
   params,
@@ -129,13 +85,11 @@ export default async function WorkflowRunDetailPage({
         {events && (
           <div className="space-y-3">
             <h2 className="text-lg font-semibold">Timeline</h2>
-            <div className="bg-card border rounded-lg overflow-hidden">
-              {events.map((event) => (
-                <div key={event.id} className="p-3 sm:p-4">
-                  <EventRenderer event={event} issue={issue} />
-                </div>
-              ))}
-            </div>
+            <WorkflowRunEventsFeed
+              workflowId={traceId}
+              initialEvents={events}
+              issue={issue}
+            />
           </div>
         )}
       </div>

--- a/components/workflow-runs/WorkflowRunEventsFeed.tsx
+++ b/components/workflow-runs/WorkflowRunEventsFeed.tsx
@@ -61,7 +61,6 @@ export default function WorkflowRunEventsFeed({
   const { data } = useSWR(`/api/workflow-runs/${workflowId}/events`, fetcher, {
     refreshInterval: 1000,
     fallbackData: initialEvents,
-    keepPreviousData: true,
   })
 
   if (!data) return null

--- a/components/workflow-runs/WorkflowRunEventsFeed.tsx
+++ b/components/workflow-runs/WorkflowRunEventsFeed.tsx
@@ -2,7 +2,6 @@
 
 import useSWR from "swr"
 
-import { AnyEvent, Issue } from "@/lib/types"
 import {
   ErrorEvent,
   LLMResponseEvent,
@@ -12,6 +11,7 @@ import {
   ToolCallResultEvent,
   UserMessageEvent,
 } from "@/components/workflow-runs/events"
+import { AnyEvent, Issue } from "@/lib/types"
 
 interface Props {
   workflowId: string

--- a/components/workflow-runs/WorkflowRunEventsFeed.tsx
+++ b/components/workflow-runs/WorkflowRunEventsFeed.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import useSWR from "swr"
+
+import { AnyEvent, Issue } from "@/lib/types"
+import {
+  ErrorEvent,
+  LLMResponseEvent,
+  StatusUpdate,
+  SystemPromptEvent,
+  ToolCallEvent,
+  ToolCallResultEvent,
+  UserMessageEvent,
+} from "@/components/workflow-runs/events"
+
+interface Props {
+  workflowId: string
+  initialEvents: AnyEvent[]
+  issue?: Issue
+}
+
+const fetcher = async (url: string): Promise<AnyEvent[]> => {
+  const res = await fetch(url)
+  if (!res.ok) throw new Error("Failed to fetch")
+  const json = await res.json()
+  return json.events as AnyEvent[]
+}
+
+function EventRenderer({ event, issue }: { event: AnyEvent; issue?: Issue }) {
+  switch (event.type) {
+    case "status":
+      return <StatusUpdate event={event} />
+    case "systemPrompt":
+      return <SystemPromptEvent event={event} />
+    case "userMessage":
+      return <UserMessageEvent event={event} />
+    case "llmResponse":
+    case "llmResponseWithPlan":
+      return <LLMResponseEvent event={event} issue={issue} />
+    case "toolCall":
+      return <ToolCallEvent event={event} />
+    case "toolCallResult":
+      return <ToolCallResultEvent event={event} />
+    case "workflowState":
+      return <StatusUpdate event={event} />
+    case "reviewComment":
+      return <UserMessageEvent event={event} />
+    case "error":
+      return <ErrorEvent event={event} />
+    default:
+      console.error(`Unrecognized event: ${JSON.stringify(event)}`)
+      return null
+  }
+}
+
+export default function WorkflowRunEventsFeed({
+  workflowId,
+  initialEvents,
+  issue,
+}: Props) {
+  const { data } = useSWR(`/api/workflow-runs/${workflowId}/events`, fetcher, {
+    refreshInterval: 1000,
+    fallbackData: initialEvents,
+    keepPreviousData: true,
+  })
+
+  if (!data) return null
+
+  return (
+    <div className="bg-card border rounded-lg overflow-hidden">
+      {data.map((event) => (
+        <div key={event.id} className="p-3 sm:p-4">
+          <EventRenderer event={event} issue={issue} />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/components/workflow-runs/events/ErrorEvent.tsx
+++ b/components/workflow-runs/events/ErrorEvent.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { XCircle } from "lucide-react"
 
 import { CollapsibleContent } from "@/components/ui/collapsible-content"

--- a/components/workflow-runs/events/LLMResponseEvent.tsx
+++ b/components/workflow-runs/events/LLMResponseEvent.tsx
@@ -20,7 +20,7 @@ interface Props {
   issue?: Issue
 }
 
-export async function LLMResponseEvent({ event, issue }: Props) {
+export function LLMResponseEvent({ event, issue }: Props) {
   const headerContent = (
     <div className="flex items-center justify-between w-full">
       <div className="flex items-center gap-2">

--- a/components/workflow-runs/events/LLMResponseEvent.tsx
+++ b/components/workflow-runs/events/LLMResponseEvent.tsx
@@ -1,4 +1,4 @@
-"use server"
+"use client"
 
 import { ExternalLink } from "lucide-react"
 import Link from "next/link"

--- a/components/workflow-runs/events/StatusUpdate.tsx
+++ b/components/workflow-runs/events/StatusUpdate.tsx
@@ -9,7 +9,7 @@ interface Props {
   event: StatusEvent | WorkflowStateEvent
 }
 
-export async function StatusUpdate({ event }: Props) {
+export function StatusUpdate({ event }: Props) {
   let displayText: string | undefined
   if (event.type === "status") {
     displayText = event.content

--- a/components/workflow-runs/events/StatusUpdate.tsx
+++ b/components/workflow-runs/events/StatusUpdate.tsx
@@ -1,4 +1,4 @@
-"use server"
+"use client"
 
 import { CheckCircle2 } from "lucide-react"
 

--- a/components/workflow-runs/events/SystemPromptEvent.tsx
+++ b/components/workflow-runs/events/SystemPromptEvent.tsx
@@ -1,4 +1,4 @@
-"use server"
+"use client"
 
 import ReactMarkdown from "react-markdown"
 

--- a/components/workflow-runs/events/SystemPromptEvent.tsx
+++ b/components/workflow-runs/events/SystemPromptEvent.tsx
@@ -10,7 +10,7 @@ export interface Props {
   event: SystemPrompt
 }
 
-export async function SystemPromptEvent({ event }: Props) {
+export function SystemPromptEvent({ event }: Props) {
   const headerContent = (
     <>
       <div className="text-xs font-medium text-blue-500 dark:text-blue-400">

--- a/components/workflow-runs/events/ToolCallEvent.tsx
+++ b/components/workflow-runs/events/ToolCallEvent.tsx
@@ -1,4 +1,4 @@
-"use server"
+"use client"
 
 import { Code2 } from "lucide-react"
 

--- a/components/workflow-runs/events/ToolCallEvent.tsx
+++ b/components/workflow-runs/events/ToolCallEvent.tsx
@@ -9,7 +9,7 @@ export interface Props {
   event: ToolCall
 }
 
-export async function ToolCallEvent({ event }: Props) {
+export function ToolCallEvent({ event }: Props) {
   const args = JSON.parse(event.args)
 
   return (

--- a/components/workflow-runs/events/ToolCallResultEvent.tsx
+++ b/components/workflow-runs/events/ToolCallResultEvent.tsx
@@ -10,7 +10,7 @@ export interface Props {
   event: ToolCallResult
 }
 
-export async function ToolCallResultEvent({ event }: Props) {
+export function ToolCallResultEvent({ event }: Props) {
   const headerContent = (
     <div className="flex items-center justify-between w-full">
       <div className="flex items-center gap-2">

--- a/components/workflow-runs/events/ToolCallResultEvent.tsx
+++ b/components/workflow-runs/events/ToolCallResultEvent.tsx
@@ -1,4 +1,4 @@
-"use server"
+"use client"
 
 import { ArrowDownLeft } from "lucide-react"
 

--- a/components/workflow-runs/events/UserMessageEvent.tsx
+++ b/components/workflow-runs/events/UserMessageEvent.tsx
@@ -1,4 +1,4 @@
-"use server"
+"use client"
 
 import ReactMarkdown from "react-markdown"
 

--- a/components/workflow-runs/events/UserMessageEvent.tsx
+++ b/components/workflow-runs/events/UserMessageEvent.tsx
@@ -10,7 +10,7 @@ export interface Props {
   event: UserMessage | ReviewComment
 }
 
-export async function UserMessageEvent({ event }: Props) {
+export function UserMessageEvent({ event }: Props) {
   const headerContent = (
     <>
       <div className="text-xs font-medium text-muted-foreground">

--- a/lib/neo4j/repositories/event.ts
+++ b/lib/neo4j/repositories/event.ts
@@ -308,16 +308,19 @@ export async function toAppEvent(
   workflowId: string
 ): Promise<appAnyEvent> {
   if (dbEvent.type === "llmResponse" && isLLMResponseWithPlan(dbEvent)) {
+    // Destructure to exclude plan-specific properties from the spread
+    const { version, status, editMessage, createdAt, ...restDbEvent } = dbEvent
+
     return {
-      ...dbEvent,
-      createdAt: dbEvent.createdAt.toStandardDate(),
+      ...restDbEvent,
+      createdAt: createdAt.toStandardDate(),
       type: "llmResponseWithPlan",
       workflowId,
       plan: {
         id: dbEvent.id,
-        status: dbEvent.status,
-        version: dbEvent.version.toNumber(),
-        editMessage: dbEvent.editMessage,
+        status: status,
+        version: version.toNumber(),
+        editMessage: editMessage,
       },
     }
   }

--- a/lib/neo4j/services/workflow.ts
+++ b/lib/neo4j/services/workflow.ts
@@ -93,7 +93,9 @@ export async function initializeWorkflowRun({
 export async function listWorkflowRuns(issue?: {
   repoFullName: string
   issueNumber: number
-}): Promise<(AppWorkflowRun & { state: WorkflowRunState; issue?: AppIssue })[]> {
+}): Promise<
+  (AppWorkflowRun & { state: WorkflowRunState; issue?: AppIssue })[]
+> {
   const session = await n4j.getSession()
   try {
     const result = await session.executeRead(async (tx) => {


### PR DESCRIPTION
## Summary
- convert workflow event components to client components
- create `WorkflowRunEventsFeed` component using SWR
- use `WorkflowRunEventsFeed` on the workflow run detail page to poll for events

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686f4facbda08333bcd8662213e3ebd3