### PR TITLE
Restrict playground to admin users

### DIFF
--- a/app/playground/evals/page.tsx
+++ b/app/playground/evals/page.tsx
@@ -1,9 +1,24 @@
 import Link from "next/link"
+import { redirect } from "next/navigation"
 
+import { auth } from "@/auth"
+import { getGithubUser } from "@/lib/github/users"
+import { getUserRoles } from "@/lib/neo4j/services/user"
 import PlanEvalCard from "@/components/playground/PlanEvalCard"
 import { Button } from "@/components/ui/button"
 
-export default function EvalsPage() {
+export default async function EvalsPage() {
+  const session = await auth()
+  if (!session?.user) {
+    redirect("/")
+  }
+
+  const githubUser = await getGithubUser()
+  const roles = githubUser ? await getUserRoles(githubUser.login).catch(() => []) : []
+  if (!roles.includes("admin")) {
+    redirect("/")
+  }
+
   return (
     <div className="container mx-auto py-8 space-y-4">
       <div>
@@ -25,3 +40,4 @@ export default function EvalsPage() {
     </div>
   )
 }
+

--- a/app/playground/evals/page.tsx
+++ b/app/playground/evals/page.tsx
@@ -2,10 +2,10 @@ import Link from "next/link"
 import { redirect } from "next/navigation"
 
 import { auth } from "@/auth"
-import { getGithubUser } from "@/lib/github/users"
-import { getUserRoles } from "@/lib/neo4j/services/user"
 import PlanEvalCard from "@/components/playground/PlanEvalCard"
 import { Button } from "@/components/ui/button"
+import { getGithubUser } from "@/lib/github/users"
+import { getUserRoles } from "@/lib/neo4j/services/user"
 
 export default async function EvalsPage() {
   const session = await auth()
@@ -14,7 +14,9 @@ export default async function EvalsPage() {
   }
 
   const githubUser = await getGithubUser()
-  const roles = githubUser ? await getUserRoles(githubUser.login).catch(() => []) : []
+  const roles = githubUser
+    ? await getUserRoles(githubUser.login).catch(() => [])
+    : []
   if (!roles.includes("admin")) {
     redirect("/")
   }
@@ -40,4 +42,3 @@ export default async function EvalsPage() {
     </div>
   )
 }
-

--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -18,8 +18,6 @@ import Link from "next/link"
 import { redirect } from "next/navigation"
 
 import { auth } from "@/auth"
-import { getGithubUser } from "@/lib/github/users"
-import { getUserRoles } from "@/lib/neo4j/services/user"
 import OAuthTokenCard from "@/components/auth/OAuthTokenCard"
 import AgentWorkflowClient from "@/components/playground/AgentWorkflowClient"
 import ApplyPatchCard from "@/components/playground/ApplyPatchCard"
@@ -30,6 +28,8 @@ import SpeechToTextCard from "@/components/playground/SpeechToTextCard"
 import UserRolesCard from "@/components/playground/UserRolesCard"
 import WriteFileCard from "@/components/playground/WriteFileCard"
 import { Button } from "@/components/ui/button"
+import { getGithubUser } from "@/lib/github/users"
+import { getUserRoles } from "@/lib/neo4j/services/user"
 
 export default async function PlaygroundPage() {
   const session = await auth()
@@ -38,7 +38,9 @@ export default async function PlaygroundPage() {
   }
 
   const githubUser = await getGithubUser()
-  const roles = githubUser ? await getUserRoles(githubUser.login).catch(() => []) : []
+  const roles = githubUser
+    ? await getUserRoles(githubUser.login).catch(() => [])
+    : []
   const isAdmin = roles.includes("admin")
   if (!isAdmin) {
     redirect("/")
@@ -67,4 +69,3 @@ export default async function PlaygroundPage() {
     </div>
   )
 }
-

--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -15,8 +15,11 @@ const DEFAULT_TOOLS = [
 ]
 
 import Link from "next/link"
+import { redirect } from "next/navigation"
 
 import { auth } from "@/auth"
+import { getGithubUser } from "@/lib/github/users"
+import { getUserRoles } from "@/lib/neo4j/services/user"
 import OAuthTokenCard from "@/components/auth/OAuthTokenCard"
 import AgentWorkflowClient from "@/components/playground/AgentWorkflowClient"
 import ApplyPatchCard from "@/components/playground/ApplyPatchCard"
@@ -30,6 +33,17 @@ import { Button } from "@/components/ui/button"
 
 export default async function PlaygroundPage() {
   const session = await auth()
+  if (!session?.user) {
+    redirect("/")
+  }
+
+  const githubUser = await getGithubUser()
+  const roles = githubUser ? await getUserRoles(githubUser.login).catch(() => []) : []
+  const isAdmin = roles.includes("admin")
+  if (!isAdmin) {
+    redirect("/")
+  }
+
   const token = session?.token?.access_token as string | undefined
 
   return (
@@ -53,3 +67,4 @@ export default async function PlaygroundPage() {
     </div>
   )
 }
+

--- a/components/layout/DynamicNavigation.tsx
+++ b/components/layout/DynamicNavigation.tsx
@@ -230,4 +230,3 @@ export default function DynamicNavigation({
     </>
   )
 }
-

--- a/components/layout/DynamicNavigation.tsx
+++ b/components/layout/DynamicNavigation.tsx
@@ -28,9 +28,11 @@ const landingNavItems = [
 export default function DynamicNavigation({
   username,
   isAuthenticated,
+  isAdmin,
 }: {
   username: string | null
   isAuthenticated: boolean
+  isAdmin: boolean
 }) {
   const pathname = usePathname()
   const searchParams = useSearchParams()
@@ -123,14 +125,16 @@ export default function DynamicNavigation({
           >
             <Link href="/workflow-runs">Workflows</Link>
           </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            asChild
-            className="flex items-center"
-          >
-            <Link href="/playground">Playground</Link>
-          </Button>
+          {isAdmin && (
+            <Button
+              variant="ghost"
+              size="sm"
+              asChild
+              className="flex items-center"
+            >
+              <Link href="/playground">Playground</Link>
+            </Button>
+          )}
           <Button
             variant="ghost"
             size="sm"
@@ -176,7 +180,7 @@ export default function DynamicNavigation({
           <SheetContent side="left" className="sm:hidden w-64 p-4">
             <nav className="mt-4 flex flex-col gap-4">
               <Link href="/workflow-runs">Workflows</Link>
-              <Link href="/playground">Playground</Link>
+              {isAdmin && <Link href="/playground">Playground</Link>}
               <Link href="/issues">Issues</Link>
               <Link href="/kanban">Kanban</Link>
               <Link href="/contribute">Contribute</Link>

--- a/components/layout/DynamicNavigation.tsx
+++ b/components/layout/DynamicNavigation.tsx
@@ -26,11 +26,9 @@ const landingNavItems = [
 ]
 
 export default function DynamicNavigation({
-  username,
   isAuthenticated,
   isAdmin,
 }: {
-  username: string | null
   isAuthenticated: boolean
   isAdmin: boolean
 }) {

--- a/components/layout/Navigation.tsx
+++ b/components/layout/Navigation.tsx
@@ -54,7 +54,6 @@ export default async function Navigation() {
 
           {/* Dynamic Navigation based on route */}
           <DynamicNavigation
-            username={githubUser?.login ?? session?.user?.name ?? null}
             isAuthenticated={!!session?.user}
             isAdmin={isAdmin}
           />
@@ -63,4 +62,3 @@ export default async function Navigation() {
     </motion.header>
   )
 }
-


### PR DESCRIPTION
### Overview
This PR implements role-based access control for the `/playground` feature set.

### Key Changes
1. **Authorization checks on pages**  
   * `app/playground/page.tsx` and `app/playground/evals/page.tsx` now verify that the authenticated user possesses the `admin` role (stored in Neo4j). Non-admin users are redirected to the home page.

2. **Navigation updates**  
   * `components/layout/Navigation.tsx` determines whether the current user is an admin and passes that flag down to the dynamic navigation component.
   * `components/layout/DynamicNavigation.tsx` accepts the new `isAdmin` prop and only renders the "Playground" links (desktop & mobile) when the user is an admin.

### Result
* Only users with the `admin` role can access `/playground` and its sub-pages.
* Non-admin users no longer see navigation links to the playground, preventing accidental discovery.

This fully addresses the GitHub issue **"Restrict /playground access to admin users"**.

Closes #873