### PR TITLE
Add pagination support to ripgrep search tool

### DIFF
--- a/components/playground/RipgrepSearchCard.tsx
+++ b/components/playground/RipgrepSearchCard.tsx
@@ -44,11 +44,13 @@ export default function RipgrepSearchCard() {
 
     const output = await runRipgrepSearch({
       env,
-      query,
-      ignoreCase,
-      hidden,
-      follow,
-      mode,
+      searchParams: {
+        query,
+        ignoreCase,
+        hidden,
+        follow,
+        mode,
+      },
     })
     setResult(output)
     setIsRunning(false)

--- a/lib/actions/ripgrep.ts
+++ b/lib/actions/ripgrep.ts
@@ -1,36 +1,21 @@
 "use server"
 
+import { z } from "zod"
+
 import { createRipgrepSearchTool } from "@/lib/tools/RipgrepSearchTool"
+import { searchParameters } from "@/lib/tools/RipgrepSearchTool"
 import { asRepoEnvironment, RepoEnvironment } from "@/lib/types"
 
+type Params = {
+  env: RepoEnvironment | string
+  searchParams: z.input<typeof searchParameters>
+}
 export async function runRipgrepSearch({
   env,
-  query,
-  ignoreCase,
-  hidden,
-  follow,
-  mode,
-  maxChars,
-  page,
-}: {
-  env: RepoEnvironment | string
-  query: string
-  ignoreCase?: boolean
-  hidden?: boolean
-  follow?: boolean
-  mode?: "literal" | "regex"
-  maxChars?: number
-  page?: number
-}): Promise<string> {
+  searchParams,
+}: Params): Promise<string> {
   const environment = asRepoEnvironment(env)
   const tool = createRipgrepSearchTool(environment)
-  return await tool.handler({
-    query,
-    ignoreCase,
-    hidden,
-    follow,
-    mode,
-    maxChars,
-    page,
-  })
+  const params = searchParameters.parse(searchParams)
+  return await tool.handler(params)
 }

--- a/lib/actions/ripgrep.ts
+++ b/lib/actions/ripgrep.ts
@@ -10,6 +10,8 @@ export async function runRipgrepSearch({
   hidden,
   follow,
   mode,
+  maxChars,
+  page,
 }: {
   env: RepoEnvironment | string
   query: string
@@ -17,8 +19,18 @@ export async function runRipgrepSearch({
   hidden?: boolean
   follow?: boolean
   mode?: "literal" | "regex"
+  maxChars?: number
+  page?: number
 }): Promise<string> {
   const environment = asRepoEnvironment(env)
   const tool = createRipgrepSearchTool(environment)
-  return await tool.handler({ query, ignoreCase, hidden, follow, mode })
+  return await tool.handler({
+    query,
+    ignoreCase,
+    hidden,
+    follow,
+    mode,
+    maxChars,
+    page,
+  })
 }

--- a/lib/tools/RipgrepSearchTool.ts
+++ b/lib/tools/RipgrepSearchTool.ts
@@ -97,7 +97,7 @@ The tool supports both literal (fixed-string) and regex search modes. By default
 - mode: "literal" (default, safer) — uses ripgrep's -F flag, interprets search as a fixed string, safe for special characters like ?, *, [, ]
 - mode: "regex" — disables -F, allows regex pattern searches, may return ripgrep errors if regex is malformed.`
 
-const searchParameters = z.object({
+export const searchParameters = z.object({
   query: z
     .string()
     .describe(
@@ -129,19 +129,19 @@ const searchParameters = z.object({
     .number()
     .int()
     .positive()
-    .optional()
     .describe(
       "Maximum number of characters to return per page. Defaults to 4000."
-    ),
+    )
+    .default(4000),
   page: z
     .number()
     .int()
     .min(1)
-    .optional()
-    .describe("Page number of results to return, starting at 1."),
+    .describe("Page number of results to return, starting at 1.")
+    .default(1),
 })
 
-type RipgrepSearchParameters = z.infer<typeof searchParameters>
+export type RipgrepSearchParameters = z.infer<typeof searchParameters>
 
 /**
  * Helper to construct the ripgrep command string based on the supplied flags.
@@ -223,8 +223,8 @@ async function fnHandler(
         return `Ripgrep search failed: Unexpected ripgrep exit code: ${exitCode}. stderr: ${stderr}`
       }
 
-      const perPage = maxChars ?? 4000
-      const currentPage = page ?? 1
+      const perPage = maxChars
+      const currentPage = page
       const start = (currentPage - 1) * perPage
       const end = start + perPage
       const output = stdout || ""
@@ -282,8 +282,8 @@ async function fnHandler(
         return `Ripgrep search failed: Unexpected ripgrep exit code: ${exitCode}. stderr: ${stderr}`
       }
 
-      const perPage = maxChars ?? 4000
-      const currentPage = page ?? 1
+      const perPage = maxChars
+      const currentPage = page
       const start = (currentPage - 1) * perPage
       const end = start + perPage
       const output = stdout || ""


### PR DESCRIPTION
## Summary
- show 1 line of context in ripgrep output
- paginate ripgrep search results by character count
- expose `maxChars` and `page` options in `runRipgrepSearch`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6877538ea00083338a503ab57d0aa8e2