### PR TITLE
Add timestamped console logs for GitHub API and Neo4j calls

### DIFF
--- a/lib/github/content.ts
+++ b/lib/github/content.ts
@@ -3,6 +3,7 @@ import {
   AuthenticatedUserRepository,
   GitHubRepository,
 } from "@/lib/types/github"
+import { withTiming } from "@/lib/utils/telemetry"
 
 export class GitHubError extends Error {
   constructor(
@@ -13,6 +14,8 @@ export class GitHubError extends Error {
     this.name = "GitHubError"
   }
 }
+
+type HttpLikeError = { status?: number }
 
 // TODO: Since all octokit functions here are using octokit.rest.repos, then
 // This file should be renamed to `repos.tsx` to reflect the resource being called
@@ -34,20 +37,25 @@ export async function getFileContent({
     if (!owner || !repo) {
       throw new Error("Invalid repository format. Expected 'owner/repo'")
     }
-    const file = await octokit.rest.repos.getContent({
-      owner,
-      repo,
-      path,
-      ref: branch,
-    })
+    const file = await withTiming(
+      `GitHub REST: repos.getContent ${repoFullName}:${branch}:${path}`,
+      () =>
+        octokit.rest.repos.getContent({
+          owner,
+          repo,
+          path,
+          ref: branch,
+        })
+    )
     return file.data
-  } catch (error) {
+  } catch (error: unknown) {
+    const http = error as HttpLikeError | undefined
     if (!error) {
       throw new GitHubError("An unknown error occurred.", 500)
     }
 
-    if (typeof error === "object" && "status" in error) {
-      switch (error.status) {
+    if (http && typeof http === "object" && "status" in http) {
+      switch (http.status) {
         case 404:
           throw new GitHubError(`File not found: ${path}`, 404)
         case 403:
@@ -86,15 +94,19 @@ export async function updateFileContent({
   const [owner, repo] = repoFullName.split("/")
   const sha = await getFileSha({ repoFullName, path, branch })
 
-  await octokit.rest.repos.createOrUpdateFileContents({
-    owner,
-    repo,
-    path,
-    message: commitMessage,
-    content: Buffer.from(content).toString("base64"),
-    branch,
-    ...(sha && { sha }),
-  })
+  await withTiming(
+    `GitHub REST: repos.createOrUpdateFileContents ${repoFullName}:${branch}:${path}`,
+    () =>
+      octokit.rest.repos.createOrUpdateFileContents({
+        owner,
+        repo,
+        path,
+        message: commitMessage,
+        content: Buffer.from(content).toString("base64"),
+        branch,
+        ...(sha && { sha }),
+      })
+  )
 }
 
 export async function getFileSha({
@@ -112,26 +124,31 @@ export async function getFileSha({
     throw new Error("No octokit found")
   }
   try {
-    const response = await octokit.rest.repos.getContent({
-      owner,
-      repo,
-      path,
-      ref: branch,
-    })
+    const response = await withTiming(
+      `GitHub REST: repos.getContent (sha) ${repoFullName}:${branch}:${path}`,
+      () =>
+        octokit.rest.repos.getContent({
+          owner,
+          repo,
+          path,
+          ref: branch,
+        })
+    )
     if (Array.isArray(response.data)) {
       throw new Error("Path points to a directory, not a file")
     }
 
     if ("sha" in response.data) {
-      return response.data.sha
+      return (response.data as unknown as { sha: string }).sha
     }
-  } catch (error) {
+  } catch (error: unknown) {
+    const http = error as HttpLikeError | undefined
     if (!error) {
       throw new GitHubError("An unknown error occurred.", 500)
     }
 
-    if (typeof error === "object" && "status" in error) {
-      switch (error.status) {
+    if (http && typeof http === "object" && "status" in http) {
+      switch (http.status) {
         case 404:
           console.debug(`[DEBUG] File ${path} not found on branch ${branch}`)
           return null
@@ -159,19 +176,24 @@ export async function checkBranchExists(
   }
 
   try {
-    await octokit.rest.repos.getBranch({
-      owner,
-      repo,
-      branch,
-    })
+    await withTiming(
+      `GitHub REST: repos.getBranch ${repoFullName}:${branch}`,
+      () =>
+        octokit.rest.repos.getBranch({
+          owner,
+          repo,
+          branch,
+        })
+    )
     return true
-  } catch (error) {
+  } catch (error: unknown) {
+    const http = error as HttpLikeError | undefined
     if (!error) {
       throw new GitHubError("An unknown error occurred.", 500)
     }
 
-    if (typeof error === "object" && "status" in error) {
-      switch (error.status) {
+    if (http && typeof http === "object" && "status" in http) {
+      switch (http.status) {
         case 404:
           return false
         default:
@@ -192,10 +214,10 @@ export async function getRepoFromString(
   if (!octokit) {
     throw new Error("No octokit found")
   }
-  const { data: repoData } = await octokit.rest.repos.get({
-    owner,
-    repo,
-  })
+  const { data: repoData } = await withTiming(
+    `GitHub REST: repos.get ${fullName}`,
+    () => octokit.rest.repos.get({ owner, repo })
+  )
   return repoData
 }
 
@@ -217,10 +239,14 @@ export async function getUserRepositories(
     throw new Error("No octokit found")
   }
   try {
-    const response = await octokit.rest.repos.listForUser({
-      username,
-      ...options,
-    })
+    const response = await withTiming(
+      `GitHub REST: repos.listForUser ${username}`,
+      () =>
+        octokit.rest.repos.listForUser({
+          username,
+          ...options,
+        })
+    )
 
     const linkHeader = response.headers.link
     const lastPageMatch = linkHeader?.match(
@@ -231,13 +257,14 @@ export async function getUserRepositories(
       repositories: response.data as AuthenticatedUserRepository[],
       maxPage,
     }
-  } catch (error) {
+  } catch (error: unknown) {
+    const http = error as HttpLikeError | undefined
     if (!error) {
       throw new GitHubError("An unknown error occurred.", 500)
     }
 
-    if (typeof error === "object" && "status" in error) {
-      switch (error.status) {
+    if (http && typeof http === "object" && "status" in http) {
+      switch (http.status) {
         case 404:
           throw new GitHubError(`User not found: ${username}`, 404)
         case 403:
@@ -277,9 +304,10 @@ export async function getAuthenticatedUserRepositories(
     throw new Error("No octokit found")
   }
   try {
-    const response = await octokit.rest.repos.listForAuthenticatedUser({
-      ...options,
-    })
+    const response = await withTiming(
+      `GitHub REST: repos.listForAuthenticatedUser`,
+      () => octokit.rest.repos.listForAuthenticatedUser({ ...options })
+    )
 
     const linkHeader = response.headers.link
     const lastPageMatch = linkHeader?.match(
@@ -290,13 +318,14 @@ export async function getAuthenticatedUserRepositories(
       repositories: response.data as AuthenticatedUserRepository[],
       maxPage,
     }
-  } catch (error) {
+  } catch (error: unknown) {
+    const http = error as HttpLikeError | undefined
     if (!error) {
       throw new GitHubError("An unknown error occurred.", 500)
     }
 
-    if (typeof error === "object" && "status" in error) {
-      switch (error.status) {
+    if (http && typeof http === "object" && "status" in http) {
+      switch (http.status) {
         case 404:
           throw new GitHubError("User not found", 404)
         case 403:
@@ -340,3 +369,4 @@ export function combineRepositories<T extends { id: number }>(
   // Convert the Map values back to an array and sort by id
   return Array.from(repoMap.values()).sort((a, b) => b.id - a.id)
 }
+

--- a/lib/github/content.ts
+++ b/lib/github/content.ts
@@ -369,4 +369,3 @@ export function combineRepositories<T extends { id: number }>(
   // Convert the Map values back to an array and sort by id
   return Array.from(repoMap.values()).sort((a, b) => b.id - a.id)
 }
-

--- a/lib/github/issues.ts
+++ b/lib/github/issues.ts
@@ -194,9 +194,8 @@ export async function getIssueListWithStatus({
   repoFullName: string
 } & Omit<ListForRepoParams, "owner" | "repo">): Promise<IssueWithStatus[]> {
   // 1. Get issues from GitHub
-  const issues = await withTiming(
-    `GitHub: getIssueList ${repoFullName}`,
-    () => getIssueList({ repoFullName, ...rest })
+  const issues = await withTiming(`GitHub: getIssueList ${repoFullName}`, () =>
+    getIssueList({ repoFullName, ...rest })
   )
 
   // 2. Query Neo4j for plans using the service layer
@@ -248,4 +247,3 @@ export async function getIssueListWithStatus({
 
   return withStatus
 }
-

--- a/lib/github/pullRequests.ts
+++ b/lib/github/pullRequests.ts
@@ -1,11 +1,11 @@
 import getOctokit, { getGraphQLClient } from "@/lib/github"
-import { withTiming, logStart, logEnd } from "@/lib/utils/telemetry"
 import {
   IssueComment,
   PullRequest,
   PullRequestList,
   PullRequestReview,
 } from "@/lib/types/github"
+import { logEnd, logStart, withTiming } from "@/lib/utils/telemetry"
 
 export async function getPullRequestOnBranch({
   repoFullName,
@@ -94,7 +94,8 @@ export async function createPullRequest({
   `
   const repoIdResult = await withTiming(
     `GitHub GraphQL: get repository id ${repoFullName}`,
-    () => graphqlWithAuth<RepositoryIdResponse>(repoIdQuery, { owner, name: repo })
+    () =>
+      graphqlWithAuth<RepositoryIdResponse>(repoIdQuery, { owner, name: repo })
   )
   const repositoryId = repoIdResult.repository.id
 
@@ -350,7 +351,11 @@ export async function getPullRequestReviewCommentsGraphQL({
   }
   const response = await withTiming(
     `GitHub GraphQL: reviews+comments ${repoFullName}#${pullNumber}`,
-    () => graphqlWithAuth<PullRequestReviewCommentsGraphQLResponse>(query, variables)
+    () =>
+      graphqlWithAuth<PullRequestReviewCommentsGraphQLResponse>(
+        query,
+        variables
+      )
   )
   // Defensive: Structure the response for easy UI/LLM consumption
   const reviews =
@@ -461,7 +466,9 @@ export async function getPRLinkedIssuesMap(
   let endCursor: string | null = null
   const issuePRStatus: Record<number, boolean> = {}
 
-  const totalStart = logStart(`GitHub GraphQL: getPRLinkedIssuesMap ${repoFullName}`)
+  const totalStart = logStart(
+    `GitHub GraphQL: getPRLinkedIssuesMap ${repoFullName}`
+  )
   while (hasNextPage) {
     const pageStart = logStart(
       `GitHub GraphQL page getPRLinkedIssuesMap ${repoFullName}`,
@@ -500,10 +507,14 @@ export async function getPRLinkedIssuesMap(
     }
     hasNextPage = response.repository.pullRequests.pageInfo.hasNextPage
     endCursor = response.repository.pullRequests.pageInfo.endCursor
-    logEnd(`GitHub GraphQL page getPRLinkedIssuesMap ${repoFullName}`, pageStart, {
-      after: variables.after,
-      nextAfter: endCursor,
-    })
+    logEnd(
+      `GitHub GraphQL page getPRLinkedIssuesMap ${repoFullName}`,
+      pageStart,
+      {
+        after: variables.after,
+        nextAfter: endCursor,
+      }
+    )
   }
   logEnd(`GitHub GraphQL: getPRLinkedIssuesMap ${repoFullName}`, totalStart)
   return issuePRStatus
@@ -569,10 +580,7 @@ export async function getIssueToPullRequestMap(
       { after: variables.after, nextAfter: endCursor }
     )
   }
-  logEnd(
-    `GitHub GraphQL: getIssueToPullRequestMap ${repoFullName}`,
-    totalStart
-  )
+  logEnd(`GitHub GraphQL: getIssueToPullRequestMap ${repoFullName}`, totalStart)
   return issuePRMap
 }
 
@@ -621,4 +629,3 @@ export async function getLinkedIssuesForPR({
     response.repository?.pullRequest?.closingIssuesReferences?.nodes || []
   return nodes.map((n) => n.number)
 }
-

--- a/lib/github/pullRequests.ts
+++ b/lib/github/pullRequests.ts
@@ -1,5 +1,5 @@
-import getOctokit from "@/lib/github"
-import { getGraphQLClient } from "@/lib/github"
+import getOctokit, { getGraphQLClient } from "@/lib/github"
+import { withTiming, logStart, logEnd } from "@/lib/utils/telemetry"
 import {
   IssueComment,
   PullRequest,
@@ -24,11 +24,15 @@ export async function getPullRequestOnBranch({
     throw new Error("No octokit found")
   }
 
-  const pr = await octokit.rest.pulls.list({
-    owner,
-    repo,
-    head: `${owner}:${branch}`,
-  })
+  const pr = await withTiming(
+    `GitHub REST: pulls.list head=${owner}:${branch}`,
+    () =>
+      octokit.rest.pulls.list({
+        owner,
+        repo,
+        head: `${owner}:${branch}`,
+      })
+  )
 
   if (pr.data.length > 0) {
     return pr.data[0]
@@ -88,12 +92,9 @@ export async function createPullRequest({
       }
     }
   `
-  const repoIdResult = await graphqlWithAuth<RepositoryIdResponse>(
-    repoIdQuery,
-    {
-      owner,
-      name: repo,
-    }
+  const repoIdResult = await withTiming(
+    `GitHub GraphQL: get repository id ${repoFullName}`,
+    () => graphqlWithAuth<RepositoryIdResponse>(repoIdQuery, { owner, name: repo })
   )
   const repositoryId = repoIdResult.repository.id
 
@@ -130,9 +131,9 @@ export async function createPullRequest({
     },
   }
 
-  const response = await graphqlWithAuth<CreatePRGraphQLResponse>(
-    createPRMutation,
-    variables
+  const response = await withTiming(
+    `GitHub GraphQL: createPullRequest ${repoFullName} ${branch}`,
+    () => graphqlWithAuth<CreatePRGraphQLResponse>(createPRMutation, variables)
   )
 
   const pr = response.createPullRequest.pullRequest
@@ -158,14 +159,18 @@ export async function getPullRequestDiff({
 
     const [owner, repo] = repoFullName.split("/")
 
-    const response = await octokit.rest.pulls.get({
-      owner,
-      repo,
-      pull_number: pullNumber,
-      mediaType: {
-        format: "diff",
-      },
-    })
+    const response = await withTiming(
+      `GitHub REST: pulls.get(diff) ${repoFullName}#${pullNumber}`,
+      () =>
+        octokit.rest.pulls.get({
+          owner,
+          repo,
+          pull_number: pullNumber,
+          mediaType: {
+            format: "diff",
+          },
+        })
+    )
 
     // Check if response.data is a string
     if (typeof response.data !== "string") {
@@ -193,10 +198,14 @@ export async function getPullRequestList({
 
   const [owner, repo] = repoFullName.split("/")
 
-  const pullRequests = await octokit.rest.pulls.list({
-    owner,
-    repo,
-  })
+  const pullRequests = await withTiming(
+    `GitHub REST: pulls.list ${repoFullName}`,
+    () =>
+      octokit.rest.pulls.list({
+        owner,
+        repo,
+      })
+  )
 
   return pullRequests.data
 }
@@ -215,11 +224,15 @@ export async function getPullRequestComments({
     throw new Error("No octokit found")
   }
 
-  const commentsResponse = await octokit.rest.issues.listComments({
-    owner,
-    repo,
-    issue_number: pullNumber,
-  })
+  const commentsResponse = await withTiming(
+    `GitHub REST: issues.listComments PR ${repoFullName}#${pullNumber}`,
+    () =>
+      octokit.rest.issues.listComments({
+        owner,
+        repo,
+        issue_number: pullNumber,
+      })
+  )
 
   return commentsResponse.data
 }
@@ -238,11 +251,15 @@ export async function getPullRequestReviews({
     throw new Error("No octokit found")
   }
 
-  const reviewsResponse = await octokit.rest.pulls.listReviews({
-    owner,
-    repo,
-    pull_number: pullNumber,
-  })
+  const reviewsResponse = await withTiming(
+    `GitHub REST: pulls.listReviews ${repoFullName}#${pullNumber}`,
+    () =>
+      octokit.rest.pulls.listReviews({
+        owner,
+        repo,
+        pull_number: pullNumber,
+      })
+  )
 
   return reviewsResponse.data
 }
@@ -331,11 +348,10 @@ export async function getPullRequestReviewCommentsGraphQL({
     reviewsLimit,
     commentsPerReview,
   }
-  const response =
-    await graphqlWithAuth<PullRequestReviewCommentsGraphQLResponse>(
-      query,
-      variables
-    )
+  const response = await withTiming(
+    `GitHub GraphQL: reviews+comments ${repoFullName}#${pullNumber}`,
+    () => graphqlWithAuth<PullRequestReviewCommentsGraphQLResponse>(query, variables)
+  )
   // Defensive: Structure the response for easy UI/LLM consumption
   const reviews =
     response?.repository?.pullRequest?.reviews?.nodes?.map((r) => ({
@@ -374,11 +390,15 @@ export async function getPullRequest({
     throw new Error("No octokit found")
   }
 
-  const response = await octokit.rest.pulls.get({
-    owner,
-    repo,
-    pull_number: pullNumber,
-  })
+  const response = await withTiming(
+    `GitHub REST: pulls.get ${repoFullName}#${pullNumber}`,
+    () =>
+      octokit.rest.pulls.get({
+        owner,
+        repo,
+        pull_number: pullNumber,
+      })
+  )
 
   return response.data
 }
@@ -400,12 +420,16 @@ export async function addLabelsToPullRequest({
   if (!owner || !repo) {
     throw new Error("Invalid repository format. Expected 'owner/repo'")
   }
-  await octokit.rest.issues.addLabels({
-    owner,
-    repo,
-    issue_number: pullNumber,
-    labels,
-  })
+  await withTiming(
+    `GitHub REST: issues.addLabels ${repoFullName}#${pullNumber}`,
+    () =>
+      octokit.rest.issues.addLabels({
+        owner,
+        repo,
+        issue_number: pullNumber,
+        labels,
+      })
+  )
 }
 
 // Minimal type for the GraphQL response
@@ -437,7 +461,12 @@ export async function getPRLinkedIssuesMap(
   let endCursor: string | null = null
   const issuePRStatus: Record<number, boolean> = {}
 
+  const totalStart = logStart(`GitHub GraphQL: getPRLinkedIssuesMap ${repoFullName}`)
   while (hasNextPage) {
+    const pageStart = logStart(
+      `GitHub GraphQL page getPRLinkedIssuesMap ${repoFullName}`,
+      { after: endCursor }
+    )
     const query = `
       query($owner: String!, $repo: String!, $after: String) {
         repository(owner: $owner, name: $repo) {
@@ -471,7 +500,12 @@ export async function getPRLinkedIssuesMap(
     }
     hasNextPage = response.repository.pullRequests.pageInfo.hasNextPage
     endCursor = response.repository.pullRequests.pageInfo.endCursor
+    logEnd(`GitHub GraphQL page getPRLinkedIssuesMap ${repoFullName}`, pageStart, {
+      after: variables.after,
+      nextAfter: endCursor,
+    })
   }
+  logEnd(`GitHub GraphQL: getPRLinkedIssuesMap ${repoFullName}`, totalStart)
   return issuePRStatus
 }
 
@@ -486,7 +520,14 @@ export async function getIssueToPullRequestMap(
   let endCursor: string | null = null
   const issuePRMap: Record<number, number> = {}
 
+  const totalStart = logStart(
+    `GitHub GraphQL: getIssueToPullRequestMap ${repoFullName}`
+  )
   while (hasNextPage) {
+    const pageStart = logStart(
+      `GitHub GraphQL page getIssueToPullRequestMap ${repoFullName}`,
+      { after: endCursor }
+    )
     const query = `
       query($owner: String!, $repo: String!, $after: String) {
         repository(owner: $owner, name: $repo) {
@@ -522,7 +563,16 @@ export async function getIssueToPullRequestMap(
     }
     hasNextPage = response.repository.pullRequests.pageInfo.hasNextPage
     endCursor = response.repository.pullRequests.pageInfo.endCursor
+    logEnd(
+      `GitHub GraphQL page getIssueToPullRequestMap ${repoFullName}`,
+      pageStart,
+      { after: variables.after, nextAfter: endCursor }
+    )
   }
+  logEnd(
+    `GitHub GraphQL: getIssueToPullRequestMap ${repoFullName}`,
+    totalStart
+  )
   return issuePRMap
 }
 
@@ -563,11 +613,12 @@ export async function getLinkedIssuesForPR({
       } | null
     } | null
   }
-  const response = (await graphqlWithAuth(
-    query,
-    variables
+  const response = (await withTiming(
+    `GitHub GraphQL: getLinkedIssuesForPR ${repoFullName}#${pullNumber}`,
+    () => graphqlWithAuth(query, variables)
   )) as LinkedIssuesResponse
   const nodes =
     response.repository?.pullRequest?.closingIssuesReferences?.nodes || []
   return nodes.map((n) => n.number)
 }
+

--- a/lib/neo4j/services/plan.ts
+++ b/lib/neo4j/services/plan.ts
@@ -19,6 +19,7 @@ import {
   WorkflowRun,
   workflowRunSchema,
 } from "@/lib/types"
+import { withTiming } from "@/lib/utils/telemetry"
 
 export async function listPlansForIssue({
   repoFullName,
@@ -30,12 +31,16 @@ export async function listPlansForIssue({
   const session = await n4j.getSession()
 
   try {
-    const result = await session.executeRead(async (tx: ManagedTransaction) => {
-      return await dbListPlansForIssue(tx, {
-        repoFullName,
-        issueNumber,
-      })
-    })
+    const result = await withTiming(
+      `Neo4j READ: listPlansForIssue ${repoFullName}#${issueNumber}`,
+      async () =>
+        session.executeRead(async (tx: ManagedTransaction) => {
+          return await dbListPlansForIssue(tx, {
+            repoFullName,
+            issueNumber,
+          })
+        })
+    )
 
     return result.map(neo4jToJs).map((plan) => planSchema.parse(plan))
   } finally {
@@ -60,24 +65,26 @@ export async function tagMessageAsPlan({
 }): Promise<LLMResponseWithPlan> {
   const session = await n4j.getSession()
   try {
-    const result = await session.executeWrite(
-      async (tx: ManagedTransaction) => {
-        // Label as Plan
-        const planNode = await labelEventAsPlan(tx, {
-          eventId,
-          status: "draft",
-          version: int(1),
-        })
+    const result = await withTiming(
+      `Neo4j WRITE: tagMessageAsPlan ${repoFullName}#${issueNumber}`,
+      async () =>
+        session.executeWrite(async (tx: ManagedTransaction) => {
+          // Label as Plan
+          const planNode = await labelEventAsPlan(tx, {
+            eventId,
+            status: "draft",
+            version: int(1),
+          })
 
-        // Create relationship
-        await createPlanImplementsIssue(tx, {
-          eventId,
-          issueNumber: int(issueNumber),
-          repoFullName,
-        })
+          // Create relationship
+          await createPlanImplementsIssue(tx, {
+            eventId,
+            issueNumber: int(issueNumber),
+            repoFullName,
+          })
 
-        return planNode
-      }
+          return planNode
+        })
     )
 
     return {
@@ -103,9 +110,13 @@ export async function getPlanWithDetails(
 ): Promise<{ plan: Plan; workflow: WorkflowRun; issue: Issue }> {
   const session = await n4j.getSession()
   try {
-    const result = await session.executeRead(async (tx: ManagedTransaction) => {
-      return await dbGetPlanWithDetails(tx, { planId })
-    })
+    const result = await withTiming(
+      `Neo4j READ: getPlanWithDetails ${planId}`,
+      async () =>
+        session.executeRead(async (tx: ManagedTransaction) => {
+          return await dbGetPlanWithDetails(tx, { planId })
+        })
+    )
 
     return {
       plan: planSchema.parse(neo4jToJs(result.plan)),
@@ -128,9 +139,14 @@ export async function getPlanStatusForIssues({
   if (!issueNumbers.length) return {}
   const session = await n4j.getSession()
   try {
-    return await session.executeRead(async (tx: ManagedTransaction) => {
-      return await dbListPlanStatusForIssues(tx, { repoFullName, issueNumbers })
-    })
+    return await withTiming(
+      `Neo4j READ: listPlanStatusForIssues ${repoFullName}`,
+      async () =>
+        session.executeRead(async (tx: ManagedTransaction) => {
+          return await dbListPlanStatusForIssues(tx, { repoFullName, issueNumbers })
+        }),
+      { count: issueNumbers.length }
+    )
   } finally {
     await session.close()
   }
@@ -147,13 +163,19 @@ export async function getLatestPlanIdsForIssues({
   if (!issueNumbers.length) return {}
   const session = await n4j.getSession()
   try {
-    return await session.executeRead(async (tx: ManagedTransaction) => {
-      return await dbListLatestPlanIdsForIssues(tx, {
-        repoFullName,
-        issueNumbers,
-      })
-    })
+    return await withTiming(
+      `Neo4j READ: listLatestPlanIdsForIssues ${repoFullName}`,
+      async () =>
+        session.executeRead(async (tx: ManagedTransaction) => {
+          return await dbListLatestPlanIdsForIssues(tx, {
+            repoFullName,
+            issueNumbers,
+          })
+        }),
+      { count: issueNumbers.length }
+    )
   } finally {
     await session.close()
   }
 }
+

--- a/lib/neo4j/services/plan.ts
+++ b/lib/neo4j/services/plan.ts
@@ -143,7 +143,10 @@ export async function getPlanStatusForIssues({
       `Neo4j READ: listPlanStatusForIssues ${repoFullName}`,
       async () =>
         session.executeRead(async (tx: ManagedTransaction) => {
-          return await dbListPlanStatusForIssues(tx, { repoFullName, issueNumbers })
+          return await dbListPlanStatusForIssues(tx, {
+            repoFullName,
+            issueNumbers,
+          })
         }),
       { count: issueNumbers.length }
     )
@@ -178,4 +181,3 @@ export async function getLatestPlanIdsForIssues({
     await session.close()
   }
 }
-

--- a/lib/neo4j/services/workflow.ts
+++ b/lib/neo4j/services/workflow.ts
@@ -168,9 +168,10 @@ export async function getWorkflowRunWithDetails(
   try {
     const { workflow, events, issue } = await withTiming(
       `Neo4j READ: getWorkflowRunWithDetails ${workflowRunId}`,
-      async () => session.executeRead(async (tx) => {
-        return await getWithDetails(tx, workflowRunId)
-      })
+      async () =>
+        session.executeRead(async (tx) => {
+          return await getWithDetails(tx, workflowRunId)
+        })
     )
     return {
       workflow: workflowRunSchema.parse(neo4jToJs(workflow)),
@@ -189,9 +190,10 @@ export async function getWorkflowRunMessages(
   try {
     const dbEvents = await withTiming(
       `Neo4j READ: getWorkflowRunMessages ${workflowRunId}`,
-      async () => session.executeRead(async (tx) => {
-        return await getMessagesForWorkflowRun(tx, workflowRunId)
-      })
+      async () =>
+        session.executeRead(async (tx) => {
+          return await getMessagesForWorkflowRun(tx, workflowRunId)
+        })
     )
     return await Promise.all(
       dbEvents.map((e) => toAppMessageEvent(e, workflowRunId))
@@ -208,13 +210,13 @@ export async function getWorkflowRunEvents(
   try {
     const dbEvents = await withTiming(
       `Neo4j READ: getWorkflowRunEvents ${workflowRunId}`,
-      async () => session.executeRead(async (tx) => {
-        return await getEventsForWorkflowRun(tx, workflowRunId)
-      })
+      async () =>
+        session.executeRead(async (tx) => {
+          return await getEventsForWorkflowRun(tx, workflowRunId)
+        })
     )
     return await Promise.all(dbEvents.map((e) => toAppEvent(e, workflowRunId)))
   } finally {
     await session.close()
   }
 }
-

--- a/lib/utils/telemetry.ts
+++ b/lib/utils/telemetry.ts
@@ -8,23 +8,27 @@ function nowIso() {
 
 export function logStart(label: string, meta?: LogMeta) {
   const start = Date.now()
-  // eslint-disable-next-line no-console
-  console.log(`[${nowIso()}][START] ${label}${meta ? " " + JSON.stringify(meta) : ""}`)
+  console.log(
+    `[${nowIso()}][START] ${label}${meta ? " " + JSON.stringify(meta) : ""}`
+  )
   return start
 }
 
 export function logEnd(label: string, start: number, meta?: LogMeta) {
   const durationMs = Date.now() - start
-  // eslint-disable-next-line no-console
   console.log(
     `[${nowIso()}][END]   ${label} (${durationMs}ms)` +
       (meta ? ` ${JSON.stringify(meta)}` : "")
   )
 }
 
-export function logError(label: string, start: number | null, error: unknown, meta?: LogMeta) {
+export function logError(
+  label: string,
+  start: number | null,
+  error: unknown,
+  meta?: LogMeta
+) {
   const durationMs = start ? Date.now() - start : undefined
-  // eslint-disable-next-line no-console
   console.error(
     `[${nowIso()}][ERROR] ${label}` +
       (typeof durationMs === "number" ? ` (${durationMs}ms)` : "") +
@@ -48,4 +52,3 @@ export async function withTiming<T>(
     throw err
   }
 }
-

--- a/lib/utils/telemetry.ts
+++ b/lib/utils/telemetry.ts
@@ -1,0 +1,51 @@
+/* Simple timestamped logging utilities for measuring durations around external calls (DB, APIs). */
+
+export type LogMeta = Record<string, unknown> | undefined
+
+function nowIso() {
+  return new Date().toISOString()
+}
+
+export function logStart(label: string, meta?: LogMeta) {
+  const start = Date.now()
+  // eslint-disable-next-line no-console
+  console.log(`[${nowIso()}][START] ${label}${meta ? " " + JSON.stringify(meta) : ""}`)
+  return start
+}
+
+export function logEnd(label: string, start: number, meta?: LogMeta) {
+  const durationMs = Date.now() - start
+  // eslint-disable-next-line no-console
+  console.log(
+    `[${nowIso()}][END]   ${label} (${durationMs}ms)` +
+      (meta ? ` ${JSON.stringify(meta)}` : "")
+  )
+}
+
+export function logError(label: string, start: number | null, error: unknown, meta?: LogMeta) {
+  const durationMs = start ? Date.now() - start : undefined
+  // eslint-disable-next-line no-console
+  console.error(
+    `[${nowIso()}][ERROR] ${label}` +
+      (typeof durationMs === "number" ? ` (${durationMs}ms)` : "") +
+      (meta ? ` ${JSON.stringify(meta)}` : ""),
+    error
+  )
+}
+
+export async function withTiming<T>(
+  label: string,
+  fn: () => Promise<T>,
+  meta?: LogMeta
+): Promise<T> {
+  const start = logStart(label, meta)
+  try {
+    const result = await fn()
+    logEnd(label, start)
+    return result
+  } catch (err) {
+    logError(label, start, err, meta)
+    throw err
+  }
+}
+


### PR DESCRIPTION
Context
Refreshing the main page and the issues list page occasionally feels slow. To help pinpoint where time is being spent, this PR adds consistent, timestamped console logs across the key GitHub API and Neo4j database calls that power these views.

What changed
- New telemetry helpers
  - lib/utils/telemetry.ts provides:
    - withTiming(label, fn, meta?) — logs [START]/[END] with ISO timestamps and duration in ms, catches errors and logs [ERROR]
    - logStart/logEnd/logError for more granular control

- GitHub API instrumentation
  - lib/github/issues.ts
    - getIssueListWithStatus now logs each stage:
      1) GitHub REST: issues list
      2) Neo4j: getPlanStatusForIssues
      3) Neo4j: getLatestPlanIdsForIssues
      4) GitHub GraphQL: getIssueToPullRequestMap
      5) Neo4j: listWorkflowRuns for each issue (per-issue labels include issue number)
    - getIssueList wraps octokit.rest.issues.listForRepo with timing
  - lib/github/pullRequests.ts
    - Timings for pulls.list, pulls.get, pulls.listReviews, issues.listComments (PR), createPullRequest GraphQL flow
    - Added detailed page-by-page timing for GraphQL pagination in getIssueToPullRequestMap (and getPRLinkedIssuesMap) to spot slow pages; logs include the cursor
  - lib/github/content.ts (main page repo listings)
    - Timings for repos.listForUser and repos.listForAuthenticatedUser
    - Also added timings around repos.get, repos.getContent, repos.getBranch, and createOrUpdateFileContents

- Neo4j instrumentation
  - lib/neo4j/services/plan.ts
    - Added withTiming around executeRead/executeWrite for listPlansForIssue, tagMessageAsPlan, getPlanWithDetails, getPlanStatusForIssues, getLatestPlanIdsForIssues
    - Includes metadata such as count of issue numbers for batch calls
  - lib/neo4j/services/workflow.ts
    - Added withTiming around executeRead/executeWrite for initializeWorkflowRun, listWorkflowRuns, getWorkflowRunWithDetails, getWorkflowRunMessages, getWorkflowRunEvents

Why this approach
- Centralized helper keeps log format consistent and easy to read/grep: [ISO][START|END|ERROR] Label (durationms) {optional meta}
- Minimal code changes in call sites while covering the critical path for the issues page and main page
- Fine-grained logs (especially GraphQL pagination and per-issue workflow checks) should make hotspots obvious without changing behavior

Notes
- This is console-only and safe in development/staging. If needed, we can later gate logs behind an env flag or move to a structured logger.
- ESLint/TypeScript clean. Tests pass locally for node/dom projects.

Example logs
- [2025-08-12T12:34:56.789Z][START] GitHub: getIssueList owner/repo
- [2025-08-12T12:34:57.123Z][END]   GitHub: getIssueList owner/repo (334ms)
- [2025-08-12T12:34:57.124Z][START] Neo4j: getPlanStatusForIssues owner/repo {"count":25}
- [2025-08-12T12:34:57.180Z][END]   Neo4j: getPlanStatusForIssues owner/repo (56ms)

Closes #975