### PR TITLE
Update workflow run event polling

### DIFF
--- a/app/api/workflow-runs/[workflowId]/events/route.ts
+++ b/app/api/workflow-runs/[workflowId]/events/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server"
 
-import { getWorkflowRunMessages } from "@/lib/neo4j/services/workflow"
+import { getWorkflowRunEvents } from "@/lib/neo4j/services/workflow"
 
 export const dynamic = "force-dynamic"
 
@@ -9,7 +9,7 @@ export async function GET(
   { params }: { params: { workflowId: string } }
 ) {
   try {
-    const events = await getWorkflowRunMessages(params.workflowId)
+    const events = await getWorkflowRunEvents(params.workflowId)
     return NextResponse.json({ events })
   } catch (err) {
     console.error("Error fetching workflow events:", err)

--- a/lib/neo4j/repositories/event.ts
+++ b/lib/neo4j/repositories/event.ts
@@ -303,6 +303,23 @@ export async function getMessagesForWorkflowRun(
   )
 }
 
+export async function getEventsForWorkflowRun(
+  tx: ManagedTransaction,
+  workflowRunId: string
+): Promise<AnyEvent[]> {
+  const result = await tx.run<{ e: Node<Integer, AnyEvent, "Event"> }>(
+    `
+    MATCH (w:WorkflowRun {id: $workflowRunId})-[:STARTS_WITH|NEXT*]->(e:Event)
+    RETURN e
+    ORDER BY e.createdAt ASC
+    `,
+    { workflowRunId }
+  )
+  return result.records.map((record) =>
+    anyEventSchema.parse(record.get("e").properties)
+  )
+}
+
 export async function toAppEvent(
   dbEvent: AnyEvent,
   workflowId: string

--- a/lib/neo4j/services/workflow.ts
+++ b/lib/neo4j/services/workflow.ts
@@ -2,10 +2,10 @@ import { int } from "neo4j-driver"
 
 import { n4j } from "@/lib/neo4j/client"
 import {
+  getEventsForWorkflowRun,
+  getMessagesForWorkflowRun,
   toAppEvent,
   toAppMessageEvent,
-  getMessagesForWorkflowRun,
-  getEventsForWorkflowRun,
 } from "@/lib/neo4j/repositories/event"
 import { toAppIssue } from "@/lib/neo4j/repositories/issue"
 import {


### PR DESCRIPTION
## Summary
- add DB helper to fetch all events for a workflow run
- expose new service wrapper `getWorkflowRunEvents`
- switch API route to return all events

## Testing
- `pnpm test` *(fails: jest not found)*
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f77b9b26483339c8c3ccb9e341f9f