### PR TITLE
feat: Add responsive Event Detail Drawer on Workflow Run Details page

### DIFF
--- a/components/workflow-runs/EventDetailDrawer.tsx
+++ b/components/workflow-runs/EventDetailDrawer.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import { useMediaQuery } from "@/lib/hooks/use-media-query"
+import { AnyEvent } from "@/lib/types"
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+  SheetClose,
+} from "@/components/ui/sheet"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Button } from "@/components/ui/button"
+
+interface Props {
+  event: AnyEvent | null
+  onOpenChange: (open: boolean) => void
+}
+
+export default function EventDetailDrawer({ event, onOpenChange }: Props) {
+  const isMobile = useMediaQuery("max-sm")
+
+  return (
+    <Sheet open={!!event} onOpenChange={onOpenChange}>
+      <SheetContent side={isMobile ? "bottom" : "right"} className="sm:max-w-md w-full">
+        <SheetHeader>
+          <SheetTitle>Event Details</SheetTitle>
+          {event && (
+            <SheetDescription>
+              <span className="font-mono text-xs text-muted-foreground">{event.type}</span>
+            </SheetDescription>
+          )}
+        </SheetHeader>
+        <ScrollArea className="h-full pr-4 mt-4">
+          {event ? (
+            <pre className="text-xs whitespace-pre-wrap break-all">
+              {JSON.stringify(event, null, 2)}
+            </pre>
+          ) : (
+            <div className="text-center text-sm text-muted-foreground">No event selected</div>
+          )}
+        </ScrollArea>
+        <div className="mt-4 flex justify-end">
+          <SheetClose asChild>
+            <Button variant="secondary" size="sm">
+              Close
+            </Button>
+          </SheetClose>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}
+

--- a/components/workflow-runs/WorkflowRunEventsFeed.tsx
+++ b/components/workflow-runs/WorkflowRunEventsFeed.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import useSWR from "swr"
+import { useState, Fragment } from "react"
 
 import { ErrorEvent } from "@/components/workflow-runs/events/ErrorEvent"
 import { LLMResponseEvent } from "@/components/workflow-runs/events/LLMResponseEvent"
@@ -10,6 +11,7 @@ import { ToolCallEvent } from "@/components/workflow-runs/events/ToolCallEvent"
 import { ToolCallResultEvent } from "@/components/workflow-runs/events/ToolCallResultEvent"
 import { UserMessageEvent } from "@/components/workflow-runs/events/UserMessageEvent"
 import { AnyEvent, Issue } from "@/lib/types"
+import EventDetailDrawer from "@/components/workflow-runs/EventDetailDrawer"
 
 interface Props {
   workflowId: string
@@ -56,6 +58,8 @@ export default function WorkflowRunEventsFeed({
   initialEvents,
   issue,
 }: Props) {
+  const [selectedEvent, setSelectedEvent] = useState<AnyEvent | null>(null)
+
   // Check if workflow has reached a terminal state
   const isWorkflowComplete = (events: AnyEvent[]) => {
     const latestWorkflowStateEvent = [...events]
@@ -66,7 +70,7 @@ export default function WorkflowRunEventsFeed({
 
     // WorkflowStateEvent has a 'state' property
     if (latestWorkflowStateEvent.type === "workflowState") {
-      const state = latestWorkflowStateEvent.state
+      const state = (latestWorkflowStateEvent as any).state
       return state === "completed" || state === "error"
     }
 
@@ -82,12 +86,26 @@ export default function WorkflowRunEventsFeed({
   if (!data) return null
 
   return (
-    <div className="bg-card border rounded-lg overflow-hidden">
-      {data.map((event) => (
-        <div key={event.id} className="p-3 sm:p-4">
-          <EventRenderer event={event} issue={issue} />
-        </div>
-      ))}
-    </div>
+    <Fragment>
+      <div className="bg-card border rounded-lg overflow-hidden">
+        {data.map((event) => (
+          <div
+            key={event.id}
+            className="p-3 sm:p-4 hover:bg-muted/50 cursor-pointer"
+            onClick={() => setSelectedEvent(event)}
+          >
+            <EventRenderer event={event} issue={issue} />
+          </div>
+        ))}
+      </div>
+
+      <EventDetailDrawer
+        event={selectedEvent}
+        onOpenChange={(open) => {
+          if (!open) setSelectedEvent(null)
+        }}
+      />
+    </Fragment>
   )
 }
+


### PR DESCRIPTION
### Summary
This PR introduces a responsive Event Detail Drawer to the Workflow Run Details page.

### Key Points
* **EventDetailDrawer** – New component built on our existing Radix‐powered `Sheet` primitive.
  * Automatically slides **from the right on desktop** and **from the bottom on mobile** via `useMediaQuery`.
  * Presents all available event data in a scrollable area (for now as formatted JSON – ready for future richer layouts).
* **WorkflowRunEventsFeed**
  * Maintains `selectedEvent` state.
  * Clicking any event row now opens the drawer with its details.
  * Adds subtle hover + cursor styling to hint interactivity.

### Demo
Desktop → Drawer on the right.  
Mobile → Drawer from bottom.

### Future Enhancements
* Replace raw JSON with a more user-friendly, event-specific layout.
* Add deep-link / URL hash support to open a particular event directly.

---
Label: `AI generated`

Closes #919