### PR TITLE
feat: introduce basic Redis-backed worker queue system

### DIFF
--- a/app/api/queue/[queue]/route.ts
+++ b/app/api/queue/[queue]/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest } from "next/server"
+
+import { workerQueue } from "@/lib/services/worker-queue"
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { queue: string } }
+) {
+  const payload = await req.json()
+  const id = await workerQueue.enqueue(params.queue, payload)
+  return Response.json({ status: "enqueued", id })
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { queue: string } }
+) {
+  const length = await workerQueue.getQueueLength(params.queue)
+  return Response.json({ queue: params.queue, length })
+}
+

--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -25,6 +25,7 @@ import ApplyPatchCard from "@/components/playground/ApplyPatchCard"
 import DockerodeExecCard from "@/components/playground/DockerodeExecCard"
 import IssueTitleCard from "@/components/playground/IssueTitleCard"
 import NewLocalTaskInput from "@/components/playground/NewLocalTaskInput"
+import QueueDemoCard from "@/components/playground/QueueDemoCard"
 import RipgrepSearchCard from "@/components/playground/RipgrepSearchCard"
 import SpeechToTextCard from "@/components/playground/SpeechToTextCard"
 import TestGithubUserFunctionsCard from "@/components/playground/TestGithubUserFunctionsCard"
@@ -86,6 +87,7 @@ export default async function PlaygroundPage() {
       <DockerodeExecCard />
       <WriteFileCard />
       <ApplyPatchCard />
+      <QueueDemoCard />
       {token ? <OAuthTokenCard token={token} /> : null}
       <div>
         <Link href="/playground/evals">
@@ -97,3 +99,4 @@ export default async function PlaygroundPage() {
     </div>
   )
 }
+

--- a/components/playground/QueueDemoCard.tsx
+++ b/components/playground/QueueDemoCard.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+export default function QueueDemoCard() {
+  const queueName = "demo"
+  const [length, setLength] = useState<number>(0)
+  const [loading, setLoading] = useState(false)
+
+  const refresh = async () => {
+    const res = await fetch(`/api/queue/${queueName}`)
+    if (!res.ok) return
+    const data = (await res.json()) as { length: number }
+    setLength(data.length)
+  }
+
+  useEffect(() => {
+    refresh()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const addJob = async () => {
+    setLoading(true)
+    await fetch(`/api/queue/${queueName}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ timestamp: Date.now() }),
+    })
+    await refresh()
+    setLoading(false)
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Redis Queue Demo</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p>
+          Queue <code>{queueName}</code> length: {length}
+        </p>
+        <Button onClick={addJob} disabled={loading}>
+          {loading ? "Adding…" : "Add Job"}
+        </Button>
+        <Button variant="outline" onClick={refresh} className="ml-2">
+          Refresh
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}
+

--- a/lib/services/worker-queue.ts
+++ b/lib/services/worker-queue.ts
@@ -1,0 +1,99 @@
+"use server"
+
+import { createClient, RedisClientType } from "redis"
+import { v4 as uuidv4 } from "uuid"
+
+export interface QueueJob<T = unknown> {
+  id: string
+  payload: T
+  enqueuedAt: number
+}
+
+function queueKey(name: string): string {
+  return `queue:${name}`
+}
+
+class WorkerQueueService {
+  private client: RedisClientType | null = null
+  private isConnecting = false
+
+  private async getClient(): Promise<RedisClientType> {
+    if (this.client?.isOpen) return this.client
+    if (this.isConnecting) {
+      // wait briefly until current connection finishes
+      await new Promise((res) => setTimeout(res, 100))
+      if (this.client?.isOpen) return this.client
+      throw new Error("Redis connection in progress failed to establish")
+    }
+    this.isConnecting = true
+    const client = createClient({ url: process.env.REDIS_URL })
+    client.on("error", (err) => console.error("Redis WorkerQueue error", err))
+    await client.connect()
+    this.client = client
+    this.isConnecting = false
+    return client
+  }
+
+  /**
+   * Enqueue a new job on the specified queue. Returns the job id.
+   */
+  async enqueue<T = unknown>(queueName: string, payload: T): Promise<string> {
+    const client = await this.getClient()
+    const job: QueueJob = {
+      id: uuidv4(),
+      payload,
+      enqueuedAt: Date.now(),
+    }
+    await client.lPush(queueKey(queueName), JSON.stringify(job))
+    return job.id
+  }
+
+  /**
+   * Return the current length of a queue.
+   */
+  async getQueueLength(queueName: string): Promise<number> {
+    const client = await this.getClient()
+    return client.lLen(queueKey(queueName))
+  }
+
+  /**
+   * Pop (blocking) a job from the queue. The timeout defaults to 0 (blocks forever).
+   */
+  async popJob<T = unknown>(
+    queueName: string,
+    timeoutSeconds = 0
+  ): Promise<QueueJob<T> | null> {
+    const client = await this.getClient()
+    const res = (await client.brPop(queueKey(queueName), timeoutSeconds)) as
+      | [string, string]
+      | null
+    if (!res) return null
+    const [, value] = res
+    return JSON.parse(value) as QueueJob<T>
+  }
+
+  /**
+   * Convenience helper to start a long-running worker that continuously
+   * processes jobs using the supplied handler function.
+   * NOTE: This is intended to be executed in a dedicated Node process,
+   * not within the Next.js request lifecycle.
+   */
+  async startWorker<T = unknown>(
+    queueName: string,
+    handler: (job: QueueJob<T>) => Promise<void>
+  ): Promise<void> {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const job = await this.popJob<T>(queueName, 0)
+      if (!job) continue // Shouldn't happen with timeout 0 but TS-safety
+      try {
+        await handler(job)
+      } catch (err) {
+        console.error(`Worker error processing job ${job.id}:`, err)
+      }
+    }
+  }
+}
+
+export const workerQueue = new WorkerQueueService()
+


### PR DESCRIPTION
### Summary
This PR lays the groundwork for a persistent worker-queue architecture backed by Redis.

1. **lib/services/worker-queue.ts** – Minimal yet production-ready queue service.  
   • Enqueues jobs with UUIDs & timestamps  
   • Persists data in `queue:<name>` Redis lists → survives Next.js restarts  
   • Helper APIs for queue length, blocking pop & long-running worker loops
2. **Next API** – `POST /api/queue/[queue]` to enqueue and `GET` to inspect queue length.
3. **Playground UI** – `QueueDemoCard` lets admins add demo jobs and monitor queue size.

This demonstrates an end-to-end path (UI → API → Redis) and establishes reusable utilities for future dedicated worker processes.

_No external dependencies added; relies on the existing `redis` package already in the repo._

Closes #950