### PR TITLE
Keep container alive after successful workflow run

### DIFF
--- a/lib/workflows/autoResolveIssue.ts
+++ b/lib/workflows/autoResolveIssue.ts
@@ -51,6 +51,7 @@ export const autoResolveIssue = async ({
   const workflowId = jobId ?? uuidv4()
   let userPermissions: RepoPermissions | null = null
   let containerCleanup: (() => Promise<void>) | null = null
+  let workflowSucceeded = false
 
   try {
     await initializeWorkflowRun({
@@ -143,6 +144,7 @@ export const autoResolveIssue = async ({
 
     await createWorkflowStateEvent({ workflowId, state: "completed" })
 
+    workflowSucceeded = true
     return result
   } catch (error) {
     await createErrorEvent({ workflowId, content: String(error) })
@@ -153,10 +155,11 @@ export const autoResolveIssue = async ({
     })
     throw error
   } finally {
-    if (containerCleanup) {
+    if (!workflowSucceeded && containerCleanup) {
       await containerCleanup()
     }
   }
 }
 
 export default autoResolveIssue
+

--- a/lib/workflows/commentOnIssue.ts
+++ b/lib/workflows/commentOnIssue.ts
@@ -46,6 +46,7 @@ export default async function commentOnIssue(
 
   let latestEvent: appBaseEvent | null = null
   let containerCleanup: (() => Promise<void>) | null = null
+  let workflowSucceeded = false
 
   try {
     await initializeWorkflowRun({
@@ -302,6 +303,7 @@ export default async function commentOnIssue(
       state: "completed",
     })
 
+    workflowSucceeded = true
     // Return the comment plus planId for downstream consumption
     return {
       status: "complete",
@@ -346,9 +348,9 @@ export default async function commentOnIssue(
 
     throw githubError // Re-throw the error to be handled by the caller
   } finally {
-    // Always cleanup the containerized environment
-    if (containerCleanup) {
+    if (!workflowSucceeded && containerCleanup) {
       await containerCleanup()
     }
   }
 }
+

--- a/lib/workflows/resolveIssue.ts
+++ b/lib/workflows/resolveIssue.ts
@@ -68,6 +68,7 @@ export const resolveIssue = async ({
 
   const repoFullName = repoFullNameSchema.parse(repository.full_name)
   let containerCleanup: (() => Promise<void>) | null = null
+  let workflowSucceeded = false
   try {
     const repoSettings: RepoSettings | null =
       await getRepositorySettings(repoFullName)
@@ -325,6 +326,7 @@ export const resolveIssue = async ({
       state: "completed",
     })
 
+    workflowSucceeded = true
     return coderResult
   } catch (error) {
     // Emit error event
@@ -347,8 +349,9 @@ export const resolveIssue = async ({
     */
     throw error
   } finally {
-    if (containerCleanup) {
+    if (!workflowSucceeded && containerCleanup) {
       await containerCleanup()
     }
   }
 }
+


### PR DESCRIPTION
This PR addresses the improvement request to avoid shutting down the container after a workflow completes successfully.

Key Updates
===========
1. **lib/workflows/resolveIssue.ts**  
   * Added `workflowSucceeded` flag.  
   * Container cleanup now only runs when the workflow fails.

2. **lib/workflows/autoResolveIssue.ts**  
   * Same alterations as above.

3. **lib/workflows/commentOnIssue.ts**  
   * Same alterations as above.

Behaviour Change
----------------
Containers will persist after a successful run, enabling post-run debugging or exploration. In case of an error, the container will still be stopped and removed, maintaining previous cleanup guarantees.

No additional dependencies or configuration changes were introduced.

Closes #827