### PR TITLE
Add plan evaluation playground

### DIFF
--- a/app/api/playground/evals/route.ts
+++ b/app/api/playground/evals/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { evaluatePlan } from "@/lib/actions/evaluatePlan"
+import { PlanEvaluationRequestSchema } from "@/lib/types/evaluation"
+
+export async function POST(req: NextRequest) {
+  try {
+    const { plan } = PlanEvaluationRequestSchema.parse(await req.json())
+    const result = await evaluatePlan(plan)
+    return NextResponse.json({ result })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Failed to evaluate"
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+}

--- a/app/playground/evals/page.tsx
+++ b/app/playground/evals/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link"
+import PlanEvalCard from "@/components/playground/PlanEvalCard"
 import { Button } from "@/components/ui/button"
 
 export default function EvalsPage() {
@@ -14,6 +15,7 @@ export default function EvalsPage() {
         Evaluations will score each workflow run on custom questions and return
         structured results.
       </p>
+      <PlanEvalCard />
       <Link href="/playground">
         <Button variant="secondary" size="sm">
           Back to Playground

--- a/components/playground/PlanEvalCard.tsx
+++ b/components/playground/PlanEvalCard.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Textarea } from "@/components/ui/textarea"
+import { PlanEvaluationSchema, PlanEvaluationResult } from "@/lib/types/evaluation"
+
+export default function PlanEvalCard() {
+  const [plan, setPlan] = useState("")
+  const [result, setResult] = useState<PlanEvaluationResult | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  const handleRun = async () => {
+    setError(null)
+    startTransition(async () => {
+      try {
+        const res = await fetch("/api/playground/evals", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ plan }),
+        })
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}))
+          throw new Error(data.error || "Request failed")
+        }
+        const data = await res.json()
+        const parsed = PlanEvaluationSchema.safeParse(data.result)
+        if (!parsed.success) {
+          throw new Error("Invalid response from server")
+        }
+        setResult(parsed.data)
+      } catch (e: unknown) {
+        setResult(null)
+        setError(String(e))
+      }
+    })
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Plan Evaluation</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Textarea
+          value={plan}
+          onChange={(e) => setPlan(e.target.value)}
+          placeholder="Paste plan here..."
+          rows={10}
+          disabled={isPending}
+        />
+        <Button onClick={handleRun} disabled={isPending || !plan.trim()}>
+          {isPending ? "Evaluating..." : "Run Evaluation"}
+        </Button>
+        {result && (
+          <div className="space-y-1 text-sm">
+            <div>{result.noTypeCasting ? "✅" : "❌"}&nbsp;No Type Casting</div>
+            <div>{result.noAnyTypes ? "✅" : "❌"}&nbsp;No <code>any</code> Types</div>
+            <div>
+              {result.noSingleItemHelper ? "✅" : "❌"}&nbsp;No One-off Conversion Helper
+            </div>
+          </div>
+        )}
+        {error && <div className="text-destructive text-sm">{error}</div>}
+      </CardContent>
+    </Card>
+  )
+}

--- a/lib/actions/evaluatePlan.ts
+++ b/lib/actions/evaluatePlan.ts
@@ -1,0 +1,47 @@
+"use server"
+
+import OpenAI from "openai"
+import { ChatCompletionMessageParam } from "openai/resources/chat/completions"
+
+import { getUserOpenAIApiKey } from "@/lib/neo4j/services/user"
+import {
+  PlanEvaluationResult,
+  PlanEvaluationSchema,
+} from "@/lib/types/evaluation"
+
+const SYSTEM_PROMPT = `You are a code quality evaluation agent. Your job is to inspect a TypeScript implementation plan and determine if it avoids several common problems.
+Return only a JSON object matching this TypeScript interface:
+{
+  noTypeCasting: boolean;    // true if the plan does not use TypeScript type casting like 'as SomeType'
+  noAnyTypes: boolean;       // true if the plan does not introduce or use the 'any' type
+  noSingleItemHelper: boolean; // true if the plan does not use a conversion helper for just a single item when a built-in method would work
+}
+If unsure about a criterion, return false for that field.`
+
+export async function evaluatePlan(plan: string): Promise<PlanEvaluationResult> {
+  const apiKey = await getUserOpenAIApiKey()
+  if (!apiKey) {
+    throw new Error("Missing OpenAI API key")
+  }
+
+  const openai = new OpenAI({ apiKey })
+
+  const messages: ChatCompletionMessageParam[] = [
+    { role: "system", content: SYSTEM_PROMPT },
+    { role: "user", content: plan },
+  ]
+
+  const resp = await openai.chat.completions.create({
+    model: "gpt-4.1",
+    messages,
+    response_format: { type: "json_object" },
+  })
+
+  const content = resp.choices[0]?.message?.content || "{}"
+
+  const parsed = PlanEvaluationSchema.safeParse(JSON.parse(content))
+  if (!parsed.success) {
+    throw new Error(`Invalid evaluation result: ${parsed.error}`)
+  }
+  return parsed.data
+}

--- a/lib/types/evaluation.ts
+++ b/lib/types/evaluation.ts
@@ -1,0 +1,14 @@
+import { z } from "zod"
+
+export const PlanEvaluationSchema = z.object({
+  noTypeCasting: z.boolean(),
+  noAnyTypes: z.boolean(),
+  noSingleItemHelper: z.boolean(),
+})
+
+export type PlanEvaluationResult = z.infer<typeof PlanEvaluationSchema>
+
+export const PlanEvaluationRequestSchema = z.object({
+  plan: z.string().min(1),
+})
+export type PlanEvaluationRequest = z.infer<typeof PlanEvaluationRequestSchema>


### PR DESCRIPTION
## Summary
- implement simple plan evaluator
- add API endpoint to run evaluation
- create Playground card for evaluations
- hook evaluation page to new card

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6874cd27aff483339ce63573234bc9ce