### PR TITLE
Show Docker container status on workflow run details page

### DIFF
--- a/app/workflow-runs/[traceId]/page.tsx
+++ b/app/workflow-runs/[traceId]/page.tsx
@@ -6,8 +6,8 @@ import BaseGitHubItemCard from "@/components/github/BaseGitHubItemCard"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import WorkflowRunEventsFeed from "@/components/workflow-runs/WorkflowRunEventsFeed"
-import { getIssue } from "@/lib/github/issues"
 import { getContainerStatus } from "@/lib/docker"
+import { getIssue } from "@/lib/github/issues"
 import { getWorkflowRunWithDetails } from "@/lib/neo4j/services/workflow"
 import { GetIssueResult } from "@/lib/types/github"
 
@@ -23,7 +23,9 @@ function containerNameForTrace(traceId: string): string {
 /**
  * Map a Docker status string to a badge variant for quick visual cues.
  */
-function badgeVariantForStatus(status: string): "default" | "secondary" | "outline" | "destructive" {
+function badgeVariantForStatus(
+  status: string
+): "default" | "secondary" | "outline" | "destructive" {
   switch (status) {
     case "running":
       return "default"
@@ -92,7 +94,6 @@ export default async function WorkflowRunDetailPage({
         <div className="space-y-2">
           <h1 className="text-2xl font-bold flex items-center gap-3 flex-wrap">
             {issue?.title || `Workflow Run: ${traceId}`}
-            {/* Container status badge */}
             <Badge variant={badgeVariantForStatus(containerStatus)}>
               Container: {containerStatus}
             </Badge>
@@ -134,4 +135,3 @@ export default async function WorkflowRunDetailPage({
     </main>
   )
 }
-

--- a/lib/docker.ts
+++ b/lib/docker.ts
@@ -312,11 +312,11 @@ export async function writeFileInContainer(
 
   if (makeDirs) {
     // Create parent directories if needed
-    command += `mkdir -p \"$(dirname \"${fullPath}\")\" && `
+    command += `mkdir -p "$(dirname "${fullPath}")" && `
   }
 
   // Use heredoc to safely write contents (avoids escaping issues)
-  command += `cat > \"${fullPath}\" << 'WRITE_FILE_EOF'\n${contents}\nWRITE_FILE_EOF`
+  command += `cat > "${fullPath}" << 'WRITE_FILE_EOF'\n${contents}\nWRITE_FILE_EOF`
 
   // Execute the command
   try {
@@ -341,8 +341,6 @@ export async function writeFileInContainer(
   }
 }
 
-// ------------------ NEW UTILITY: getContainerStatus ------------------
-
 /**
  * Retrieve a Docker container's status string via `docker inspect`.
  *
@@ -350,16 +348,13 @@ export async function writeFileInContainer(
  * "removing", "exited", "dead". If the container cannot be found, the
  * function returns "not_found".
  */
-export async function getContainerStatus(
-  name: string
-): Promise<string> {
+export async function getContainerStatus(name: string): Promise<string> {
   try {
-    const { stdout } = await execPromise(
-      `docker inspect -f '{{.State.Status}}' ${name}`
-    )
-    return stdout.trim() || "unknown"
+    const docker = new Docker({ socketPath: "/var/run/docker.sock" })
+    const container = docker.getContainer(name)
+    const data = await container.inspect()
+    return data.State?.Status || "unknown"
   } catch {
     return "not_found"
   }
 }
-


### PR DESCRIPTION
### Summary
Adds visibility into the Docker container that backs each workflow run.

1. **lib/docker.ts**
   * Introduces `getContainerStatus(name)` – a small helper that leverages `docker inspect` to return the container's current state (falls back to `not_found`).

2. **app/workflow-runs/[traceId]/page.tsx**
   * Generates the expected container name (`agent-${traceId}`) and queries its status with the new helper.
   * Displays the result as a coloured `<Badge>` beside the workflow-run title.
     * `running` → primary colour (default)
     * `exited / paused / dead / created` → secondary colour
     * `not_found` → outline

This delivers the feature requested in the issue by providing a quick, always-visible indicator of whether the associated container is still alive.

Closes #840