### PR TITLE
Handle invalid GitHub tokens

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { SessionProvider } from "next-auth/react"
 
 import { auth } from "@/auth"
 import Navigation from "@/components/layout/Navigation"
+import TokenErrorToast from "@/components/common/TokenErrorToast"
 import { Toaster } from "@/components/ui/toaster"
 
 const inter = Inter({ subsets: ["latin"] })
@@ -31,6 +32,7 @@ export default async function RootLayout({
       >
         <SessionProvider session={session}>
           <Navigation />
+          <TokenErrorToast />
           {children}
           <Toaster />
         </SessionProvider>

--- a/components/common/TokenErrorToast.tsx
+++ b/components/common/TokenErrorToast.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { useEffect } from "react"
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
+
+import { useToast } from "@/lib/hooks/use-toast"
+
+export default function TokenErrorToast() {
+  const searchParams = useSearchParams()
+  const pathname = usePathname()
+  const router = useRouter()
+  const { toast } = useToast()
+
+  useEffect(() => {
+    if (searchParams.get("error") === "invalid-token") {
+      toast({
+        variant: "destructive",
+        title: "Authentication Error",
+        description: "Your GitHub token was invalid. Please sign in again.",
+      })
+      const params = new URLSearchParams(searchParams.toString())
+      params.delete("error")
+      const newQuery = params.toString()
+      router.replace(newQuery ? `${pathname}?${newQuery}` : pathname)
+    }
+  }, [searchParams, toast, router, pathname])
+
+  return null
+}
+

--- a/lib/github/users.ts
+++ b/lib/github/users.ts
@@ -1,9 +1,10 @@
 "use server"
 
-import { getUserOctokit } from "@/lib/github"
+import { getUserOctokit, GitHubTokenError } from "@/lib/github"
 import { listUserRepositories } from "@/lib/github/graphql/queries/listUserRepositories"
 import { listUserAppRepositories } from "@/lib/github/repos"
 import { GitHubUser, RepoPermissions } from "@/lib/types/github"
+import { signOut } from "@/auth"
 
 export async function getGithubUser(): Promise<GitHubUser | null> {
   try {
@@ -17,6 +18,9 @@ export async function getGithubUser(): Promise<GitHubUser | null> {
     return user
   } catch (e) {
     console.error(e)
+    if (e instanceof GitHubTokenError) {
+      await signOut({ redirectTo: "/?error=invalid-token" })
+    }
     return null
   }
 }


### PR DESCRIPTION
## Summary
- detect invalid GitHub tokens when creating Octokit
- sign out when authentication fails
- surface token failure to the user via toast message

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68875012ced88333bdae7be3815b1058