### PR TITLE
Fix Langfuse integration in autoResolveIssue workflow

### DIFF
--- a/lib/workflows/autoResolveIssue.ts
+++ b/lib/workflows/autoResolveIssue.ts
@@ -45,6 +45,11 @@ export const autoResolveIssue = async ({
 
   const workflowId = jobId ?? uuidv4()
 
+  // Langfuse trace & span setup
+  const trace = langfuse.trace({ name: "autoResolve" })
+  const span = trace.span({ name: "PlanAndCodeAgent" })
+  let spanClosed = false
+
   try {
     await initializeWorkflowRun({
       id: workflowId,
@@ -91,9 +96,6 @@ export const autoResolveIssue = async ({
       owner,
       repo,
     })
-
-    const trace = langfuse.trace({ name: "autoResolve" })
-    const span = trace.span({ name: "PlanAndCodeAgent" })
 
     const agent = new PlanAndCodeAgent({
       apiKey,
@@ -147,6 +149,10 @@ export const autoResolveIssue = async ({
 
     await createWorkflowStateEvent({ workflowId, state: "completed" })
 
+    // Close the Langfuse span to ensure data gets flushed
+    span.end()
+    spanClosed = true
+
     return result
   } catch (error) {
     await createErrorEvent({ workflowId, content: String(error) })
@@ -156,7 +162,17 @@ export const autoResolveIssue = async ({
       content: String(error),
     })
     throw error
+  } finally {
+    // Make sure the span is always closed, even on error paths
+    if (!spanClosed) {
+      try {
+        span.end()
+      } catch {
+        /* ignore */
+      }
+    }
   }
 }
 
 export default autoResolveIssue
+


### PR DESCRIPTION
### Problem
Langfuse traces generated by the **autoResolveIssue** workflow were missing the model inputs, outputs and token-usage data. While the workflow did create a Langfuse trace/span, that span was **never closed** so the SDK never flushed the metadata associated with the OpenAI calls.

### Fix
1.  Create the Langfuse trace & span *outside* of the main `try / catch` block so we have access to it in all execution paths.
2.  Explicitly call `span.end()` on the happy-path (right after the agent finishes) so Langfuse can persist the gathered data (inputs, outputs, token cost, …).
3.  Add a `finally` safeguard to make sure the span is always closed even if an error is thrown before the normal `span.end()` call.

This implementation mirrors the working pattern used in other workflows (e.g. **commentOnIssue**) and restores full observability for **autoResolveIssue** runs.

No functional behaviour changes to the agent logic – only observability.


Closes #874