### PR TITLE
Show spinning icon for issues with active workflows

### DIFF
--- a/components/issues/StatusIndicators.tsx
+++ b/components/issues/StatusIndicators.tsx
@@ -1,4 +1,4 @@
-import { GitPullRequest, NotebookPen } from "lucide-react"
+import { GitPullRequest, Loader2, NotebookPen } from "lucide-react"
 import Link from "next/link"
 
 import {
@@ -12,7 +12,12 @@ import type { IssueWithStatus } from "@/lib/github/issues"
 interface Props {
   issue: Pick<
     IssueWithStatus,
-    "hasPlan" | "hasPR" | "planId" | "prNumber" | "number"
+    | "hasActiveWorkflow"
+    | "hasPlan"
+    | "hasPR"
+    | "planId"
+    | "prNumber"
+    | "number"
   >
   repoFullName: string
 }
@@ -21,6 +26,20 @@ export default function StatusIndicators({ issue, repoFullName }: Props) {
   return (
     <TooltipProvider delayDuration={200}>
       <div className="flex flex-row gap-2">
+        {/* Active Workflow Spinner Slot */}
+        <div style={{ width: 24, display: "flex", justifyContent: "center" }}>
+          {issue.hasActiveWorkflow ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Loader2
+                  className="inline align-text-bottom mr-0.5 animate-spin text-purple-600"
+                  size={18}
+                />
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Workflow running</TooltipContent>
+            </Tooltip>
+          ) : null}
+        </div>
         {/* Plan Icon Slot */}
         <div style={{ width: 24, display: "flex", justifyContent: "center" }}>
           {issue.hasPlan && issue.planId ? (
@@ -65,3 +84,4 @@ export default function StatusIndicators({ issue, repoFullName }: Props) {
     </TooltipProvider>
   )
 }
+

--- a/lib/github/issues.ts
+++ b/lib/github/issues.ts
@@ -58,10 +58,10 @@ export async function getIssue({
       return { type: "other_error", error: "Unknown error" }
     }
     if (typeof error === "object" && "status" in error) {
-      if ((error as { status: number }).status === 404) {
+      if (error.status === 404) {
         return { type: "not_found" }
       }
-      if ((error as { status: number }).status === 403) {
+      if (error.status === 403) {
         return { type: "forbidden" }
       }
     }
@@ -211,7 +211,7 @@ export async function getIssueListWithStatus({
           (r) => r.state !== "completed" && r.state !== "error"
         )
       } catch (err) {
-        // ignore errors fetching workflow runs
+        console.error(`Issue listing workflow runs: ${String(err)}`)
       }
 
       return {
@@ -227,4 +227,3 @@ export async function getIssueListWithStatus({
 
   return withStatus
 }
-

--- a/lib/github/issues.ts
+++ b/lib/github/issues.ts
@@ -6,6 +6,7 @@ import {
   getLatestPlanIdsForIssues,
   getPlanStatusForIssues,
 } from "@/lib/neo4j/services/plan"
+import { listWorkflowRuns } from "@/lib/neo4j/services/workflow"
 import {
   GetIssueResult,
   GitHubIssue,
@@ -57,10 +58,10 @@ export async function getIssue({
       return { type: "other_error", error: "Unknown error" }
     }
     if (typeof error === "object" && "status" in error) {
-      if (error.status === 404) {
+      if ((error as { status: number }).status === 404) {
         return { type: "not_found" }
       }
-      if (error.status === 403) {
+      if ((error as { status: number }).status === 403) {
         return { type: "forbidden" }
       }
     }
@@ -101,7 +102,7 @@ export async function getIssueComments({
   const octokit = await getOctokit()
   const [owner, repo] = repoFullName.split("/")
   if (!owner || !repo) {
-    throw new Error("Invalid repository format. Expected '\''owner/repo'\''")
+    throw new Error("Invalid repository format. Expected 'owner/repo'")
   }
   if (!octokit) {
     throw new Error("No octokit found")
@@ -165,17 +166,18 @@ export async function updateIssueComment({
 }
 
 /**
- * Aggregates GitHub issues with Neo4j plan and PR status
+ * Aggregates GitHub issues with Neo4j plan, PR, and workflow status
  */
 export type IssueWithStatus = GitHubIssue & {
   hasPlan: boolean
   hasPR: boolean
+  hasActiveWorkflow: boolean
   planId?: string | null
   prNumber?: number
 }
 
 /**
- * For a repo, get list of issues with hasPlan and hasPR badges.
+ * For a repo, get list of issues with hasPlan, hasPR, and active workflow badges.
  */
 export async function getIssueListWithStatus({
   repoFullName,
@@ -188,26 +190,41 @@ export async function getIssueListWithStatus({
 
   // 2. Query Neo4j for plans using the service layer
   const issueNumbers = issues.map((issue) => issue.number)
-  const issuePlanStatus = await getPlanStatusForIssues({
-    repoFullName,
-    issueNumbers,
-  })
-  const issuePlanIds = await getLatestPlanIdsForIssues({
-    repoFullName,
-    issueNumbers,
-  })
+  const [issuePlanStatus, issuePlanIds] = await Promise.all([
+    getPlanStatusForIssues({ repoFullName, issueNumbers }),
+    getLatestPlanIdsForIssues({ repoFullName, issueNumbers }),
+  ])
 
   // 3. Get PRs from GitHub using GraphQL, and find for each issue if it has a PR referencing it.
   const issuePRMap = await getIssueToPullRequestMap(repoFullName)
 
-  // 4. Compose the final list
-  const withStatus: IssueWithStatus[] = issues.map((issue) => ({
-    ...issue,
-    hasPlan: issuePlanStatus[issue.number] || false,
-    hasPR: Boolean(issuePRMap[issue.number]),
-    planId: issuePlanIds[issue.number] || null,
-    prNumber: issuePRMap[issue.number],
-  }))
+  // 4. Determine active workflows for each issue (simple sequential for now)
+  const withStatus: IssueWithStatus[] = await Promise.all(
+    issues.map(async (issue) => {
+      let hasActiveWorkflow = false
+      try {
+        const runs = await listWorkflowRuns({
+          repoFullName,
+          issueNumber: issue.number,
+        })
+        hasActiveWorkflow = runs.some(
+          (r) => r.state !== "completed" && r.state !== "error"
+        )
+      } catch (err) {
+        // ignore errors fetching workflow runs
+      }
+
+      return {
+        ...issue,
+        hasPlan: issuePlanStatus[issue.number] || false,
+        hasPR: Boolean(issuePRMap[issue.number]),
+        hasActiveWorkflow,
+        planId: issuePlanIds[issue.number] || null,
+        prNumber: issuePRMap[issue.number],
+      }
+    })
+  )
 
   return withStatus
 }
+


### PR DESCRIPTION
### Description
This PR addresses the request to display a spinning icon on the issues list page whenever an issue has a workflow that is currently running.

### Key Updates
1. **`lib/github/issues.ts`**
   • Extends `IssueWithStatus` with a new `hasActiveWorkflow` boolean.
   • Determines `hasActiveWorkflow` by querying Neo4j for workflow runs per issue and checking for any run whose state is not `completed` or `error`.

2. **`components/issues/StatusIndicators.tsx`**
   • Accepts the new `hasActiveWorkflow` prop.
   • Renders a purple `Loader2` icon with `animate-spin` to indicate an active workflow – positioned before the existing Plan and PR icons.

### Behaviour
When the issues page is rendered, server-side logic now checks each issue for active workflows.  If found, the spinning indicator is displayed in the Status column so users can instantly see work that is in progress.

### Notes
• No client-side polling/SWR was added per the issue instructions; the information is evaluated once when the page is built.
• All other functionality (plan & PR icons, dropdown actions, etc.) remains unchanged.

---
Label: `AI generated`

Closes #833