### PR TITLE
Switch auto-resolve workflows to GitHub App authentication

### DIFF
--- a/app/api/resolve/route.ts
+++ b/app/api/resolve/route.ts
@@ -2,81 +2,88 @@ import { NextRequest, NextResponse } from "next/server"
 import { v4 as uuidv4 } from "uuid"
 import { z } from "zod"
 
+import { App } from "octokit"
+
+import { getPrivateKeyFromFile } from "@/lib/github"
 import { getRepoFromString } from "@/lib/github/content"
 import { getIssue } from "@/lib/github/issues"
 import { getUserOpenAIApiKey } from "@/lib/neo4j/services/user"
 import { ResolveRequestSchema } from "@/lib/schemas/api"
+import { runWithInstallationId } from "@/lib/utils/utils-server"
 import { resolveIssue } from "@/lib/workflows/resolveIssue"
+
+async function getRepoInstallationId(repoFullName: string): Promise<number | null> {
+  try {
+    const [owner, repo] = repoFullName.split("/")
+    if (!owner || !repo) return null
+
+    const appId = process.env.GITHUB_APP_ID
+    if (!appId) return null
+
+    const privateKey = await getPrivateKeyFromFile()
+    const app = new App({ appId, privateKey })
+    const installation = await app.getRepoInstallation({ owner, repo })
+    return installation.id
+  } catch (err) {
+    console.warn(`[WARNING] Unable to resolve installation id for ${repoFullName}:`, err)
+    return null
+  }
+}
 
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
 
-    const {
-      issueNumber,
-      repoFullName,
-      createPR,
-      environment,
-      installCommand,
-      planId,
-    } = ResolveRequestSchema.parse(body)
+    const { issueNumber, repoFullName, createPR, environment, installCommand, planId } = ResolveRequestSchema.parse(body)
+
     const apiKey = await getUserOpenAIApiKey()
     if (!apiKey) {
-      return NextResponse.json(
-        { error: "Missing OpenAI API key" },
-        { status: 401 }
-      )
+      return NextResponse.json({ error: "Missing OpenAI API key" }, { status: 401 })
     }
 
-    // Generate a unique job ID
     const jobId = uuidv4()
 
-    // Start the resolve workflow as a background job
     ;(async () => {
       try {
-        // Get full repository details and issue
-        const fullRepo = await getRepoFromString(repoFullName)
-        const issue = await getIssue({
-          fullName: repoFullName,
-          issueNumber,
-        })
+        const installationId = await getRepoInstallationId(repoFullName)
 
-        if (issue.type !== "success") {
-          throw new Error(JSON.stringify(issue))
+        const executeWorkflow = async () => {
+          const fullRepo = await getRepoFromString(repoFullName)
+          const issue = await getIssue({ fullName: repoFullName, issueNumber })
+
+          if (issue.type !== "success") {
+            throw new Error(JSON.stringify(issue))
+          }
+
+          await resolveIssue({
+            issue: issue.issue,
+            repository: fullRepo,
+            apiKey,
+            jobId,
+            createPR,
+            planId,
+            ...(environment && { environment }),
+            ...(installCommand && { installCommand }),
+          })
         }
 
-        await resolveIssue({
-          issue: issue.issue,
-          repository: fullRepo,
-          apiKey,
-          jobId,
-          createPR,
-          planId,
-          ...(environment && { environment }),
-          ...(installCommand && { installCommand }),
-        })
+        if (installationId) {
+          runWithInstallationId(String(installationId), executeWorkflow)
+        } else {
+          await executeWorkflow()
+        }
       } catch (error) {
-        // Save error status
         console.error(String(error))
       }
     })()
 
-    // Return the job ID immediately
     return NextResponse.json({ jobId })
   } catch (error) {
     console.error("Error processing request:", error)
     if (error instanceof z.ZodError) {
-      return NextResponse.json(
-        {
-          error: "Invalid request data",
-          details: error.errors,
-        },
-        { status: 400 }
-      )
+      return NextResponse.json({ error: "Invalid request data", details: error.errors }, { status: 400 })
     }
-    return NextResponse.json(
-      { error: "Failed to process request" },
-      { status: 500 }
-    )
+    return NextResponse.json({ error: "Failed to process request" }, { status: 500 })
   }
 }
+

--- a/app/api/workflow/autoResolveIssue/route.ts
+++ b/app/api/workflow/autoResolveIssue/route.ts
@@ -2,46 +2,66 @@ import { NextRequest, NextResponse } from "next/server"
 import { v4 as uuidv4 } from "uuid"
 import { z } from "zod"
 
+import { App } from "octokit"
+
+import { getPrivateKeyFromFile } from "@/lib/github"
 import { getRepoFromString } from "@/lib/github/content"
 import { getIssue } from "@/lib/github/issues"
 import { getUserOpenAIApiKey } from "@/lib/neo4j/services/user"
 import { AutoResolveIssueRequestSchema } from "@/lib/schemas/api"
+import { runWithInstallationId } from "@/lib/utils/utils-server"
 import autoResolveIssue from "@/lib/workflows/autoResolveIssue"
+
+async function getRepoInstallationId(repoFullName: string): Promise<number | null> {
+  try {
+    const [owner, repo] = repoFullName.split("/")
+    if (!owner || !repo) return null
+
+    const appId = process.env.GITHUB_APP_ID
+    if (!appId) return null
+
+    const privateKey = await getPrivateKeyFromFile()
+    const app = new App({ appId, privateKey })
+    const installation = await app.getRepoInstallation({ owner, repo })
+    return installation.id
+  } catch (err) {
+    console.warn(`[WARNING] Unable to resolve installation id for ${repoFullName}:`, err)
+    return null
+  }
+}
 
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
-    const { issueNumber, repoFullName } =
-      AutoResolveIssueRequestSchema.parse(body)
+    const { issueNumber, repoFullName } = AutoResolveIssueRequestSchema.parse(body)
 
     const apiKey = await getUserOpenAIApiKey()
     if (!apiKey) {
-      return NextResponse.json(
-        { error: "Missing OpenAI API key" },
-        { status: 401 }
-      )
+      return NextResponse.json({ error: "Missing OpenAI API key" }, { status: 401 })
     }
 
     const jobId = uuidv4()
 
     ;(async () => {
       try {
-        const repo = await getRepoFromString(repoFullName)
-        const issueResult = await getIssue({
-          fullName: repoFullName,
-          issueNumber,
-        })
+        const installationId = await getRepoInstallationId(repoFullName)
 
-        if (issueResult.type !== "success") {
-          throw new Error(JSON.stringify(issueResult))
+        const executeWorkflow = async () => {
+          const repo = await getRepoFromString(repoFullName)
+          const issueResult = await getIssue({ fullName: repoFullName, issueNumber })
+
+          if (issueResult.type !== "success") {
+            throw new Error(JSON.stringify(issueResult))
+          }
+
+          await autoResolveIssue({ issue: issueResult.issue, repository: repo, apiKey, jobId })
         }
 
-        await autoResolveIssue({
-          issue: issueResult.issue,
-          repository: repo,
-          apiKey,
-          jobId,
-        })
+        if (installationId) {
+          runWithInstallationId(String(installationId), executeWorkflow)
+        } else {
+          await executeWorkflow()
+        }
       } catch (error) {
         console.error(error)
       }
@@ -51,14 +71,9 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     console.error("Error processing request:", error)
     if (error instanceof z.ZodError) {
-      return NextResponse.json(
-        { error: "Invalid request data", details: error.errors },
-        { status: 400 }
-      )
+      return NextResponse.json({ error: "Invalid request data", details: error.errors }, { status: 400 })
     }
-    return NextResponse.json(
-      { error: "Failed to process request" },
-      { status: 500 }
-    )
+    return NextResponse.json({ error: "Failed to process request" }, { status: 500 })
   }
 }
+


### PR DESCRIPTION
### Summary
Migrates the *autoResolveIssue* and *resolveIssue* workflows away from classic
OAuth authentication and over to our GitHub App (`issuetopr-dev`).

### Key Points
1. **Installation ID detection**
   * Added lightweight helper inside the API routes to query the GitHub REST
     API (via `octokit.App`) for the installation associated with the target
     repository.
2. **Context propagation**
   * Wrapped workflow execution inside `runWithInstallationId(...)` so all
     downstream GitHub helpers transparently receive the installation ID
     through the `asyncLocalStorage` mechanism that already exists in the
     code-base.
3. **Fallback safety**
   * If the App is *not* installed (public repo, etc.) the routes fall back to
     previous behaviour without impacting users.

### Files changed
* `app/api/workflow/autoResolveIssue/route.ts`
* `app/api/resolve/route.ts`

These changes ensure cloning, pushing, permission checks and PR creation now
work with the GitHub App installation tokens, completing the migration
requested in the linked issue.

Closes #905