### PR TITLE
feat: Add Task creation & display alongside GitHub issues

### DIFF
--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+
+import { createTask } from "@/lib/neo4j/services/task"
+import { getGithubUser } from "@/lib/github/users"
+import { repoFullNameSchema } from "@/lib/types/github"
+
+export const dynamic = "force-dynamic"
+
+const CreateTaskRequestSchema = z.object({
+  repoFullName: repoFullNameSchema,
+  title: z.string().min(1),
+  body: z.string().optional(),
+})
+
+export async function POST(req: NextRequest) {
+  try {
+    const json = await req.json()
+    const parseResult = CreateTaskRequestSchema.safeParse(json)
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { error: "Invalid request body", details: parseResult.error.errors },
+        { status: 400 }
+      )
+    }
+
+    const { repoFullName, title, body } = parseResult.data
+
+    const user = await getGithubUser()
+    if (!user) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 }
+      )
+    }
+
+    const task = await createTask({
+      repoFullName: repoFullName.fullName,
+      title,
+      body,
+      createdBy: user.login,
+    })
+
+    return NextResponse.json({ success: true, task })
+  } catch (error) {
+    console.error("[tasks] Task creation error:", error)
+    return NextResponse.json(
+      { error: "Failed to create task" },
+      { status: 500 }
+    )
+  }
+}

--- a/components/issues/IssueTable.tsx
+++ b/components/issues/IssueTable.tsx
@@ -1,34 +1,61 @@
 import IssueRow from "@/components/issues/IssueRow"
+import TaskRow from "@/components/issues/TaskRow"
 import { Table, TableBody } from "@/components/ui/table"
 import { getIssueListWithStatus } from "@/lib/github/issues"
+import { listTasksForRepo } from "@/lib/neo4j/services/task"
 import { RepoFullName } from "@/lib/types/github"
 
 interface Props {
   repoFullName: RepoFullName
 }
 
+type TableItem =
+  | { kind: "issue"; data: Awaited<ReturnType<typeof getIssueListWithStatus>>[number] }
+  | { kind: "task"; data: Awaited<ReturnType<typeof listTasksForRepo>>[number] }
+
 export default async function IssueTable({ repoFullName }: Props) {
   try {
-    const issues = await getIssueListWithStatus({
-      repoFullName: repoFullName.fullName,
-      per_page: 25,
-    })
+    // Fetch GitHub issues and local tasks in parallel
+    const [issues, tasks] = await Promise.all([
+      getIssueListWithStatus({
+        repoFullName: repoFullName.fullName,
+        per_page: 25,
+      }),
+      listTasksForRepo(repoFullName.fullName),
+    ])
 
-    if (issues.length === 0) {
-      return <p className="text-center py-4">No open issues found.</p>
+    // If no items
+    if (issues.length === 0 && tasks.length === 0) {
+      return <p className="text-center py-4">No open issues or tasks found.</p>
     }
+
+    // Build unified list and sort by recency (updated_at for issues, createdAt for tasks)
+    const combined: TableItem[] = [
+      ...issues.map((i) => ({ kind: "issue" as const, data: i })),
+      ...tasks.map((t) => ({ kind: "task" as const, data: t })),
+    ]
+
+    combined.sort((a, b) => {
+      const aTime = a.kind === "issue" ? new Date(a.data.updated_at).getTime() : new Date(a.data.createdAt).getTime()
+      const bTime = b.kind === "issue" ? new Date(b.data.updated_at).getTime() : new Date(b.data.createdAt).getTime()
+      return bTime - aTime // Descending
+    })
 
     return (
       <div className="rounded-md border">
         <Table className="table-fixed sm:table-auto">
           <TableBody>
-            {issues.map((issue) => (
-              <IssueRow
-                key={issue.id}
-                issue={issue}
-                repoFullName={repoFullName.fullName}
-              />
-            ))}
+            {combined.map((item) =>
+              item.kind === "issue" ? (
+                <IssueRow
+                  key={`issue-${item.data.id}`}
+                  issue={item.data}
+                  repoFullName={repoFullName.fullName}
+                />
+              ) : (
+                <TaskRow key={`task-${item.data.id}`} task={item.data} />
+              )
+            )}
           </TableBody>
         </Table>
       </div>

--- a/components/issues/TaskRow.tsx
+++ b/components/issues/TaskRow.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { formatDistanceToNow } from "date-fns"
+import Link from "next/link"
+import { TableCell, TableRow } from "@/components/ui/table"
+import { Badge } from "@/components/ui/badge"
+import type { Task } from "@/lib/types"
+
+interface TaskRowProps {
+  task: Task
+}
+
+export default function TaskRow({ task }: TaskRowProps) {
+  // Create a local URL to view the task details (not implemented yet)
+  const localTaskUrl = "#" // Placeholder – could link to a future task page
+
+  return (
+    <TableRow className="sm:table-row flex flex-col sm:flex-row w-full bg-muted/50">
+      {/* Title & meta */}
+      <TableCell className="py-4 flex-1">
+        <div className="flex flex-col gap-1">
+          <div className="font-medium text-base break-words flex items-center gap-2">
+            <Link href={localTaskUrl} className="hover:underline">
+              {task.title ?? "(No title)"}
+            </Link>
+            <Badge variant="secondary">Task</Badge>
+          </div>
+          <div className="text-sm text-muted-foreground flex flex-wrap items-center gap-2">
+            <span>{task.createdBy}</span>
+            <span>•</span>
+            <span>
+              Created {formatDistanceToNow(new Date(task.createdAt), { addSuffix: true })}
+            </span>
+          </div>
+        </div>
+      </TableCell>
+      {/* Empty placeholder cells to align with IssueRow layout */}
+      <TableCell className="text-center align-middle w-full sm:w-12 mb-2 sm:mb-0">
+        {/* No plan / PR / workflow indicators for local tasks yet */}
+      </TableCell>
+      <TableCell className="text-right">
+        {/* No workflow actions for tasks at the moment */}
+      </TableCell>
+    </TableRow>
+  )
+}


### PR DESCRIPTION
### Summary
This PR implements the requested functionality to create tasks in the database and show them mixed with GitHub issues on the repository issues page.

### Key Changes
1. **API**
   • `POST /api/tasks` – New endpoint to create a task (stored in Neo4j) using the authenticated GitHub username.

2. **UI / Components**
   • **`NewTaskInput`** now creates a local task via the new API route and updates copy from "Create GitHub Issue" to "Create Task".
   • **`IssueTable`** fetches both GitHub issues and local tasks, merges & sorts them by recency, and renders an appropriate row for each.
   • **`TaskRow`** – new component providing a lightweight, GitHub-style row with a "Task" badge for clear differentiation.

3. **Server Logic**
   • Added `app/api/tasks/route.ts` which validates input, retrieves the current user, persists the task via `createTask`, and returns the created record.

### Visual
Tasks now appear in the issues list with a muted background and a **Task** badge so users can instantly spot entries that are *not* GitHub issues.

### Notes / Future Work
* Sync-to-GitHub functionality for tasks can be added later.
* A dedicated task details page can be introduced by linking `TaskRow`.

---
Closes internal request to “Create tasks in database and display alongside issues”. 🚀

Closes #858