### PR TITLE
fix: Maintain search bar focus in repo selector

### DIFF
--- a/components/common/RepoSelector.tsx
+++ b/components/common/RepoSelector.tsx
@@ -86,6 +86,24 @@ export default function RepoSelector({
       )
     : repos
 
+  // Ensure that the currently selected repository is always present in the list.
+  // When it vanishes due to a search filter Radix re-calculates focus which causes
+  // the <Input> to lose focus (mobile keyboards collapse). By force-including the
+  // selected repo we keep the internal focus management stable.
+  const visibleRepos = (() => {
+    if (filteredRepos.some((r) => r.full_name === selectedRepo)) {
+      return filteredRepos
+    }
+
+    const selectedEntry = repos.find((r) => r.full_name === selectedRepo)
+    if (!selectedEntry) {
+      return filteredRepos
+    }
+
+    // Prepend to avoid changing the relative ordering of the filtered list.
+    return [selectedEntry, ...filteredRepos]
+  })()
+
   // 1. Loading state
   if (loading) {
     return <div className="px-4 py-2">Loading...</div>
@@ -142,12 +160,12 @@ export default function RepoSelector({
         </div>
         {loading && <div className="px-4 py-2">Loading...</div>}
         {!loading &&
-          filteredRepos.map((repo) => (
+          visibleRepos.map((repo) => (
             <SelectItem key={repo.full_name} value={repo.full_name}>
               {repo.full_name}
             </SelectItem>
           ))}
-        {!loading && filteredRepos.length > 0 && (
+        {!loading && visibleRepos.length > 0 && (
           <div className="my-1 border-t border-border/40" />
         )}
         <Button asChild variant="ghost" className="w-full">


### PR DESCRIPTION
### Problem
On mobile devices the keyboard collapses while typing in the repository selector’s search box when the currently-selected repository is filtered out of view.  This happens because Radix UI’s `Select` loses the active item and re-assigns focus, causing the `<Input />` component to blur.

### Solution
Always include the currently selected repository in the list of `<SelectItem>` options, even when it doesn’t match the current search query.  By keeping the active item mounted Radix no longer changes focus and the search input retains focus throughout typing.

### Implementation details
* Added a `visibleRepos` array that is guaranteed to contain the selected repository.
* Prepend the selected repository to the filtered list when it would otherwise be missing.
* Replaced usage of `filteredRepos` with `visibleRepos` when rendering `<SelectItem>` components.

This change is isolated to `components/common/RepoSelector.tsx` and requires no API changes or additional packages.

### Testing
Manual testing on desktop and mobile simulators confirmed that the search bar maintains focus and the on-screen keyboard remains open while typing, regardless of whether the selected repository matches the filter.

---
Label: AI generated

Closes #931