### PR TITLE
Add detailed console logs to debug speech-to-text flow on Safari

### DIFF
--- a/app/api/openai/transcribe/route.ts
+++ b/app/api/openai/transcribe/route.ts
@@ -39,7 +39,10 @@ export async function POST(request: NextRequest) {
     const result = await transcribeAudio(audioFile)
 
     if (result.success) {
-      console.log("[Transcribe API] Transcription success. Text length=", result.text.length)
+      console.log(
+        "[Transcribe API] Transcription success. Text length=",
+        result.text.length
+      )
       return NextResponse.json({ text: result.text }, { status: 200 })
     } else {
       console.error("[Transcribe API] Transcription failed", result.error)
@@ -53,4 +56,3 @@ export async function POST(request: NextRequest) {
     )
   }
 }
-

--- a/app/api/openai/transcribe/route.ts
+++ b/app/api/openai/transcribe/route.ts
@@ -5,36 +5,52 @@ import { transcribeAudio } from "@/lib/openai"
 
 export async function POST(request: NextRequest) {
   try {
+    console.log("[Transcribe API] POST /api/openai/transcribe invoked")
+
     // Get the form data containing the audio file
     const formData = await request.formData()
+    console.log("[Transcribe API] formData entries:", [...formData.keys()])
+
     const audioFile = formData.get("audio") as File
 
     if (!audioFile) {
+      console.warn("[Transcribe API] Missing audio file in formData")
       return NextResponse.json({ error: "Missing audio file" }, { status: 400 })
     }
+
+    console.log("[Transcribe API] Received audio file", {
+      name: audioFile.name,
+      type: audioFile.type,
+      size: audioFile.size,
+    })
 
     // Get user's OpenAI API key
     const apiKey = await getUserOpenAIApiKey()
     if (!apiKey) {
+      console.warn("[Transcribe API] Missing OpenAI API key for user")
       return NextResponse.json(
         { error: "Missing OpenAI API key" },
         { status: 401 }
       )
     }
 
+    console.log("[Transcribe API] Calling transcribeAudio()")
     // Transcribe the audio using the existing function
     const result = await transcribeAudio(audioFile)
 
     if (result.success) {
+      console.log("[Transcribe API] Transcription success. Text length=", result.text.length)
       return NextResponse.json({ text: result.text }, { status: 200 })
     } else {
+      console.error("[Transcribe API] Transcription failed", result.error)
       return NextResponse.json({ error: result.error }, { status: 500 })
     }
   } catch (error) {
-    console.error("Transcription API error:", error)
+    console.error("[Transcription API] Unexpected error:", error)
     return NextResponse.json(
       { error: "An unexpected error occurred: " + error },
       { status: 500 }
     )
   }
 }
+

--- a/components/playground/SpeechToTextCard.tsx
+++ b/components/playground/SpeechToTextCard.tsx
@@ -75,7 +75,10 @@ export default function SpeechToTextCard() {
         }
       }
 
-      console.log("[SpeechToText] Starting media recorder. Using MIME type:", mimeType || "default")
+      console.log(
+        "[SpeechToText] Starting media recorder. Using MIME type:",
+        mimeType || "default"
+      )
       setRecordedMimeType(mimeType || "audio/webm")
 
       const recorder = mimeType
@@ -87,7 +90,10 @@ export default function SpeechToTextCard() {
       }
       recorder.onstop = handleRecordingStop
       recorder.start()
-      console.log("[SpeechToText] MediaRecorder started, state=", recorder.state)
+      console.log(
+        "[SpeechToText] MediaRecorder started, state=",
+        recorder.state
+      )
       setMediaRecorder(recorder)
       setIsRecording(true)
     } catch (err) {
@@ -105,7 +111,11 @@ export default function SpeechToTextCard() {
   }
 
   const handleRecordingStop = useCallback(async () => {
-    console.log("[SpeechToText] handleRecordingStop invoked – assembling blob from", audioChunks.current.length, "chunks")
+    console.log(
+      "[SpeechToText] handleRecordingStop invoked – assembling blob from",
+      audioChunks.current.length,
+      "chunks"
+    )
     setIsRecording(false)
 
     // Ensure microphone is released as soon as recording stops.
@@ -146,13 +156,18 @@ export default function SpeechToTextCard() {
       const formData = new FormData()
       formData.append("audio", audioFile)
 
-      console.log("[SpeechToText] Sending fetch request to /api/openai/transcribe")
+      console.log(
+        "[SpeechToText] Sending fetch request to /api/openai/transcribe"
+      )
       const response = await fetch("/api/openai/transcribe", {
         method: "POST",
         body: formData,
       })
 
-      console.log("[SpeechToText] Fetch response received. status=", response.status)
+      console.log(
+        "[SpeechToText] Fetch response received. status=",
+        response.status
+      )
 
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}))
@@ -244,4 +259,3 @@ export default function SpeechToTextCard() {
     </Card>
   )
 }
-


### PR DESCRIPTION
### What & Why
Mobile Safari stops recording after ~30 s which makes it hard to pinpoint where the pipeline fails.  This PR introduces verbose, structured console logging on both the client and server side so we can follow the full journey of the audio:

1.  `SpeechToTextCard`
    * Logs when recording starts / stops
    * Logs chosen MIME type, MediaRecorder state, blob & file metadata
    * Logs fetch request to `/api/openai/transcribe` and the corresponding response status/result
2.  `POST /api/openai/transcribe`
    * Logs invocation, presence & details of the uploaded file
    * Logs user-API-key availability
    * Logs transcription success/failure and the length of the returned text

These logs do **not** change any functional behaviour—they only surface additional information in the browser console (client) and server logs (API route).  This should greatly simplify tracking down the 30-second recording limit experienced on iOS Safari.

### Scope
Small, focused changes limited to:
* `components/playground/SpeechToTextCard.tsx`
* `app/api/openai/transcribe/route.ts`

No dependencies, no UI/UX changes other than log output.

Closes #937