### PR TITLE
Add start/stop/delete container controls on Workflow Run details

### DIFF
--- a/app/api/workflow-runs/[workflowId]/container/route.ts
+++ b/app/api/workflow-runs/[workflowId]/container/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import {
+  getContainerStatus,
+  isContainerRunning,
+  stopAndRemoveContainer,
+} from "@/lib/docker"
+
+// We use child_process exec for simple docker CLI commands that are not yet
+// wrapped by util functions (start/stop). Keeping the dependency small avoids
+// introducing additional dockerode calls for these one-liners.
+import { exec as hostExec } from "child_process"
+import util from "util"
+
+const execPromise = util.promisify(hostExec)
+
+export const dynamic = "force-dynamic"
+
+/**
+ * Derive the deterministic container name used by our workflow utilities.
+ */
+function containerNameForTrace(traceId: string): string {
+  return `agent-${traceId}`.replace(/[^a-zA-Z0-9_.-]/g, "-")
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { workflowId: string } }
+) {
+  const containerName = containerNameForTrace(params.workflowId)
+  const status = await getContainerStatus(containerName)
+  return NextResponse.json({ status })
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { workflowId: string } }
+) {
+  const { action } = (await request.json()) as { action?: string }
+
+  if (!action || !["start", "stop", "delete"].includes(action)) {
+    return NextResponse.json({ error: "Invalid action" }, { status: 400 })
+  }
+
+  const containerName = containerNameForTrace(params.workflowId)
+
+  try {
+    switch (action) {
+      case "start": {
+        // If container exists but not running, start it. Otherwise ignore.
+        const running = await isContainerRunning(containerName)
+        if (!running) {
+          await execPromise(`docker start ${containerName}`)
+        }
+        break
+      }
+      case "stop": {
+        // Stop without removing to allow future restarts
+        await execPromise(`docker stop ${containerName}`)
+        break
+      }
+      case "delete": {
+        // Stop & remove via existing helper
+        await stopAndRemoveContainer(containerName)
+        break
+      }
+    }
+  } catch (err) {
+    console.error(`[ContainerActions] Failed to ${action} ${containerName}:`, err)
+    return NextResponse.json({ error: "Failed to execute action" }, { status: 500 })
+  }
+
+  const status = await getContainerStatus(containerName)
+  return NextResponse.json({ status })
+}
+

--- a/app/api/workflow-runs/[workflowId]/container/route.ts
+++ b/app/api/workflow-runs/[workflowId]/container/route.ts
@@ -1,16 +1,15 @@
+// We use child_process exec for simple docker CLI commands that are not yet
+// wrapped by util functions (start/stop). Keeping the dependency small avoids
+// introducing additional dockerode calls for these one-liners.
+import { exec as hostExec } from "child_process"
 import { NextRequest, NextResponse } from "next/server"
+import util from "util"
 
 import {
   getContainerStatus,
   isContainerRunning,
   stopAndRemoveContainer,
 } from "@/lib/docker"
-
-// We use child_process exec for simple docker CLI commands that are not yet
-// wrapped by util functions (start/stop). Keeping the dependency small avoids
-// introducing additional dockerode calls for these one-liners.
-import { exec as hostExec } from "child_process"
-import util from "util"
 
 const execPromise = util.promisify(hostExec)
 
@@ -66,11 +65,16 @@ export async function POST(
       }
     }
   } catch (err) {
-    console.error(`[ContainerActions] Failed to ${action} ${containerName}:`, err)
-    return NextResponse.json({ error: "Failed to execute action" }, { status: 500 })
+    console.error(
+      `[ContainerActions] Failed to ${action} ${containerName}:`,
+      err
+    )
+    return NextResponse.json(
+      { error: "Failed to execute action" },
+      { status: 500 }
+    )
   }
 
   const status = await getContainerStatus(containerName)
   return NextResponse.json({ status })
 }
-

--- a/app/workflow-runs/[traceId]/page.tsx
+++ b/app/workflow-runs/[traceId]/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link"
 import { notFound } from "next/navigation"
 
 import BaseGitHubItemCard from "@/components/github/BaseGitHubItemCard"
-import { Badge } from "@/components/ui/badge"
+import ContainerManager from "@/components/workflow-runs/ContainerManager"
 import { Button } from "@/components/ui/button"
 import WorkflowRunEventsFeed from "@/components/workflow-runs/WorkflowRunEventsFeed"
 import { getContainerStatus } from "@/lib/docker"
@@ -18,27 +18,6 @@ import { GetIssueResult } from "@/lib/types/github"
  */
 function containerNameForTrace(traceId: string): string {
   return `agent-${traceId}`.replace(/[^a-zA-Z0-9_.-]/g, "-")
-}
-
-/**
- * Map a Docker status string to a badge variant for quick visual cues.
- */
-function badgeVariantForStatus(
-  status: string
-): "default" | "secondary" | "outline" | "destructive" {
-  switch (status) {
-    case "running":
-      return "default"
-    case "exited":
-    case "created":
-    case "paused":
-    case "dead":
-      return "secondary"
-    case "not_found":
-      return "outline"
-    default:
-      return "secondary"
-  }
 }
 
 export default async function WorkflowRunDetailPage({
@@ -94,13 +73,15 @@ export default async function WorkflowRunDetailPage({
         <div className="space-y-2">
           <h1 className="text-2xl font-bold flex items-center gap-3 flex-wrap">
             {issue?.title || `Workflow Run: ${traceId}`}
-            <Badge variant={badgeVariantForStatus(containerStatus)}>
-              Container: {containerStatus}
-            </Badge>
           </h1>
+          {/* Container actions & status */}
+          <ContainerManager
+            workflowId={traceId}
+            initialStatus={containerStatus}
+          />
           {workflow.type && (
             <p className="text-sm text-muted-foreground">
-              Workflow Type:{" "}
+              Workflow Type: {" "}
               {workflow.type === "commentOnIssue"
                 ? "Comment on Issue"
                 : workflow.type}
@@ -135,3 +116,4 @@ export default async function WorkflowRunDetailPage({
     </main>
   )
 }
+

--- a/app/workflow-runs/[traceId]/page.tsx
+++ b/app/workflow-runs/[traceId]/page.tsx
@@ -3,8 +3,8 @@ import Link from "next/link"
 import { notFound } from "next/navigation"
 
 import BaseGitHubItemCard from "@/components/github/BaseGitHubItemCard"
-import ContainerManager from "@/components/workflow-runs/ContainerManager"
 import { Button } from "@/components/ui/button"
+import ContainerManager from "@/components/workflow-runs/ContainerManager"
 import WorkflowRunEventsFeed from "@/components/workflow-runs/WorkflowRunEventsFeed"
 import { getContainerStatus } from "@/lib/docker"
 import { getIssue } from "@/lib/github/issues"
@@ -81,7 +81,7 @@ export default async function WorkflowRunDetailPage({
           />
           {workflow.type && (
             <p className="text-sm text-muted-foreground">
-              Workflow Type: {" "}
+              Workflow Type:{" "}
               {workflow.type === "commentOnIssue"
                 ? "Comment on Issue"
                 : workflow.type}
@@ -116,4 +116,3 @@ export default async function WorkflowRunDetailPage({
     </main>
   )
 }
-

--- a/components/workflow-runs/ContainerManager.tsx
+++ b/components/workflow-runs/ContainerManager.tsx
@@ -1,0 +1,114 @@
+"use client"
+
+import { useCallback } from "react"
+import useSWR from "swr"
+import { Loader2, Play, Square, Trash2 } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+
+interface Props {
+  workflowId: string
+  /** Initial status returned from the server component for fast paint */
+  initialStatus: string
+}
+
+function badgeVariantForStatus(
+  status: string
+): "default" | "secondary" | "outline" | "destructive" {
+  switch (status) {
+    case "running":
+      return "default"
+    case "exited":
+    case "created":
+    case "paused":
+    case "dead":
+      return "secondary"
+    case "not_found":
+      return "outline"
+    default:
+      return "secondary"
+  }
+}
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json())
+
+export default function ContainerManager({ workflowId, initialStatus }: Props) {
+  const { data, mutate, isValidating } = useSWR<{ status: string }>(
+    `/api/workflow-runs/${workflowId}/container`,
+    fetcher,
+    {
+      fallbackData: { status: initialStatus },
+      refreshInterval: (latest) => {
+        // Poll periodically to refresh status. Faster while running.
+        if (!latest) return 0
+        return latest.status === "running" ? 5000 : 15000
+      },
+    }
+  )
+
+  const status = data?.status ?? "unknown"
+
+  const performAction = useCallback(
+    async (action: "start" | "stop" | "delete") => {
+      await fetch(`/api/workflow-runs/${workflowId}/container`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action }),
+      })
+      mutate()
+    },
+    [workflowId, mutate]
+  )
+
+  return (
+    <div className="flex items-center gap-3 flex-wrap">
+      {/* Status badge */}
+      <Badge variant={badgeVariantForStatus(status)}>Container: {status}</Badge>
+
+      {/* Action buttons */}
+      <div className="flex items-center gap-2">
+        <Button
+          size="sm"
+          variant="secondary"
+          disabled={status === "running" || isValidating}
+          onClick={() => performAction("start")}
+        >
+          {isValidating ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Play className="h-4 w-4" />
+          )}
+          <span className="sr-only">Start container</span>
+        </Button>
+        <Button
+          size="sm"
+          variant="secondary"
+          disabled={status !== "running" || isValidating}
+          onClick={() => performAction("stop")}
+        >
+          {isValidating ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Square className="h-4 w-4" />
+          )}
+          <span className="sr-only">Stop container</span>
+        </Button>
+        <Button
+          size="sm"
+          variant="destructive"
+          disabled={status === "not_found" || isValidating}
+          onClick={() => performAction("delete")}
+        >
+          {isValidating ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Trash2 className="h-4 w-4" />
+          )}
+          <span className="sr-only">Delete container</span>
+        </Button>
+      </div>
+    </div>
+  )
+}
+

--- a/components/workflow-runs/ContainerManager.tsx
+++ b/components/workflow-runs/ContainerManager.tsx
@@ -1,8 +1,8 @@
 "use client"
 
+import { Loader2, Play, Square, Trash2 } from "lucide-react"
 import { useCallback } from "react"
 import useSWR from "swr"
-import { Loader2, Play, Square, Trash2 } from "lucide-react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -111,4 +111,3 @@ export default function ContainerManager({ workflowId, initialStatus }: Props) {
     </div>
   )
 }
-


### PR DESCRIPTION
### What
Adds container lifecycle controls (start, stop, delete) to each Workflow Run.

### Why
Previously a workflow’s Docker container was started and left running forever. Users had no way to manage it, quickly exhausting machine resources.

### How
1. **API** – New route `app/api/workflow-runs/[workflowId]/container/route.ts`
   • `GET` returns current container status.
   • `POST` accepts `{ action: "start" | "stop" | "delete" }` and performs the requested Docker command.

2. **Client UI** – `components/workflow-runs/ContainerManager.tsx`
   • Shows a status badge that auto-refreshes (SWR polling).
   • Provides Start, Stop, and Delete buttons with sensible disabled states.

3. **Page integration** – Injected `ContainerManager` into `app/workflow-runs/[traceId]/page.tsx` replacing the static badge.

### Result
Users can now:
• Start a previously stopped container.
• Gracefully stop a running container.
• Delete a container entirely.
Status updates live-refresh, honouring the rule of least surprise.

Closes #868