### PR TITLE
Reduce horizontal padding on mobile issues page

### DIFF
--- a/app/[username]/[repo]/issues/page.tsx
+++ b/app/[username]/[repo]/issues/page.tsx
@@ -18,7 +18,8 @@ export default async function RepoPage({ params }: Props) {
   const repoFullName = repoFullNameSchema.parse(`${username}/${repo}`)
 
   return (
-    <main className="container mx-auto p-4">
+    // Reduce horizontal padding on small screens while retaining existing spacing on larger breakpoints
+    <main className="container mx-auto p-2 sm:p-4">
       <div className="flex justify-between items-center mb-4 gap-4">
         <h1 className="text-2xl font-bold">
           {username} / {repo} - Issues
@@ -31,3 +32,4 @@ export default async function RepoPage({ params }: Props) {
     </main>
   )
 }
+

--- a/app/issues/page.tsx
+++ b/app/issues/page.tsx
@@ -22,7 +22,8 @@ export default async function IssuesPage({
     const firstRepo = repos[0]
     if (!firstRepo) {
       return (
-        <div className="container mx-auto py-10">
+        // Reduce horizontal padding on small screens too
+        <div className="container mx-auto py-10 px-2 sm:px-4">
           <h1 className="text-2xl font-bold mb-6">Your Issues</h1>
           <div className="text-destructive">
             You have no accessible repositories. Please add or connect a GitHub
@@ -42,7 +43,8 @@ export default async function IssuesPage({
 
   const repoFullName = repoFullNameParseResult.data
   return (
-    <main className="container mx-auto py-10 max-w-4xl w-full">
+    // Add smaller horizontal padding on mobile while keeping layout unchanged otherwise
+    <main className="container mx-auto py-10 px-2 sm:px-4 max-w-4xl w-full">
       <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-6 gap-4">
         <h1 className="text-2xl font-bold">Your Issues & Workflows</h1>
         <div className="flex items-center gap-3">
@@ -60,3 +62,4 @@ export default async function IssuesPage({
     </main>
   )
 }
+


### PR DESCRIPTION
### Problem
On mobile devices the main issues list pages (`/issues` and repository-specific `/[username]/[repo]/issues`) had fairly wide horizontal padding (coming from Tailwind's `container` padding plus our own `p-4`). This left unnecessary empty space and made content feel cramped.

### Solution
Apply smaller horizontal padding on small screens while retaining the previous spacing on larger breakpoints:

* `app/[username]/[repo]/issues/page.tsx` – change `p-4` to `p-2 sm:p-4`.
* `app/issues/page.tsx` – add `px-2 sm:px-4` to the main container and the fallback "no repos" container.

`sm` and above remains unchanged (`p-4`), so desktop/tablet layouts are identical, but mobile now gets a more generous content width.

### Notes
No functional/logic changes – just CSS class tweaks. No tests affected.

Closes #889