### PR TITLE
Remove issue creation webhook trigger

### DIFF
--- a/lib/webhook.ts
+++ b/lib/webhook.ts
@@ -3,7 +3,6 @@ import { v4 as uuidv4 } from "uuid"
 import { getRepoFromString } from "@/lib/github/content"
 import { getIssue } from "@/lib/github/issues"
 import { updateJobStatus } from "@/lib/redis-old"
-import autoResolveIssue from "@/lib/workflows/autoResolveIssue"
 import { resolveIssue } from "@/lib/workflows/resolveIssue"
 
 const POST_TO_GITHUB_SETTING = true // TODO: Set setting in database
@@ -94,48 +93,8 @@ export const routeWebhookHandler = async ({
     }
 
     if (action === "opened") {
-      if (typeof process.env.OPENAI_API_KEY !== "string") {
-        throw new Error("OPENAI_API_KEY is not set")
-      }
-
-      // Generate a unique job ID
-      const jobId = uuidv4()
-      await updateJobStatus(
-        jobId,
-        'Received "opened" issue webhook. Starting autoResolveIssue workflow.'
-      )
-
-      const issueNumber = payload["issue"]["number"]
-      const repoFullName = payload["repository"]["full_name"]
-      const apiKey = process.env.OPENAI_API_KEY // TODO: Prefer GitHub App session token, if available
-
-      // Fire-and-forget auto-resolve
-      ;(async () => {
-        try {
-          const fullRepo = await getRepoFromString(repoFullName)
-          const issueResult = await getIssue({
-            fullName: repoFullName,
-            issueNumber,
-          })
-
-          if (issueResult.type !== "success") {
-            console.error("Failed to get issue:", issueResult)
-            return
-          }
-
-          await autoResolveIssue({
-            issue: issueResult.issue,
-            repository: fullRepo,
-            apiKey,
-            jobId,
-          })
-        } catch (e) {
-          console.error(
-            "Failed to run autoResolveIssue workflow from webhook:",
-            e
-          )
-        }
-      })()
+      // No-op: we intentionally do not launch any workflow on new issue creation.
+      return
     }
   } else {
     const repository =
@@ -143,3 +102,4 @@ export const routeWebhookHandler = async ({
     console.log(`${event} event received on ${repository}`)
   }
 }
+


### PR DESCRIPTION
Summary
- Removes the workflow trigger on new GitHub issue creation (issues.opened).
- The webhook handler now returns early with a no-op when an issue is opened, ensuring no workflows are launched automatically.
- Label-based triggers (e.g., adding the "resolve" label) remain unchanged.

Why
We no longer want to automatically launch any workflow when a new issue is created.

Changes
- lib/webhook.ts: Removed the autoResolveIssue path for `action === "opened"` and cleaned up the unused import.

Testing
- Ran the full Jest test suite locally; all tests passed.

Impact
- New issues will no longer trigger autoResolveIssue or any workflow.
- Existing behavior for label-triggered workflows is preserved.

Closes #978