### PR TITLE
feat: Add speech-to-text feature using Whisper API

### DIFF
--- a/app/api/openai/transcribe/route.ts
+++ b/app/api/openai/transcribe/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server"
+import { openai } from "@/lib/openai"
+
+// Whisper transcription endpoint
+// Accepts multipart/form-data with field "file" containing an audio blob.
+// Returns JSON: { text: string }
+
+export const dynamic = "force-dynamic" // Ensure this is executed in a Node context
+
+export async function POST(req: NextRequest) {
+  try {
+    const formData = await req.formData()
+    const file = formData.get("file")
+
+    if (!file || !(file instanceof Blob)) {
+      return NextResponse.json({ error: "Missing audio file" }, { status: 400 })
+    }
+
+    // Convert the incoming blob to a File object so that the OpenAI SDK can accept it.
+    // In Node 18+, File is available globally via undici's fetch implementation.
+    const audioFile = new File([file], "recording.webm", { type: file.type || "audio/webm" })
+
+    // Call Whisper
+    const transcription = await openai.audio.transcriptions.create({
+      file: audioFile,
+      model: "whisper-1",
+    })
+
+    return NextResponse.json({ text: transcription.text })
+  } catch (err) {
+    console.error("Whisper transcription failed", err)
+    return NextResponse.json({ error: String(err) }, { status: 500 })
+  }
+}
+

--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -23,6 +23,7 @@ import ApplyPatchCard from "@/components/playground/ApplyPatchCard"
 import DockerodeExecCard from "@/components/playground/DockerodeExecCard"
 import IssueTitleCard from "@/components/playground/IssueTitleCard"
 import RipgrepSearchCard from "@/components/playground/RipgrepSearchCard"
+import SpeechToTextCard from "@/components/playground/SpeechToTextCard"
 import UserRolesCard from "@/components/playground/UserRolesCard"
 import WriteFileCard from "@/components/playground/WriteFileCard"
 import { Button } from "@/components/ui/button"
@@ -35,6 +36,7 @@ export default async function PlaygroundPage() {
     <div className="space-y-8 px-4 py-8 md:container md:mx-auto">
       <AgentWorkflowClient defaultTools={DEFAULT_TOOLS} />
       <IssueTitleCard />
+      <SpeechToTextCard />
       <UserRolesCard />
       <RipgrepSearchCard />
       <DockerodeExecCard />
@@ -51,3 +53,4 @@ export default async function PlaygroundPage() {
     </div>
   )
 }
+

--- a/components/playground/SpeechToTextCard.tsx
+++ b/components/playground/SpeechToTextCard.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { useToast } from "@/lib/hooks/use-toast"
+
+export default function SpeechToTextCard() {
+  const [isRecording, setIsRecording] = useState(false)
+  const [mediaRecorder, setMediaRecorder] = useState<MediaRecorder | null>(null)
+  const audioChunks = useRef<Blob[]>([])
+
+  const [transcript, setTranscript] = useState("")
+  const [isTranscribing, setIsTranscribing] = useState(false)
+  const { toast } = useToast()
+
+  useEffect(() => {
+    return () => {
+      // Cleanup recorder on unmount
+      mediaRecorder?.stream.getTracks().forEach((t) => t.stop())
+    }
+  }, [mediaRecorder])
+
+  const startRecording = async () => {
+    if (!navigator.mediaDevices?.getUserMedia) {
+      toast({
+        description: "Your browser does not support audio recording.",
+        variant: "destructive",
+      })
+      return
+    }
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      const recorder = new MediaRecorder(stream)
+      recorder.ondataavailable = (e) => {
+        if (e.data.size > 0) audioChunks.current.push(e.data)
+      }
+      recorder.onstop = handleRecordingStop
+      recorder.start()
+      setMediaRecorder(recorder)
+      setIsRecording(true)
+    } catch (err) {
+      toast({ description: "Unable to access microphone." })
+    }
+  }
+
+  const stopRecording = () => {
+    mediaRecorder?.stop()
+  }
+
+  const handleRecordingStop = useCallback(async () => {
+    setIsRecording(false)
+    const blob = new Blob(audioChunks.current, { type: "audio/webm" })
+    audioChunks.current = []
+
+    // Send to server
+    const formData = new FormData()
+    formData.append("file", blob, "recording.webm")
+
+    setIsTranscribing(true)
+    try {
+      const res = await fetch("/api/openai/transcribe", {
+        method: "POST",
+        body: formData,
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || "Failed to transcribe")
+      setTranscript(data.text as string)
+    } catch (err) {
+      toast({ description: String(err), variant: "destructive" })
+    } finally {
+      setIsTranscribing(false)
+    }
+  }, [toast])
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(transcript)
+      toast({ description: "Copied transcription to clipboard." })
+    } catch {
+      toast({ description: "Failed to copy.", variant: "destructive" })
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Speech ➜ Text (Whisper)</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label>Transcription</Label>
+          <Textarea
+            rows={6}
+            value={transcript}
+            onChange={(e) => setTranscript(e.target.value)}
+            placeholder="Press the microphone, speak, then stop to transcribe..."
+          />
+        </div>
+        <div className="flex items-center gap-4">
+          {isRecording ? (
+            <Button variant="destructive" onClick={stopRecording} disabled={isTranscribing}>
+              Stop Recording
+            </Button>
+          ) : (
+            <Button onClick={startRecording} disabled={isTranscribing}>
+              {isTranscribing ? "Transcribing..." : "Start Recording"}
+            </Button>
+          )}
+          <Button variant="outline" onClick={handleCopy} disabled={!transcript}>
+            Copy
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+


### PR DESCRIPTION
### Added
1. **SpeechToTextCard** component in Playground – provides microphone recording, Whisper transcription and copy functionality.
2. **/api/openai/transcribe** endpoint – proxies uploaded audio to OpenAI Whisper (model `whisper-1`) and returns the transcription.
3. Integrated the new card into the Playground page.

### How it works
1. User taps **Start Recording** – browser microphone is captured using the MediaRecorder API.
2. User taps **Stop Recording** – audio is packaged in a `Blob`, sent as `multipart/form-data` to `/api/openai/transcribe`.
3. The route forwards the audio to the OpenAI Whisper API and returns `{ text }` which is placed in the editable textarea.
4. **Copy** button copies the transcription to the clipboard.

### Notes
* The API route is flagged `force-dynamic` to ensure it runs in the Node.js runtime where the OpenAI SDK works.
* Requires `OPENAI_API_KEY` to be set in the server environment.
* Gracefully handles unsupported browsers and permission errors with toast notifications.

Closes #859