### PR TITLE
Chunked audio streaming + live transcription via SSE (no S3)

### DIFF
--- a/app/api/transcription/finalize/route.ts
+++ b/app/api/transcription/finalize/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server"
+import { createClient } from "redis"
+
+import { publishEvent } from "@/lib/services/redis-stream"
+
+export const dynamic = "force-dynamic"
+
+const rKey = (sessionId: string, suffix: string) => `transcribe:${sessionId}:${suffix}`
+
+export async function POST(req: NextRequest) {
+  try {
+    const url = new URL(req.url)
+    const sessionId = url.searchParams.get("sessionId") || req.headers.get("x-session-id") || undefined
+
+    if (!sessionId) {
+      return NextResponse.json({ error: "Missing sessionId" }, { status: 400 })
+    }
+
+    const redis = createClient({ url: process.env.REDIS_URL })
+    await redis.connect()
+
+    try {
+      const [finalText, provisional] = await Promise.all([
+        redis.get(rKey(sessionId, "final")),
+        redis.get(rKey(sessionId, "provisional")),
+      ])
+
+      const newFinal = [finalText || "", provisional || ""].filter(Boolean).join(" ").trim()
+
+      await Promise.all([
+        redis.set(rKey(sessionId, "final"), newFinal),
+        redis.set(rKey(sessionId, "provisional"), ""),
+      ])
+
+      await publishEvent(sessionId, {
+        type: "status",
+        data: { status: "transcription_update", final: newFinal, provisional: "" },
+        timestamp: new Date(),
+      })
+
+      await publishEvent(sessionId, {
+        type: "status",
+        data: { status: "completed" },
+        timestamp: new Date(),
+      })
+
+      return NextResponse.json({ ok: true, finalized: true })
+    } finally {
+      await redis.disconnect()
+    }
+  } catch (err) {
+    console.error("[transcription/finalize] Error:", err)
+    return NextResponse.json({ error: String(err) }, { status: 500 })
+  }
+}
+

--- a/app/api/transcription/finalize/route.ts
+++ b/app/api/transcription/finalize/route.ts
@@ -5,12 +5,16 @@ import { publishEvent } from "@/lib/services/redis-stream"
 
 export const dynamic = "force-dynamic"
 
-const rKey = (sessionId: string, suffix: string) => `transcribe:${sessionId}:${suffix}`
+const rKey = (sessionId: string, suffix: string) =>
+  `transcribe:${sessionId}:${suffix}`
 
 export async function POST(req: NextRequest) {
   try {
     const url = new URL(req.url)
-    const sessionId = url.searchParams.get("sessionId") || req.headers.get("x-session-id") || undefined
+    const sessionId =
+      url.searchParams.get("sessionId") ||
+      req.headers.get("x-session-id") ||
+      undefined
 
     if (!sessionId) {
       return NextResponse.json({ error: "Missing sessionId" }, { status: 400 })
@@ -25,7 +29,10 @@ export async function POST(req: NextRequest) {
         redis.get(rKey(sessionId, "provisional")),
       ])
 
-      const newFinal = [finalText || "", provisional || ""].filter(Boolean).join(" ").trim()
+      const newFinal = [finalText || "", provisional || ""]
+        .filter(Boolean)
+        .join(" ")
+        .trim()
 
       await Promise.all([
         redis.set(rKey(sessionId, "final"), newFinal),
@@ -34,7 +41,11 @@ export async function POST(req: NextRequest) {
 
       await publishEvent(sessionId, {
         type: "status",
-        data: { status: "transcription_update", final: newFinal, provisional: "" },
+        data: {
+          status: "transcription_update",
+          final: newFinal,
+          provisional: "",
+        },
         timestamp: new Date(),
       })
 
@@ -53,4 +64,3 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: String(err) }, { status: 500 })
   }
 }
-

--- a/app/api/transcription/ingest/route.ts
+++ b/app/api/transcription/ingest/route.ts
@@ -1,0 +1,129 @@
+import { NextRequest, NextResponse } from "next/server"
+import { createClient } from "redis"
+
+import { publishEvent } from "@/lib/services/redis-stream"
+import { transcribeAudio } from "@/lib/openai"
+
+// This route accepts small audio chunks (3-5s) and appends them to a per-session buffer.
+// It also performs a naive incremental transcription for live updates and publishes them via SSE
+// using the existing /api/workflow/[workflowId] endpoint.
+
+export const dynamic = "force-dynamic"
+
+const rKey = (sessionId: string, suffix: string) => `transcribe:${sessionId}:${suffix}`
+
+export async function POST(req: NextRequest) {
+  try {
+    const url = new URL(req.url)
+    const sessionId = url.searchParams.get("sessionId") || req.headers.get("x-session-id") || undefined
+    const seqParam = url.searchParams.get("seq") || req.headers.get("x-seq") || undefined
+    const finalizeFlag = url.searchParams.get("finalize") || req.headers.get("x-finalize") || undefined
+
+    if (!sessionId) {
+      return NextResponse.json({ error: "Missing sessionId" }, { status: 400 })
+    }
+
+    const contentType = req.headers.get("content-type") || "audio/webm"
+
+    // If this is a finalize-only call (no body expected), handle finalization and return
+    if (finalizeFlag) {
+      const redis = createClient({ url: process.env.REDIS_URL })
+      await redis.connect()
+      try {
+        const [finalText, provisional] = await Promise.all([
+          redis.get(rKey(sessionId, "final")),
+          redis.get(rKey(sessionId, "provisional")),
+        ])
+        const newFinal = [finalText || "", provisional || ""].filter(Boolean).join(" ").trim()
+        await Promise.all([
+          redis.set(rKey(sessionId, "final"), newFinal),
+          redis.set(rKey(sessionId, "provisional"), ""),
+        ])
+
+        await publishEvent(sessionId, {
+          type: "status",
+          data: { status: "transcription_update", final: newFinal, provisional: "" },
+          timestamp: new Date(),
+        })
+        await publishEvent(sessionId, {
+          type: "status",
+          data: { status: "completed" },
+          timestamp: new Date(),
+        })
+
+        return NextResponse.json({ ok: true, finalized: true })
+      } finally {
+        await redis.disconnect()
+      }
+    }
+
+    // Read the binary body (the audio slice)
+    const arrayBuffer = await req.arrayBuffer()
+    if (!arrayBuffer || arrayBuffer.byteLength === 0) {
+      return NextResponse.json({ error: "Empty request body" }, { status: 400 })
+    }
+
+    const seq = Number(seqParam ?? "0")
+    const buf = Buffer.from(arrayBuffer)
+
+    const redis = createClient({ url: process.env.REDIS_URL })
+    await redis.connect()
+
+    try {
+      // Persist chunk reference structures
+      // Store the chunk bytes at a dedicated key and track sequence in a sorted set
+      const chunkKey = rKey(sessionId, `chunk:${seq}`)
+      await Promise.all([
+        redis.set(chunkKey, buf.toString("base64")),
+        redis.zAdd(rKey(sessionId, "chunks"), [{ score: seq, value: String(seq) }]),
+        redis.setNX(rKey(sessionId, "mime"), contentType),
+      ])
+
+      // Naive live-transcription strategy:
+      // - Move previous provisional into final
+      // - Transcribe ONLY the newest chunk as provisional
+      const [prevFinal, prevProvisional] = await Promise.all([
+        redis.get(rKey(sessionId, "final")),
+        redis.get(rKey(sessionId, "provisional")),
+      ])
+
+      const baseFinal = [prevFinal || "", prevProvisional || ""].filter(Boolean).join(" ")
+
+      // Build a File from the buffer so we can reuse transcribeAudio()
+      // Note: Next.js (Node 18+) supports File/Blob in the server runtime.
+      const file = new File([buf], `chunk-${seq}.webm`, { type: contentType })
+
+      const tr = await transcribeAudio(file)
+      const chunkText = tr.success ? tr.text : ""
+
+      const newFinal = baseFinal.trim()
+      const newProvisional = chunkText.trim()
+
+      await Promise.all([
+        redis.set(rKey(sessionId, "final"), newFinal),
+        redis.set(rKey(sessionId, "provisional"), newProvisional),
+        redis.set(rKey(sessionId, "lastSeq"), String(seq)),
+      ])
+
+      // Publish SSE update via existing workflow streaming channel
+      await publishEvent(sessionId, {
+        type: "status",
+        data: {
+          status: "transcription_update",
+          final: newFinal,
+          provisional: newProvisional,
+          seq,
+        },
+        timestamp: new Date(),
+      })
+
+      return NextResponse.json({ ok: true })
+    } finally {
+      await redis.disconnect()
+    }
+  } catch (err) {
+    console.error("[transcription/ingest] Error:", err)
+    return NextResponse.json({ error: String(err) }, { status: 500 })
+  }
+}
+

--- a/lib/hooks/useVoiceDictation.ts
+++ b/lib/hooks/useVoiceDictation.ts
@@ -130,15 +130,18 @@ export function useVoiceDictation(options?: UseVoiceDictationOptions) {
       setRecordedMimeType(mimeType || "audio/webm")
 
       // Create a new session id for this recording
-      const sessionId = typeof crypto !== "undefined" && "randomUUID" in crypto
-        ? crypto.randomUUID()
-        : `${Date.now()}-${Math.random().toString(36).slice(2)}`
+      const sessionId =
+        typeof crypto !== "undefined" && "randomUUID" in crypto
+          ? crypto.randomUUID()
+          : `${Date.now()}-${Math.random().toString(36).slice(2)}`
       sessionIdRef.current = sessionId
       seqRef.current = 0
 
       // Start SSE subscription for live transcript updates
       if (sseRef.current) {
-        try { sseRef.current.close() } catch {}
+        try {
+          sseRef.current.close()
+        } catch {}
       }
       const es = new EventSource(`/api/workflow/${sessionId}`)
       sseRef.current = es
@@ -149,7 +152,8 @@ export function useVoiceDictation(options?: UseVoiceDictationOptions) {
           const event = JSON.parse(ev.data)
           if (
             event?.type === "status" &&
-            (event?.data?.status === "transcription_update" || event?.data?.status === "completed")
+            (event?.data?.status === "transcription_update" ||
+              event?.data?.status === "completed")
           ) {
             const final = event?.data?.final || ""
             const provisional = event?.data?.provisional || ""
@@ -158,7 +162,9 @@ export function useVoiceDictation(options?: UseVoiceDictationOptions) {
             if (onTranscribed) onTranscribed(combined)
             if (event?.data?.status === "completed") {
               pushDebug("SSE completed")
-              try { es.close() } catch {}
+              try {
+                es.close()
+              } catch {}
               sseRef.current = null
             }
           }
@@ -200,10 +206,13 @@ export function useVoiceDictation(options?: UseVoiceDictationOptions) {
         // Finalize the transcript: tell server to commit provisional into final
         if (sessionIdRef.current) {
           try {
-            await fetch(`/api/transcription/finalize?sessionId=${sessionIdRef.current}`, {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-            })
+            await fetch(
+              `/api/transcription/finalize?sessionId=${sessionIdRef.current}`,
+              {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+              }
+            )
             pushDebug("Finalize request sent")
           } catch (e) {
             pushDebug(`[Finalize] Failed: ${String(e)}`)
@@ -328,4 +337,3 @@ export function useVoiceDictation(options?: UseVoiceDictationOptions) {
     stopRecording,
   }
 }
-


### PR DESCRIPTION
Summary

This PR introduces a first-pass implementation of the chunked audio streaming and live transcription pipeline outlined in the issue. It avoids large single uploads and S3 by streaming small audio slices to the backend and providing live-updating transcripts via SSE.

What’s included

- API: /api/transcription/ingest (POST)
  - Accepts small audio slices (e.g., audio/webm;codecs=opus) via binary body
  - Session-based buffering in Redis (stores chunks and mime; tracks seq)
  - Naive stabilization: previous provisional text gets incorporated into final; the latest chunk’s transcript becomes provisional
  - Publishes live updates to /api/workflow/[sessionId] SSE stream with events of type "status" and data { status: "transcription_update", final, provisional, seq }
  - Supports finalize flag as a POST without a body (via ?finalize=1 or X-Finalize header) to commit provisional into final and emit a completed event

- API: /api/transcription/finalize (POST)
  - Explicit endpoint to finalize a session: merges provisional into final and emits completed status

- Client Hook: useVoiceDictation
  - Uses MediaRecorder with a 3s timeslice to generate small chunks continuously
  - Sends each chunk to the ingest endpoint immediately
  - Opens an SSE connection to /api/workflow/[sessionId] to receive live transcript updates
  - Maintains a local playback blob after stop (so users can replay their recording)
  - Keeps existing VoiceDictationCard working, but now transcripts appear live during recording

Notes on architecture

- No S3. Chunks are stored short-term in Redis with keys like transcribe:{sessionId}:chunk:{seq} (base64) and an ordered index. This is enough for a first iteration and can be swapped later for longer-term storage if needed.
- SSE is reused from the existing workflow streaming route /api/workflow/[workflowId]. The sessionId doubles as a workflowId.
- Transcription uses the existing transcribeAudio() helper. The ingest route constructs a File from each chunk and calls Whisper. For now, this is per-chunk, keeping the implementation small and focused.
- Stabilization is naive but provides the right user experience split: "final" (won’t change) and "provisional" (last chunk).

Follow-ups (future iterations)

- Implement real 30s window building with 5–8s overlap and merge based on word-level timestamps (requires verbose JSON output; currently using simple text).
- Optional VAD-based window splits.
- Move heavier processing to the worker (BullMQ) with a dedicated queue ("transcribe") to keep API handlers thin. The current PR keeps everything in the API layer to minimize scope.
- Add session cleanup TTL and limits.

How to test locally

1) Start dev server: pnpm dev
2) Open Playground > Speech ➜ Text card (VoiceDictationCard) and start recording.
3) Speak for a bit; every ~3 seconds a chunk is uploaded and the transcript updates live.
4) Stop recording to finalize (provisional is merged into final and a completed event is emitted). Playback URL is created for the full recording.

Env

- Uses REDIS_URL (same as existing SSE/queue usage) for chunk storage and pub/sub.

Caveats

- This first version transcribes per-chunk, not sliding 30s windows; accuracy is good enough for proving the UX. The merge logic is intentionally simple to keep changes small and focused.

Screens/UX impact

- VoiceDictationCard behaves the same from a UI standpoint but now shows a live-updating transcript during recording.

Please review and let me know if you prefer we also wire this into the worker queue in this PR or defer that to a follow-up (recommended).

Closes #969