### PR TITLE
Refactor: centralize workflow type enum

### DIFF
--- a/lib/types/neo4j.ts
+++ b/lib/types/neo4j.ts
@@ -61,7 +61,6 @@ export type PullRequest = {
 
 // Workflow Management Types
 
-
 export type WorkflowRun = {
   id: string
   workflowType: WorkflowType

--- a/lib/types/neo4j.ts
+++ b/lib/types/neo4j.ts
@@ -1,4 +1,4 @@
-import { LLMResponse as LLMResponseNew } from "@/lib/types"
+import { LLMResponse as LLMResponseNew, WorkflowType } from "@/lib/types"
 
 // Core Entity Types
 // TODO: Use zod to create schemas, then export types from schemas
@@ -61,12 +61,6 @@ export type PullRequest = {
 
 // Workflow Management Types
 
-export type WorkflowType =
-  | "commentOnIssue"
-  | "resolveIssue"
-  | "autoResolveIssue"
-  | "identifyPRGoal"
-  | "reviewPullRequest"
 
 export type WorkflowRun = {
   id: string

--- a/lib/types/schemas.ts
+++ b/lib/types/schemas.ts
@@ -1,6 +1,6 @@
 import { z } from "zod"
 
-import { WorkflowType } from "./neo4j"
+import { workflowTypeEnum } from "./index"
 
 // Base Event Schema
 /**
@@ -96,13 +96,7 @@ export const anyEventSchema = z.discriminatedUnion("type", [
  */
 export const workflowRunSchema = z.object({
   id: z.string(),
-  workflowType: z.enum([
-    "commentOnIssue",
-    "resolveIssue",
-    "autoResolveIssue",
-    "identifyPRGoal",
-    "reviewPullRequest",
-  ] as const satisfies readonly WorkflowType[]),
+  workflowType: workflowTypeEnum,
   created_at: z.date(),
 })
 

--- a/lib/types/schemas.ts
+++ b/lib/types/schemas.ts
@@ -1,6 +1,6 @@
 import { z } from "zod"
 
-import { workflowTypeEnum } from "./index"
+import { workflowTypeEnum } from "@/lib/types"
 
 // Base Event Schema
 /**


### PR DESCRIPTION
## Summary
- import `WorkflowType` from the shared types file in the deprecated `neo4j` models
- reuse `workflowTypeEnum` in deprecated `schemas.ts`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6877540432b8833382c7960dd258d31a