### PR TITLE
Migrate default OpenAI model to gpt-5

### DIFF
--- a/__tests__/lib/agents/resolveIssue.llm.test.ts
+++ b/__tests__/lib/agents/resolveIssue.llm.test.ts
@@ -81,7 +81,7 @@ describe("resolveIssue LLM agent uses FileCheckTool after file write", () => {
     const agent = new TestAgent({
       messages: injected,
       apiKey: process.env.OPENAI_API_KEY || "sk-test",
-      model: "gpt-4.1",
+      model: "gpt-5",
     })
     // Cast each tool to the generic shape expected by `addTool` to avoid
     // union-type incompatibilities at compile time.

--- a/lib/agents/IssueTitleAgent.ts
+++ b/lib/agents/IssueTitleAgent.ts
@@ -22,7 +22,7 @@ Return ONLY the title text with no additional commentary.`
 
 export class IssueTitleAgent extends Agent {
   constructor(params: AgentConstructorParams) {
-    super({ model: "gpt-4.1", ...params })
+    super({ model: "gpt-5", ...params })
 
     this.setSystemPrompt(SYSTEM_PROMPT)
   }

--- a/lib/agents/PlanAndCodeAgent.ts
+++ b/lib/agents/PlanAndCodeAgent.ts
@@ -67,7 +67,7 @@ export class PlanAndCodeAgent extends ResponsesAPIAgent {
     } = params
 
     // Initialise base Agent (model defaults to "o3" if not overridden)
-    super({ model: "o3", ...base })
+    super({ model: "gpt-5", ...base })
 
     if (jobId) {
       this.jobId = jobId

--- a/lib/agents/base/index.ts
+++ b/lib/agents/base/index.ts
@@ -39,7 +39,7 @@ export class Agent {
   private untrackedMessages: EnhancedMessage[] = [] // Queue for untracked messages
   tools: Tool<ZodType, unknown>[] = []
   llm: OpenAI | null = null
-  model: ChatModel = "o3"
+  model: ChatModel = "gpt-5" as ChatModel
   jobId?: string
 
   constructor({ model, systemPrompt, apiKey }: AgentConstructorParams) {

--- a/lib/agents/thinker.ts
+++ b/lib/agents/thinker.ts
@@ -35,7 +35,7 @@ Lookup configuration files to better understand the codebase requirements and st
 
 export class ThinkerAgent extends Agent {
   constructor(params: AgentConstructorParams = {}) {
-    super({ model: "o3", ...params }) // always set o3 first
+    super({ model: "gpt-5", ...params }) // always set o3 first
     this.setDeveloperPrompt(DEVELOPER_PROMPT).catch(console.error)
   }
 }

--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -48,7 +48,7 @@ export async function getChatCompletion({
     { role: "user", content: userPrompt },
   ]
   const res = await openai.chat.completions.create({
-    model: "o3",
+    model: "gpt-5",
     messages,
   })
   return res.choices[0]?.message?.content || ""

--- a/lib/workflows/alignmentCheck.ts
+++ b/lib/workflows/alignmentCheck.ts
@@ -183,7 +183,7 @@ export async function alignmentCheck({
     // 3. Init agent
     const agentParams: AgentConstructorParams = {
       apiKey: openAIApiKey,
-      model: "gpt-4.1",
+      model: "gpt-5",
     }
     const agent = new AlignmentAgent(agentParams)
     await agent.addJobId(workflowId)
@@ -235,7 +235,7 @@ export async function alignmentCheck({
       // 1. Instantiate the agent
       const assessmentAgent = new PostAlignmentAssessmentAgent({
         apiKey: openAIApiKey,
-        model: "gpt-4.1",
+        model: "gpt-5",
       })
       await assessmentAgent.addJobId(workflowId)
       assessmentAgent.addSpan({

--- a/lib/workflows/commentOnIssue.ts
+++ b/lib/workflows/commentOnIssue.ts
@@ -200,7 +200,7 @@ export default async function commentOnIssue(
     })
 
     // Create and initialize the thinker agent
-    const thinker = new ThinkerAgent({ apiKey, model: "o3" })
+    const thinker = new ThinkerAgent({ apiKey, model: "gpt-5" })
 
     await thinker.addJobId(jobId) // Set jobId before any messages are added
 

--- a/lib/workflows/resolveIssue.ts
+++ b/lib/workflows/resolveIssue.ts
@@ -182,7 +182,7 @@ export const resolveIssue = async ({
     // Initialize the persistent coder agent
     const coder = new CoderAgent({
       apiKey,
-      model: "o3",
+      model: "gpt-5",
       createPR: Boolean(
         createPR && userPermissions?.canPush && userPermissions?.canCreatePR
       ),


### PR DESCRIPTION
### Summary
OpenAI has released `gpt-5`; this PR migrates the entire code-base to use it as the new default model for all agent workflows, utilities and tests.

### Key changes
1. **Global default** – `lib/agents/base` now defaults to `gpt-5`.
2. **Explicit overrides** – All hard-coded model references (`"o3"`, `"gpt-4.1"`) in agents, workflows and helper functions are updated to `gpt-5`.
3. **Utility update** – `lib/openai.ts` now requests chat completions with `gpt-5`.
4. **Test suite** – Test fixtures adjusted to expect the new model.

TypeScript compatibility is preserved by casting the literal to `ChatModel` until upstream typings include the new model.

---
Closes the internal task: “migrate to latest openai gpt-5”.


Closes #959