### PR TITLE
feat(shared): add anthropic sdk adapter

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5394,7 +5394,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.17.24
+      '@types/node': 20.19.10
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -5407,14 +5407,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.24
+      '@types/node': 20.19.10
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.17.24)(ts-node@10.9.2(@types/node@20.17.24)(typescript@5.8.2))
+      jest-config: 29.7.0(@types/node@20.19.10)(ts-node@10.9.2(@types/node@20.17.24)(typescript@5.8.2))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -5439,7 +5439,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.24
+      '@types/node': 20.19.10
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -5457,7 +5457,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 20.17.24
+      '@types/node': 20.19.10
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -5479,7 +5479,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 20.17.24
+      '@types/node': 20.19.10
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -5549,7 +5549,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.17.24
+      '@types/node': 20.19.10
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -6576,7 +6576,7 @@ snapshots:
 
   '@types/docker-modem@3.0.6':
     dependencies:
-      '@types/node': 20.17.30
+      '@types/node': 20.19.10
       '@types/ssh2': 1.15.5
 
   '@types/dockerode@3.3.42':
@@ -6605,7 +6605,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 20.17.24
+      '@types/node': 20.19.10
 
   '@types/hast@3.0.4':
     dependencies:
@@ -6628,7 +6628,7 @@ snapshots:
 
   '@types/jsdom@20.0.1':
     dependencies:
-      '@types/node': 20.17.24
+      '@types/node': 20.19.10
       '@types/tough-cookie': 4.0.5
       parse5: 7.2.1
 
@@ -8443,7 +8443,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.24
+      '@types/node': 20.19.10
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3
@@ -8513,6 +8513,37 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-config@29.7.0(@types/node@20.19.10)(ts-node@10.9.2(@types/node@20.17.24)(typescript@5.8.2)):
+    dependencies:
+      '@babel/core': 7.26.10
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.26.10)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.19.10
+      ts-node: 10.9.2(@types/node@20.17.24)(typescript@5.8.2)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
   jest-diff@29.7.0:
     dependencies:
       chalk: 4.1.2
@@ -8552,7 +8583,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.24
+      '@types/node': 20.19.10
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -8562,7 +8593,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 20.17.24
+      '@types/node': 20.19.10
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -8601,7 +8632,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.17.24
+      '@types/node': 20.19.10
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -8636,7 +8667,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.24
+      '@types/node': 20.19.10
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -8664,7 +8695,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.24
+      '@types/node': 20.19.10
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.2
@@ -8710,7 +8741,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.17.24
+      '@types/node': 20.19.10
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -8729,7 +8760,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.24
+      '@types/node': 20.19.10
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -8744,7 +8775,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 20.17.24
+      '@types/node': 20.19.10
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -9607,7 +9638,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 20.17.30
+      '@types/node': 20.19.10
       long: 5.3.2
 
   psl@1.15.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,6 +271,28 @@ importers:
         specifier: ^5.3.4
         version: 5.7.0
 
+  shared:
+    dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.59.0
+        version: 0.59.0
+      bullmq:
+        specifier: ^5.0.0
+        version: 5.56.10
+      ioredis:
+        specifier: ^5.3.2
+        version: 5.7.0
+      zod:
+        specifier: ^3.22.4
+        version: 3.24.2
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.19.10
+      typescript:
+        specifier: ^5
+        version: 5.8.2
+
 packages:
 
   '@adobe/css-tools@4.4.2':
@@ -283,6 +305,10 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@anthropic-ai/sdk@0.59.0':
+    resolution: {integrity: sha512-m9w9tC+N+GUNprwEOhU3VKKSYwXA1fIevRCe7kOFonV4xu5vxqmqyoLy+dkdVvc5W1F4WUTVE/7I4criaF9gnw==}
+    hasBin: true
 
   '@auth/core@0.37.2':
     resolution: {integrity: sha512-kUvzyvkcd6h1vpeMAojK2y7+PAV5H+0Cc9+ZlKYDFhDY31AlvsB+GW5vNO4qE3Y07KeQgvNO9U0QUx/fN62kBw==}
@@ -5009,6 +5035,8 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
+
+  '@anthropic-ai/sdk@0.59.0': {}
 
   '@auth/core@0.37.2':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,4 +2,4 @@
 packages:
   - .
   - apps/*
-  - shared/*
+  - shared/

--- a/shared/package.json
+++ b/shared/package.json
@@ -25,6 +25,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.59.0",
     "bullmq": "^5.0.0",
     "ioredis": "^5.3.2",
     "zod": "^3.22.4"

--- a/shared/src/adapters/anthropic.ts
+++ b/shared/src/adapters/anthropic.ts
@@ -1,8 +1,8 @@
 import Anthropic from "@anthropic-ai/sdk"
 
-import type { LLMAdapter, LLMMessage } from "@/shared/src/core/ports/llm"
+import type { LLMMessage, LLMPort } from "@/shared/src/core/ports/llm"
 
-export class AnthropicAdapter implements LLMAdapter {
+export class AnthropicAdapter implements LLMPort {
   private client: Anthropic
 
   constructor(apiKey: string | undefined = process.env.ANTHROPIC_API_KEY) {

--- a/shared/src/adapters/anthropic.ts
+++ b/shared/src/adapters/anthropic.ts
@@ -1,8 +1,9 @@
 import Anthropic from "@anthropic-ai/sdk"
+
 import type { LLMAdapter, LLMMessage } from "@/shared/src/core/ports/llm"
 
 export class AnthropicAdapter implements LLMAdapter {
-  private client: any
+  private client: Anthropic
 
   constructor(apiKey: string | undefined = process.env.ANTHROPIC_API_KEY) {
     if (!apiKey) {

--- a/shared/src/adapters/anthropic.ts
+++ b/shared/src/adapters/anthropic.ts
@@ -1,0 +1,41 @@
+import Anthropic from "@anthropic-ai/sdk"
+import type { LLMAdapter, LLMMessage } from "@/shared/src/core/ports/llm"
+
+export class AnthropicAdapter implements LLMAdapter {
+  private client: any
+
+  constructor(apiKey: string | undefined = process.env.ANTHROPIC_API_KEY) {
+    if (!apiKey) {
+      throw new Error("Anthropic API key is missing")
+    }
+    this.client = new Anthropic({ apiKey })
+  }
+
+  async createCompletion({
+    system,
+    messages,
+    model = "claude-3-5-sonnet-latest",
+    maxTokens = 1024,
+  }: {
+    system?: string
+    messages: LLMMessage[]
+    model?: string
+    maxTokens?: number
+  }): Promise<string> {
+    const response = await this.client.messages.create({
+      model,
+      system,
+      max_tokens: maxTokens,
+      messages: messages.map((m) => ({
+        role: m.role,
+        content: m.content,
+      })),
+    })
+
+    return response.content
+      .map((block) => ("text" in block ? block.text : ""))
+      .join("")
+  }
+}
+
+export default AnthropicAdapter

--- a/shared/src/core/ports/llm.ts
+++ b/shared/src/core/ports/llm.ts
@@ -1,0 +1,13 @@
+export interface LLMMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export interface LLMAdapter {
+  createCompletion(params: {
+    system?: string;
+    messages: LLMMessage[];
+    model?: string;
+    maxTokens?: number;
+  }): Promise<string>;
+}

--- a/shared/src/core/ports/llm.ts
+++ b/shared/src/core/ports/llm.ts
@@ -1,13 +1,13 @@
 export interface LLMMessage {
-  role: "user" | "assistant";
-  content: string;
+  role: "user" | "assistant"
+  content: string
 }
 
-export interface LLMAdapter {
+export interface LLMPort {
   createCompletion(params: {
-    system?: string;
-    messages: LLMMessage[];
-    model?: string;
-    maxTokens?: number;
-  }): Promise<string>;
+    system?: string
+    messages: LLMMessage[]
+    model?: string
+    maxTokens?: number
+  }): Promise<string>
 }

--- a/shared/src/types/anthropic-ai-sdk.d.ts
+++ b/shared/src/types/anthropic-ai-sdk.d.ts
@@ -1,0 +1,4 @@
+declare module "@anthropic-ai/sdk" {
+  const Anthropic: any
+  export default Anthropic
+}

--- a/shared/src/types/anthropic-ai-sdk.d.ts
+++ b/shared/src/types/anthropic-ai-sdk.d.ts
@@ -1,4 +1,0 @@
-declare module "@anthropic-ai/sdk" {
-  const Anthropic: any
-  export default Anthropic
-}


### PR DESCRIPTION
## Summary
- refactor anthropic integration into adapter layer
- define LLM interface for provider-agnostic workflows
- move LLM interface definitions into core ports for cleaner architecture

## Testing
- `pnpm lint`
- `pnpm test`
- `cd shared && pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689c3e1b08e48333ae04e1be3f353f7d