### PR TITLE
feat: Add GitHub CLI with automatic user authentication to agent container

### DIFF
--- a/docker/agent-base/Dockerfile
+++ b/docker/agent-base/Dockerfile
@@ -1,14 +1,17 @@
 # Lightweight base image for containerized agent workflows
-# Includes Node.js 22 (npm), pnpm, Python 3.11, Poetry, ripgrep, git, and tree
+# Includes Node.js 22 (npm), pnpm, Python 3.11, Poetry, ripgrep, git, tree, and GitHub CLI (gh)
 # OS: Debian "bookworm-slim"
 FROM node:22-slim
 
 # Avoid interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
 
+# -----------------------------------------------------------------------------
+# 1. Base tooling (ripgrep, git, Python, etc.)
+# -----------------------------------------------------------------------------
 # Install CLI tooling: ripgrep, git, tree, Python 3.11, pip, and curl
 # - Python 3.11 and pip3 are available directly in Debian Bookworm
-# - curl is needed for Poetry installation
+# - curl is needed for Poetry installation + GitHub CLI repository bootstrap
 # - Clean package lists after installation to minimize image size
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -21,6 +24,25 @@ RUN apt-get update && \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
+# -----------------------------------------------------------------------------
+# 2. GitHub CLI (gh)
+# -----------------------------------------------------------------------------
+# Install GitHub CLI using the official Debian package repository. We add the
+# signed APT source and install `gh` without any recommended extras to keep the
+# image lightweight.
+RUN set -euo pipefail && \
+    # Add GitHub CLI apt repository
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+
+# -----------------------------------------------------------------------------
+# 3. Python Poetry
+# -----------------------------------------------------------------------------
 # Symlink python3 and pip3 to expected locations (just in case)
 RUN ln -sf /usr/bin/python3.11 /usr/local/bin/python3 && \
     ln -sf /usr/bin/pip3 /usr/local/bin/pip3
@@ -31,11 +53,15 @@ RUN ln -sf /usr/bin/python3.11 /usr/local/bin/python3 && \
 RUN curl -sSL https://install.python-poetry.org | python3 - && \
     ln -sf /root/.local/bin/poetry /usr/local/bin/poetry
 
+# -----------------------------------------------------------------------------
+# 4. Node.js package managers (pnpm)
+# -----------------------------------------------------------------------------
 # Enable Corepack (bundled with Node 22) and activate latest stable pnpm version
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
-# Verify toolchain versions for transparency (for cache/debugging)
-# Now includes: Python, pip, and Poetry checks
+# -----------------------------------------------------------------------------
+# 5. Verify toolchain versions for transparency (useful for caching/debugging)
+# -----------------------------------------------------------------------------
 RUN rg --version \
  && git --version \
  && node --version \
@@ -43,10 +69,15 @@ RUN rg --version \
  && pnpm --version \
  && python3 --version \
  && pip3 --version \
- && poetry --version
+ && poetry --version \
+ && gh --version
 
+# -----------------------------------------------------------------------------
+# 6. Workspace defaults
+# -----------------------------------------------------------------------------
 # Set working directory where the agent will later receive a repository to work on
 WORKDIR /workspace
 
 # Default command keeps the container alive for interactive use
 CMD ["/bin/bash"]
+

--- a/lib/utils/container.ts
+++ b/lib/utils/container.ts
@@ -134,6 +134,21 @@ export async function createContainerizedWorktree({
 
   const containerName = `agent-${workflowId}`.replace(/[^a-zA-Z0-9_.-]/g, "-")
 
+  // Obtain GitHub token (optional in this path)
+  let envVars: Record<string, string> = {}
+  try {
+    const authResult = await getAuthToken()
+    if (authResult?.token) {
+      envVars = {
+        GITHUB_TOKEN: authResult.token,
+        GH_TOKEN: authResult.token,
+      }
+    }
+  } catch (e) {
+    // Non-fatal; proceed without token if unavailable
+    console.warn("[WARN] Failed to obtain GitHub token for worktree container", e)
+  }
+
   // 4. Start detached container mounting both the *clone* (read-only) and the *worktree* (rw)
   await startContainer({
     image,
@@ -143,6 +158,7 @@ export async function createContainerizedWorktree({
       { hostPath: worktreeDir, containerPath: worktreeDir },
     ],
     workdir: worktreeDir,
+    env: envVars,
   })
 
   // Helper functions
@@ -200,7 +216,7 @@ export async function createContainerizedWorkspace({
     )
   }
 
-  // 2. Start a detached container with GITHUB_TOKEN env set
+  // 2. Start a detached container with GITHUB_TOKEN & GH_TOKEN env set
   const containerName = `agent-${workflowId}`.replace(/[^a-zA-Z0-9_.-]/g, "-")
 
   await startContainer({
@@ -209,6 +225,7 @@ export async function createContainerizedWorkspace({
     user: "root",
     env: {
       GITHUB_TOKEN: token,
+      GH_TOKEN: token,
     },
     workdir: mountPath,
   })
@@ -324,3 +341,4 @@ export async function copyRepoToExistingContainer({
     throw new Error(`Failed to copy repository to container: ${e}`)
   }
 }
+


### PR DESCRIPTION
### Overview
This PR completes the "Add GitHub CLI with user authentication to agent container" issue by providing two key enhancements:

1. **GitHub CLI inside agent container**  
   • `docker/agent-base/Dockerfile` now installs the official `gh` binary via GitHub’s apt repository.  
   • The tool-chain verification step has been extended with `gh --version` so the image build output clearly shows the installed version.

2. **Seamless authentication for `gh`**  
   • The helper that spins up containers for worktree-based workflows (`createContainerizedWorktree`) now looks up the current user (or app) OAuth token and exposes it inside the container as **both** `GITHUB_TOKEN` and `GH_TOKEN`.  
   • The workspace-based helper (`createContainerizedWorkspace`) already exported `GITHUB_TOKEN`; it now exports **`GH_TOKEN` as well** for parity.  
   With these env vars present, the GitHub CLI automatically authenticates—no manual `gh auth login` needed.

### Why this matters
Agents can now execute commands such as `gh pr create`, `gh issue list`, etc., on the user’s behalf directly from inside the container.

### Implementation notes
* Installation follows the official instructions from https://cli.github.com.  
* Token retrieval uses the existing `getAuthToken` helper; if unavailable in the worktree flow we simply continue without the env vars.

No breaking changes are introduced. Existing workflows continue to work, but now gain first-class access to `gh`.

---
Label: `AI generated`

Closes #867