### PR TITLE
Lazily load linked PRs for listed issues

### DIFF
--- a/app/api/issues/[issueId]/pullRequest/route.ts
+++ b/app/api/issues/[issueId]/pullRequest/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server"
 
-import { getIssueToPullRequestMap } from "@/lib/github/pullRequests"
+import { getLinkedPRNumberForIssue } from "@/lib/github/issues"
 
 export const dynamic = "force-dynamic"
 
@@ -22,8 +22,10 @@ export async function GET(
       return NextResponse.json({ error: "Invalid issue id" }, { status: 400 })
     }
 
-    const map = await getIssueToPullRequestMap(repo)
-    const prNumber = map[issueNumber] ?? null
+    const prNumber = await getLinkedPRNumberForIssue({
+      repoFullName: repo,
+      issueNumber,
+    })
     return NextResponse.json({ prNumber })
   } catch (err) {
     console.error("Error fetching PR for issue:", err)
@@ -33,3 +35,4 @@ export async function GET(
     )
   }
 }
+

--- a/components/issues/PRStatusIndicator.tsx
+++ b/components/issues/PRStatusIndicator.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import { GitPullRequest, Loader2 } from "lucide-react"
+import { useEffect, useState } from "react"
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+
+interface Props {
+  repoFullName: string
+  issueNumber: number
+}
+
+export default function PRStatusIndicator({ repoFullName, issueNumber }: Props) {
+  const [loading, setLoading] = useState(true)
+  const [prNumber, setPrNumber] = useState<number | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      try {
+        setLoading(true)
+        const res = await fetch(
+          `/api/issues/${issueNumber}/pullRequest?repo=${encodeURIComponent(repoFullName)}`
+        )
+        if (!res.ok) throw new Error(`Failed to fetch PR for issue #${issueNumber}`)
+        const data = (await res.json()) as { prNumber: number | null }
+        if (!cancelled) setPrNumber(data.prNumber ?? null)
+      } catch {
+        if (!cancelled) setPrNumber(null)
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [issueNumber, repoFullName])
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <div style={{ width: 24, display: "flex", justifyContent: "center" }}>
+        {loading ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Loader2 className="inline align-text-bottom mr-0.5 animate-spin text-muted-foreground" size={18} />
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Checking linked PR…</TooltipContent>
+          </Tooltip>
+        ) : prNumber ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <a
+                href={`https://github.com/${repoFullName}/pull/${prNumber}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="cursor-pointer"
+              >
+                <GitPullRequest className="inline align-text-bottom text-green-600" size={18} />
+              </a>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">PR ready</TooltipContent>
+          </Tooltip>
+        ) : null}
+      </div>
+    </TooltipProvider>
+  )
+}
+

--- a/components/issues/StatusIndicators.tsx
+++ b/components/issues/StatusIndicators.tsx
@@ -1,6 +1,7 @@
-import { GitPullRequest, Loader2, NotebookPen } from "lucide-react"
+import { Loader2, NotebookPen } from "lucide-react"
 import Link from "next/link"
 
+import PRStatusIndicator from "@/components/issues/PRStatusIndicator"
 import {
   Tooltip,
   TooltipContent,
@@ -14,9 +15,7 @@ interface Props {
     IssueWithStatus,
     | "hasActiveWorkflow"
     | "hasPlan"
-    | "hasPR"
     | "planId"
-    | "prNumber"
     | "number"
   >
   repoFullName: string
@@ -59,27 +58,8 @@ export default function StatusIndicators({ issue, repoFullName }: Props) {
             </Tooltip>
           ) : null}
         </div>
-        {/* PR Icon Slot */}
-        <div style={{ width: 24, display: "flex", justifyContent: "center" }}>
-          {issue.hasPR && issue.prNumber ? (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <a
-                  href={`https://github.com/${repoFullName}/pull/${issue.prNumber}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="cursor-pointer"
-                >
-                  <GitPullRequest
-                    className="inline align-text-bottom text-green-600"
-                    size={18}
-                  />
-                </a>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">PR ready</TooltipContent>
-            </Tooltip>
-          ) : null}
-        </div>
+        {/* PR Icon Slot - lazily fetched on the client */}
+        <PRStatusIndicator repoFullName={repoFullName} issueNumber={issue.number} />
       </div>
     </TooltipProvider>
   )

--- a/lib/github/issues.ts
+++ b/lib/github/issues.ts
@@ -1,7 +1,6 @@
 "use server"
 
-import getOctokit, { getUserOctokit } from "@/lib/github"
-import { getIssueToPullRequestMap } from "@/lib/github/pullRequests"
+import getOctokit, { getGraphQLClient, getUserOctokit } from "@/lib/github"
 import {
   getLatestPlanIdsForIssues,
   getPlanStatusForIssues,
@@ -209,13 +208,7 @@ export async function getIssueListWithStatus({
     ),
   ])
 
-  // 3. Get PRs from GitHub using GraphQL, and find for each issue if it has a PR referencing it.
-  const issuePRMap = await withTiming(
-    `GitHub GraphQL: getIssueToPullRequestMap ${repoFullName}`,
-    () => getIssueToPullRequestMap(repoFullName)
-  )
-
-  // 4. Determine active workflows for each issue (simple sequential for now)
+  // 3. Determine active workflows for each issue (simple sequential for now)
   const withStatus: IssueWithStatus[] = await Promise.all(
     issues.map(async (issue) => {
       let hasActiveWorkflow = false
@@ -237,13 +230,113 @@ export async function getIssueListWithStatus({
       return {
         ...issue,
         hasPlan: issuePlanStatus[issue.number] || false,
-        hasPR: Boolean(issuePRMap[issue.number]),
+        // Lazily load PR info on the client to avoid heavy initial GraphQL scans
+        hasPR: false,
         hasActiveWorkflow,
         planId: issuePlanIds[issue.number] || null,
-        prNumber: issuePRMap[issue.number],
+        prNumber: undefined,
       }
     })
   )
 
   return withStatus
 }
+
+/**
+ * Lightweight GraphQL call to find a PR linked to a specific issue number.
+ * This avoids scanning all PRs in the repository.
+ */
+export async function getLinkedPRNumberForIssue({
+  repoFullName,
+  issueNumber,
+}: {
+  repoFullName: string
+  issueNumber: number
+}): Promise<number | null> {
+  const [owner, repo] = repoFullName.split("/")
+  const graphqlWithAuth = await getGraphQLClient()
+  if (!graphqlWithAuth) throw new Error("Could not initialize GraphQL client")
+
+  const query = `
+    query($owner: String!, $repo: String!, $issueNumber: Int!) {
+      repository(owner: $owner, name: $repo) {
+        issue(number: $issueNumber) {
+          timelineItems(first: 100, itemTypes: [CROSS_REFERENCED_EVENT, REFERENCED_EVENT]) {
+            nodes {
+              __typename
+              ... on CrossReferencedEvent {
+                isCrossRepository
+                willClose
+                source {
+                  __typename
+                  ... on PullRequest {
+                    number
+                  }
+                }
+              }
+              ... on ReferencedEvent {
+                subject {
+                  __typename
+                  ... on PullRequest { number }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `
+
+  type Node =
+    | {
+        __typename: "CrossReferencedEvent"
+        isCrossRepository: boolean
+        willClose: boolean
+        source: { __typename: string; number?: number } | null
+      }
+    | {
+        __typename: "ReferencedEvent"
+        subject: { __typename: string; number?: number } | null
+      }
+
+  interface Resp {
+    repository: {
+      issue: {
+        timelineItems: { nodes: Node[] }
+      } | null
+    } | null
+  }
+
+  const variables = { owner, repo, issueNumber }
+  const resp = (await withTiming(
+    `GitHub GraphQL: getLinkedPRNumberForIssue ${repoFullName}#${issueNumber}`,
+    () => graphqlWithAuth<Resp>(query, variables)
+  )) as Resp
+
+  const nodes = resp.repository?.issue?.timelineItems?.nodes || []
+
+  // Prefer PRs that will close this issue when merged
+  for (const n of nodes) {
+    if (n.__typename === "CrossReferencedEvent" && n.willClose) {
+      if (n.source?.__typename === "PullRequest" && n.source.number) {
+        return n.source.number
+      }
+    }
+  }
+  // Fallback: any PR reference
+  for (const n of nodes) {
+    if (n.__typename === "ReferencedEvent") {
+      if (n.subject?.__typename === "PullRequest" && n.subject.number) {
+        return n.subject.number
+      }
+    }
+    if (n.__typename === "CrossReferencedEvent") {
+      if (n.source?.__typename === "PullRequest" && n.source.number) {
+        return n.source.number
+      }
+    }
+  }
+
+  return null
+}
+


### PR DESCRIPTION
Summary
- Defer PR linkage checks until after issues render to reduce initial load and network usage.
- Replace repo-wide PR scan with a targeted per-issue GraphQL query that inspects timeline items.
- Add a lightweight client-side indicator that fetches and shows a PR icon only for visible issues.

What changed
1) Server-side issue listing
- getIssueListWithStatus no longer calls getIssueToPullRequestMap (which paged through all PRs in a repo).
- It now returns issues without PR linkage precomputed (hasPR=false, prNumber=undefined), while still including plan/workflow info from Neo4j.

2) Efficient API for a single issue
- Updated /api/issues/[issueId]/pullRequest to use a new GraphQL function getLinkedPRNumberForIssue, which queries only the requested issue’s timeline items (CrossReferencedEvent/ReferencedEvent) and returns a prNumber or null.

3) Client-side lazy indicator
- New components/issues/PRStatusIndicator.tsx fetches the PR number for each listed issue after render.
- StatusIndicators now uses PRStatusIndicator for the PR slot and shows a small spinner while the lookup runs.

Why
Previously we built a full issue→PR map by paginating every PR in the repo and collecting closingIssuesReferences. That was heavy for large repos and slowed down the main issues page. The new approach:
- Loads issues first (fast) and renders the table.
- Then, for only the visible issues, it performs per-issue GraphQL calls to check if there’s a linked PR.
- The per-issue query is cheap and avoids scanning the entire repo’s PR history.

Notes
- The GraphQL query prioritizes CrossReferencedEvent entries that will close the issue when merged; it falls back to any PR reference if none match willClose.
- The UI shows a loader in the PR slot until the lookup completes.

No breaking API changes. The per-issue endpoint still returns { prNumber }.


Closes #987