### PR TITLE
Add plan evaluation tool

### DIFF
--- a/components/playground/PlanEvalCard.tsx
+++ b/components/playground/PlanEvalCard.tsx
@@ -6,9 +6,9 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Textarea } from "@/components/ui/textarea"
 import {
-  PlanEvaluationResult,
-  PlanEvaluationSchema,
-} from "@/lib/types/evaluation"
+  plan753EvaluationSchema as PlanEvaluationSchema,
+  Plan753EvaluationResult as PlanEvaluationResult,
+} from "@/lib/evals/plan-753"
 
 export default function PlanEvalCard() {
   const [plan, setPlan] = useState("")

--- a/lib/actions/evaluatePlan.ts
+++ b/lib/actions/evaluatePlan.ts
@@ -1,56 +1,43 @@
 "use server"
 
-import OpenAI from "openai"
-import { zodResponseFormat } from "openai/helpers/zod"
 import { ChatCompletionMessageParam } from "openai/resources/chat/completions"
-import type { ChatCompletionTool } from "openai/resources/chat/completions/completions"
-import { zodToJsonSchema } from "zod-to-json-schema"
 
 import { getUserOpenAIApiKey } from "@/lib/neo4j/services/user"
+import { TestAgent } from "@/lib/agents/testAgent"
 import {
-  PlanEvaluationResult,
-  PlanEvaluationSchema,
-} from "@/lib/types/evaluation"
+  createPlan753EvaluationTool,
+  Plan753EvaluationResult,
+} from "@/lib/evals/plan-753"
 
 const SYSTEM_PROMPT = `You are an output evaluation agent. Your job is to inspect a coding implementation plan and determine if it avoids several common problems.\n\nReturn an evaluation using the provided tool. If unsure about a criterion, return false for that field.`
 
-const planEvaluationTool: ChatCompletionTool = {
-  type: "function",
-  function: {
-    name: "PlanEvaluation",
-    description:
-      "Return an evaluation of the implementation plan using this schema.",
-    parameters: zodToJsonSchema(PlanEvaluationSchema, "PlanEvaluation"),
-  },
-}
+const planEvaluationTool = createPlan753EvaluationTool()
 
 export async function evaluatePlan(
   plan: string
-): Promise<PlanEvaluationResult> {
+): Promise<Plan753EvaluationResult> {
   const apiKey = await getUserOpenAIApiKey()
   if (!apiKey) {
     throw new Error("Missing OpenAI API key")
   }
 
-  const openai = new OpenAI({ apiKey })
+  const agent = new TestAgent({ apiKey, systemPrompt: SYSTEM_PROMPT })
+  agent.addTool(planEvaluationTool)
 
   const messages: ChatCompletionMessageParam[] = [
-    { role: "system", content: SYSTEM_PROMPT },
     { role: "user", content: plan },
   ]
 
-  const completion = await openai.chat.completions.create({
-    model: "gpt-4.1",
-    messages,
-    tools: [planEvaluationTool],
-    tool_choice: "required",
-    store: true,
-  })
+  for (const message of messages) {
+    await agent.addMessage(message)
+  }
 
-  const toolCall = completion.choices[0]?.message?.tool_calls?.[0]
-  if (!toolCall) {
+  const { messages: finalMessages } = await agent.runWithFunctions()
+
+  const toolMessage = [...finalMessages].reverse().find((m) => m.role === "tool")
+  if (!toolMessage || typeof toolMessage.content !== "string") {
     throw new Error("No tool call result received from OpenAI")
   }
-  const result = JSON.parse(toolCall.function.arguments)
-  return result
+
+  return JSON.parse(toolMessage.content) as Plan753EvaluationResult
 }

--- a/lib/evals/plan-753.ts
+++ b/lib/evals/plan-753.ts
@@ -1,0 +1,40 @@
+import { z } from "zod"
+import { createTool } from "@/lib/tools/helper"
+
+export const plan753EvaluationSchema = z
+  .object({
+    noTypeCasting: z
+      .boolean()
+      .describe(
+        "true if the plan does not use TypeScript type casting like 'as SomeType'"
+      ),
+    noAnyTypes: z
+      .boolean()
+      .describe(
+        "false if the plan suggests using the 'any' type. True if there is suggestion to use the 'any' type anywhere in the Plan. "
+      ),
+    noSingleItemHelper: z
+      .boolean()
+      .describe(
+        "true if the plan does NOT introduce single-purpose helper functions whose only job is to convert one Neo4j value (for example wrapping Integer.toNumber() in neo4jToJsNumber). Built-in Neo4j conversion methods—.toNumber(), .toString(), etc.—or a general object-level helper should be used instead. Return false if the plan suggests any helper dedicated to converting a single property or primitive value."
+      ),
+    noUnnecessaryDestructuring: z
+      .boolean()
+      .describe(
+        "true if the plan does NOT destructure an object just to re-wrap the same property before passing it to a helper. For instance, avoid patterns like `const { number } = dbIssue; return { ...neo4jToJs({ number }) }` when `neo4jToJs(dbIssue)` would suffice. Return false when such redundant destructuring is present in the plan."
+      ),
+  })
+  .describe(
+    "Evaluation schema for plans generated from youngchingjui/issue-to-pr#753"
+  )
+
+export type Plan753EvaluationResult = z.infer<typeof plan753EvaluationSchema>
+
+export const createPlan753EvaluationTool = () =>
+  createTool({
+    name: "plan_753_evaluation",
+    description: "Return an evaluation of the implementation plan using this schema.",
+    schema: plan753EvaluationSchema,
+    handler: (params: Plan753EvaluationResult) => params,
+  })
+

--- a/lib/types/evaluation.ts
+++ b/lib/types/evaluation.ts
@@ -1,33 +1,5 @@
 import { z } from "zod"
 
-export const PlanEvaluationSchema = z
-  .object({
-    noTypeCasting: z
-      .boolean()
-      .describe(
-        "true if the plan does not use TypeScript type casting like 'as SomeType'"
-      ),
-    noAnyTypes: z
-      .boolean()
-      .describe(
-        "false if the plan suggests using the 'any' type. True if there is suggestion to use the 'any' type anywhere in the Plan. "
-      ),
-    noSingleItemHelper: z
-      .boolean()
-      .describe(
-        "true if the plan does NOT introduce single-purpose helper functions whose only job is to convert one Neo4j value (for example wrapping Integer.toNumber() in neo4jToJsNumber). Built-in Neo4j conversion methods—.toNumber(), .toString(), etc.—or a general object-level helper should be used instead. Return false if the plan suggests any helper dedicated to converting a single property or primitive value."
-      ),
-    noUnnecessaryDestructuring: z
-      .boolean()
-      .describe(
-        "true if the plan does NOT destructure an object just to re-wrap the same property before passing it to a helper. For instance, avoid patterns like `const { number } = dbIssue; return { ...neo4jToJs({ number }) }` when `neo4jToJs(dbIssue)` would suffice. Return false when such redundant destructuring is present in the plan."
-      ),
-  })
-  .describe(
-    "Evaluation schema for plans generated from youngchingjui/issue-to-pr#753"
-  )
-
-export type PlanEvaluationResult = z.infer<typeof PlanEvaluationSchema>
 
 export const PlanEvaluationRequestSchema = z.object({
   plan: z.string().min(1),


### PR DESCRIPTION
## Summary
- move plan evaluation schema into `/lib/evals`
- expose `createPlan753EvaluationTool` for OpenAI functions
- update evaluation action to use `TestAgent` with the new tool
- adjust playground evaluation card imports
- keep request schema in `lib/types/evaluation`

## Testing
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6874e0098f188333bb69c9f8e44129d8