### PR TITLE
Reorganize dynamic menu and switch to hamburger navigation icon

### DIFF
--- a/components/layout/DynamicNavigation.tsx
+++ b/components/layout/DynamicNavigation.tsx
@@ -42,7 +42,7 @@ const authenticatedNavItems = (
     { label: "Issues", href: "/issues" },
     { label: "Kanban", href: "/kanban" },
     { label: "Contribute", href: "/contribute" },
-    { label: "Settings", href: "/settings" },
+    // NOTE: Settings is intentionally excluded here and added in the second section
   ]
 
   if (isAdmin) {
@@ -151,22 +151,29 @@ export default function DynamicNavigation({
       <div className="flex items-center ml-auto">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <button className="inline-flex items-center justify-center focus:outline-none">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src={avatarUrl || "/next.svg"}
-                alt="Profile"
-                className="w-8 h-8 rounded-full border"
-              />
-            </button>
+            <Button variant="ghost" size="icon" className="inline-flex items-center justify-center">
+              <Menu className="h-5 w-5" />
+              <span className="sr-only">Open Menu</span>
+            </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-48">
+          <DropdownMenuContent align="end" className="w-56">
             {navItems.map((item) => (
               <DropdownMenuItem key={item.href} asChild>
                 <Link href={item.href}>{item.label}</Link>
               </DropdownMenuItem>
             ))}
             <DropdownMenuSeparator />
+            <DropdownMenuItem asChild>
+              <Link href="/settings" className="flex items-center gap-2">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={avatarUrl || "/next.svg"}
+                  alt="Profile"
+                  className="w-4 h-4 rounded-full border"
+                />
+                <span>Settings</span>
+              </Link>
+            </DropdownMenuItem>
             <DropdownMenuItem
               onSelect={handleSignOut}
               className="cursor-pointer"
@@ -215,3 +222,4 @@ export default function DynamicNavigation({
     </>
   )
 }
+


### PR DESCRIPTION
Summary
- Reorganized the authenticated user dropdown menu:
  - All primary links (Workflows, Issues, Kanban, Contribute, and admin-only PRDs/Playground) remain in the first section.
  - Settings was moved to a second section alongside Log out.
  - Added the user’s avatar next to the Settings label to clearly indicate user settings.
- Replaced the avatar-based menu trigger with a consistent hamburger (Menu) icon for both desktop and mobile.
- Kept existing mobile sheets for unauthenticated users, which already use a hamburger icon.

Why
- Matches the desired layout with Settings grouped with Log out and visually associated with the user via the avatar.
- Ensures a consistent hamburger icon is used as the navigation menu trigger across desktop and mobile.

Files changed
- components/layout/DynamicNavigation.tsx

Notes
- The menu contents and navigation remain unchanged for unauthenticated flows except for keeping the existing hamburger-triggered sheet.
- No backend or API changes required.

Closes #976