### PR TITLE
Restructure tsconfig for monorepo with base, tests, and shared libs

### DIFF
--- a/__tests__/config/jest.config.base.ts
+++ b/__tests__/config/jest.config.base.ts
@@ -6,8 +6,14 @@ const baseConfig: Config = {
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/$1",
   },
+  globals: {
+    "ts-jest": {
+      tsconfig: "<rootDir>/tsconfig.tests.json",
+    },
+  },
   coveragePathIgnorePatterns: ["/node_modules/", "/.next/", "/coverage/"],
   rootDir: "../..",
 }
 
 export default baseConfig
+

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "esnext",
+    "lib": ["esnext"],
+    "strict": true,
+    "skipLibCheck": true,
+    "incremental": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"],
+      "@shared/*": ["shared/*"],
+      "@workers/*": ["apps/workers/*"],
+      "@/components/*": ["components/*"],
+      "@/styles/*": ["styles/*"]
+    }
+  },
+  "exclude": ["node_modules"]
+}
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,34 +1,20 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "noEmit": true,
+    "jsx": "preserve",
+    "plugins": [
+      { "name": "next" }
+    ],
     "paths": {
       "@/styles/*": ["styles/*"],
       "@/components/*": ["components/*"],
       "@/*": ["./*"]
-    },
-    "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "strictNullChecks": true,
-    "noImplicitAny": false,
-    "noEmit": true,
-    "incremental": true,
-    "module": "esnext",
-    "esModuleInterop": true,
-    "moduleResolution": "node10",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "preserve",
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ]
+    }
   },
   "include": ["**/*", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }
+

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": ["__tests__/**/*"]
+}
+


### PR DESCRIPTION
### Summary
This PR introduces a new TypeScript configuration hierarchy that prepares the repository for a true monorepo setup:

1. **`tsconfig.base.json`** – root‐level base config shared by every package/app.
   • Common compiler settings (strict, ES2017 target, etc.)
   • Global `paths` for upcoming workspaces: `shared`, `apps/workers`, etc.

2. **`tsconfig.json`** – the original Next.js app config now *extends* the base config and only contains Next-specific overrides such as DOM libs, JSX handling and the Next plugin.

3. **`tsconfig.tests.json`** – dedicated config for the Jest test suite; extends the base config and enables the appropriate module system and type declarations.

4. **Jest tweaks** – `ts-jest` is pointed at the new `tsconfig.tests.json` so tests compile with the correct settings.

This structure keeps the existing application working while giving us a solid foundation to add future apps (e.g. `apps/workers`) and a reusable `shared/` library.

_No runtime code was changed – only configuration files have been added or updated._

Closes #953