### PR TITLE
Fix mobile focus loss in repository search dropdown

### DIFF
--- a/components/common/RepoSelector.tsx
+++ b/components/common/RepoSelector.tsx
@@ -134,6 +134,10 @@ export default function RepoSelector({
             // Auto focus when dropdown opens
             autoFocus
             className="h-8 text-sm"
+            // Prevent Radix Select typeahead from closing the dropdown on key presses.
+            onKeyDown={(e) => e.stopPropagation()}
+            // On mobile, some browsers emit pointer events that can bubble up and close the menu.
+            onPointerDown={(e) => e.stopPropagation()}
           />
         </div>
         {loading && <div className="px-4 py-2">Loading...</div>}


### PR DESCRIPTION
### Problem
On mobile browsers, typing into the repository search field inside the dropdown immediately dismissed the virtual keyboard. Each key press was bubbling up to Radix‐UI's `Select`, triggering the component's built-in type-ahead logic and consequently closing the menu.

### Solution
Stop event propagation from the search `<Input>`:
1. `onKeyDown`: prevents key events from reaching `Select` so the menu stays open while typing.
2. `onPointerDown`: blocks touch/pointer events that could also bubble up and close the menu on some browsers.

These small changes keep the dropdown open and the input focused, allowing continuous typing on mobile devices.

### Affected Components
`components/common/RepoSelector.tsx`

No other functionality is altered.

Closes #929