### PR TITLE
Limit GitHub OAuth scope to basic read-only user info

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -36,7 +36,7 @@ function getRedirectBaseUrl() {
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
   providers: [
-    // Traditional OAuth provider for public repository access
+    // Traditional OAuth provider – limited to basic read-only user information
     GithubProvider({
       id: "github-oauth",
       name: "GitHub OAuth",
@@ -45,7 +45,9 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       authorization: {
         url: "https://github.com/login/oauth/authorize",
         params: {
-          scope: "read:user user:email repo workflow",
+          // Request ONLY public profile + e-mail so that later we can separately ask
+          // for additional repository scopes via the GitHub App installation flow.
+          scope: "read:user user:email",
           redirect_uri: `${getRedirectBaseUrl()}/api/auth/callback/github-oauth`,
         },
       },
@@ -134,3 +136,4 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     },
   },
 })
+


### PR DESCRIPTION
### Why
The application only needs a user's public profile and email address for the initial sign-in step. Repository-level permissions will be requested later via the GitHub App installation flow. Keeping the OAuth scope minimal improves security and user trust.

### What
* Removed the unnecessary `repo` and `workflow` scopes from the `github-oauth` provider in `auth.ts`.
* The provider now requests only `read:user user:email`, which is sufficient for obtaining the avatar, name and verified email.

### Notes
No other code changes were required. This reduction in permissions aligns with the principle of least privilege and the upcoming GitHub App flow.

Closes #902