### PR TITLE
UI polish: remove nav border & enlarge task input box

### DIFF
--- a/components/issues/NewTaskInput.tsx
+++ b/components/issues/NewTaskInput.tsx
@@ -232,15 +232,16 @@ export default function NewTaskInput({ repoFullName }: Props) {
           placeholder="Describe a task or use the microphone to speak..."
           required
           disabled={isSubmitting}
-          rows={3}
+          // Height tweaks: 50% viewport on mobile, 40% on md+ screens
+          className="h-[50vh] md:h-[40vh]"
         />
       </div>
       <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
         <Button type="submit" disabled={isSubmitting}>
           {generatingTitle ? (
             <>
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Generating issue
-              title...
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Generating
+              issue title...
             </>
           ) : loading || isPending ? (
             <>
@@ -272,3 +273,4 @@ export default function NewTaskInput({ repoFullName }: Props) {
     </form>
   )
 }
+

--- a/components/layout/Navigation.tsx
+++ b/components/layout/Navigation.tsx
@@ -34,7 +34,8 @@ export default async function Navigation() {
       initial={{ opacity: 0, y: -20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5 }}
-      className="sticky top-0 z-50 w-full border-b backdrop-blur bg-background/95 supports-[backdrop-filter]:bg-background/60"
+      // Removed border-b to create a seamless look per design request
+      className="sticky top-0 z-50 w-full backdrop-blur bg-background/95 supports-[backdrop-filter]:bg-background/60"
     >
       <div className="container max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex h-14 items-center py-2">


### PR DESCRIPTION
### ✨ What’s new
1. **Navigation header** – removed the bottom border for a cleaner, seamless appearance.
2. **New-task input** – the textarea is now considerably taller:
   * **Mobile (base)**: 50 % of the viewport height.
   * **Desktop (`md+`)**: 40 % of the viewport height.

These tweaks implement the requested design changes and improve the task-creation experience across devices.

Closes #938