### PR TITLE
Handle errors during GitHub issue creation in NewTaskInput

### DIFF
--- a/components/issues/NewTaskInput.tsx
+++ b/components/issues/NewTaskInput.tsx
@@ -19,6 +19,11 @@ export default function NewTaskInput({ repoFullName }: Props) {
   const [description, setDescription] = useState("")
   const [loading, setLoading] = useState(false)
   const [generatingTitle, setGeneratingTitle] = useState(false)
+  // useTransition is useful for UI updates (e.g. router.refresh).
+  // We should NOT perform remote/network work inside the transition callback
+  // because any thrown error will escape the surrounding try/catch resulting
+  // in an unhandled runtime error. Instead we do the async work first and
+  // then transition the UI update.
   const [isPending, startTransition] = useTransition()
 
   // Recording related state
@@ -80,36 +85,42 @@ export default function NewTaskInput({ repoFullName }: Props) {
 
     setLoading(true)
     try {
-      startTransition(async () => {
-        const res = await createIssue({
-          repoFullName,
-          title: taskTitle,
-          body: description,
-        })
-        if (res.status === 201) {
-          toast({
-            title: "Task synced to GitHub",
-            description: `Created: ${taskTitle}`,
-            variant: "default",
-          })
-          setDescription("")
-          // Refresh the data so the new issue appears in the list immediately
-          router.refresh()
-        } else {
-          toast({
-            title: "Error creating task",
-            description: res.status || "Failed to create GitHub issue.",
-            variant: "destructive",
-          })
-        }
-        setLoading(false)
+      // 1️⃣ Perform the async GitHub call **outside** of startTransition so
+      //     errors are captured by this try/catch.
+      const res = await createIssue({
+        repoFullName,
+        title: taskTitle,
+        body: description,
       })
-    } catch (err: unknown) {
+
+      if (res.status === 201) {
+        toast({
+          title: "Task synced to GitHub",
+          description: `Created: ${taskTitle}`,
+          variant: "default",
+        })
+        setDescription("")
+        // 2️⃣ Then transition any UI updates (like router.refresh) that can be
+        //     deferred without blocking user feedback.
+        startTransition(() => {
+          router.refresh()
+        })
+      } else {
+        toast({
+          title: "Error creating task",
+          description: res.status || "Failed to create GitHub issue.",
+          variant: "destructive",
+        })
+      }
+    } catch (err: any) {
+      // Attempt to use GitHub error message if available
+      const message = err?.message || String(err)
       toast({
         title: "Error creating task",
-        description: String(err),
+        description: message,
         variant: "destructive",
       })
+    } finally {
       setLoading(false)
     }
   }
@@ -226,3 +237,4 @@ export default function NewTaskInput({ repoFullName }: Props) {
     </form>
   )
 }
+


### PR DESCRIPTION
### Problem
Creating a GitHub issue from the **Issues** page could crash the UI when the GitHub API returned an error (e.g. *"Issues are disabled for this repo"*). The network request ran inside a `startTransition` callback, so the exception was **not** caught by the surrounding `try/catch`, leading to an unhandled runtime error.

### Solution
1. Execute `createIssue` *outside* of `startTransition` so we can `await` it and catch any thrown errors.
2. Use `startTransition` solely for UI-only work (`router.refresh`).
3. Surface meaningful error messages to the user via toast notifications.
4. Added inline comments to document the rationale and avoid future regressions.

### Result
Errors coming from the GitHub API are now handled gracefully and the page no longer crashes. Users receive a clear toast notification instead.

Closes #884