### PR TITLE
Add OpenAI agent playground

### DIFF
--- a/app/playground/agent/page.tsx
+++ b/app/playground/agent/page.tsx
@@ -1,0 +1,19 @@
+"use server"
+
+import Link from "next/link"
+
+import AgentCompletionCard from "@/components/playground/AgentCompletionCard"
+import { Button } from "@/components/ui/button"
+
+export default function AgentPlaygroundPage() {
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <AgentCompletionCard />
+      <Link href="/playground">
+        <Button variant="secondary" size="sm">
+          Back to Playground
+        </Button>
+      </Link>
+    </div>
+  )
+}

--- a/components/playground/AgentCompletionCard.tsx
+++ b/components/playground/AgentCompletionCard.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import { useState, useTransition } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Textarea } from "@/components/ui/textarea"
+import { getAgentCompletion } from "@/lib/actions/openaiAgent"
+
+export default function AgentCompletionCard() {
+  const [systemPrompt, setSystemPrompt] = useState("")
+  const [userPrompt, setUserPrompt] = useState("")
+  const [response, setResponse] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  const handleSubmit = () => {
+    setResponse(null)
+    startTransition(async () => {
+      const res = await getAgentCompletion({
+        systemPrompt,
+        userPrompt,
+      })
+      setResponse(res)
+    })
+  }
+
+  return (
+    <Card className="max-w-2xl w-full mx-auto">
+      <CardHeader>
+        <CardTitle>OpenAI Agent Completion</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div>
+          <p className="mb-2 text-sm font-medium">System Prompt</p>
+          <Textarea
+            value={systemPrompt}
+            onChange={(e) => setSystemPrompt(e.target.value)}
+            rows={12}
+            placeholder="Enter system prompt"
+          />
+        </div>
+        <div>
+          <p className="mb-2 text-sm font-medium">User Prompt</p>
+          <Textarea
+            value={userPrompt}
+            onChange={(e) => setUserPrompt(e.target.value)}
+            rows={4}
+            placeholder="Enter user prompt"
+          />
+        </div>
+        <Button onClick={handleSubmit} disabled={isPending} type="button">
+          {isPending ? "Sending..." : "Send"}
+        </Button>
+        {response !== null && (
+          <Textarea readOnly value={response} rows={10} className="mt-4" />
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/lib/actions/openaiAgent.ts
+++ b/lib/actions/openaiAgent.ts
@@ -1,0 +1,24 @@
+"use server"
+
+import { ChatCompletionMessageParam } from "openai/resources/chat/completions"
+
+import { openai } from "@/lib/openai"
+
+export async function getAgentCompletion({
+  systemPrompt,
+  userPrompt,
+}: {
+  systemPrompt: string
+  userPrompt: string
+}): Promise<string> {
+  const messages: ChatCompletionMessageParam[] = [
+    { role: "system", content: systemPrompt },
+    { role: "user", content: userPrompt },
+  ]
+
+  const res = await openai.chat.completions.create({
+    model: "gpt-4o",
+    messages,
+  })
+  return res.choices[0]?.message?.content || ""
+}


### PR DESCRIPTION
## Summary
- add server action for simple OpenAI agent completion calls
- add `AgentCompletionCard` UI component
- expose new playground page at `/playground/agent`

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f8c3e0cbc833387cdb914936dd8a2