### PR TITLE
Extract image URLs from GitHub issues for agent messages

### DIFF
--- a/lib/workflows/autoResolveIssue.ts
+++ b/lib/workflows/autoResolveIssue.ts
@@ -18,6 +18,7 @@ import {
   createContainerizedDirectoryTree,
   createContainerizedWorkspace,
 } from "@/lib/utils/container"
+import { extractImageUrlsFromMarkdown } from "@/lib/utils/markdown"
 import { setupLocalRepository } from "@/lib/utils/utils-server"
 
 interface Params {
@@ -118,6 +119,16 @@ export const autoResolveIssue = async ({
       type: "message",
     })
 
+    // Add image URLs if present in the issue body
+    const imageUrls = extractImageUrlsFromMarkdown(issue.body ?? "")
+    if (imageUrls.length > 0) {
+      await agent.addInput({
+        role: "user",
+        content: `Github issue images:\n${imageUrls.join("\n")}`,
+        type: "message",
+      })
+    }
+
     if (comments && comments.length > 0) {
       await agent.addInput({
         role: "user",
@@ -160,3 +171,4 @@ export const autoResolveIssue = async ({
 }
 
 export default autoResolveIssue
+

--- a/lib/workflows/commentOnIssue.ts
+++ b/lib/workflows/commentOnIssue.ts
@@ -23,6 +23,7 @@ import {
   createContainerizedDirectoryTree,
   createContainerizedWorkspace,
 } from "@/lib/utils/container"
+import { extractImageUrlsFromMarkdown } from "@/lib/utils/markdown"
 import { setupLocalRepository } from "@/lib/utils/utils-server"
 
 interface GitHubError extends Error {
@@ -218,6 +219,15 @@ export default async function commentOnIssue(
       content: `Github issue title: ${issue.title}\nGithub issue description: ${issue.body}`,
     })
 
+    // Extract image URLs
+    const imageUrls = extractImageUrlsFromMarkdown(issue.body ?? "")
+    if (imageUrls.length > 0) {
+      await thinker.addMessage({
+        role: "user",
+        content: `Github issue images:\n${imageUrls.join("\n")}`,
+      })
+    }
+
     // Add tree information as user message
     if (tree && tree.length > 0) {
       await thinker.addMessage({
@@ -327,7 +337,7 @@ export default async function commentOnIssue(
         await updateIssueComment({
           repoFullName: repo.full_name,
           commentId: initialCommentId,
-          comment: `[Issue to PR] Failed to generate a plan for this issue:\n\n\`\`\`\n${errorMessage}\n\`\`\``,
+          comment: `[Issue to PR] Failed to generate a plan for this issue:\n\n\u0060\u0060\u0060\n${errorMessage}\n\u0060\u0060\u0060`,
         })
       } catch (updateError) {
         console.error("Failed to update error message in comment:", {
@@ -352,3 +362,4 @@ export default async function commentOnIssue(
     }
   }
 }
+

--- a/lib/workflows/resolveIssue.ts
+++ b/lib/workflows/resolveIssue.ts
@@ -40,6 +40,7 @@ import {
   createContainerizedDirectoryTree,
   createContainerizedWorkspace,
 } from "@/lib/utils/container"
+import { extractImageUrlsFromMarkdown } from "@/lib/utils/markdown"
 import { setupLocalRepository } from "@/lib/utils/utils-server"
 
 interface ResolveIssueParams {
@@ -249,6 +250,15 @@ export const resolveIssue = async ({
       content: `Github issue title: ${issue.title}\nGithub issue description: ${issue.body}`,
     })
 
+    // Extract image URLs from the issue body and provide them to the agent if any are found
+    const imageUrls = extractImageUrlsFromMarkdown(issue.body ?? "")
+    if (imageUrls.length > 0) {
+      await coder.addMessage({
+        role: "user",
+        content: `Github issue images:\n${imageUrls.join("\n")}`,
+      })
+    }
+
     // Add comments if they exist
     if (comments && comments.length > 0) {
       await coder.addMessage({
@@ -343,3 +353,4 @@ export const resolveIssue = async ({
     }
   }
 }
+


### PR DESCRIPTION
### What & Why
Agents currently receive the issue title and description, but any images referenced in the markdown are **not** surfaced.  
This change parses the issue body for markdown image syntax (`![alt](url)`) and, when present, supplies the list of image URLs to the agent as an additional `user` message.

### Where
1. `lib/workflows/resolveIssue.ts`
2. `lib/workflows/autoResolveIssue.ts`
3. `lib/workflows/commentOnIssue.ts`

All three workflows now:
* import `extractImageUrlsFromMarkdown` from `lib/utils/markdown`
* call the helper on the issue body
* add a new user message (`Github issue images:`) when one or more URLs are found

### Notes
* No new dependencies were added.
* The helper already existed in the codebase, so only workflow-level wiring was needed.
* Behaviour is completely additive—workflows continue to operate unchanged when no images are present.

This closes the gap described in "Extract image URLs from GitHub issues for agent messages" issue.

Closes #925