### PR TITLE
feat(shared): add container core entity

### DIFF
--- a/shared/src/core/entities/container.ts
+++ b/shared/src/core/entities/container.ts
@@ -1,0 +1,90 @@
+export type ContainerStatus = "created" | "running" | "stopped" | "removed"
+
+export interface ContainerProps {
+  /**
+   * Optional unique identifier of the container, typically assigned by the
+   * runtime (e.g. Docker). If omitted the container is considered not yet
+   * created in the runtime.
+   */
+  id?: string
+
+  /**
+   * Docker image that the container is based on.
+   */
+  image: string
+
+  /**
+   * Human friendly name for the container.
+   */
+  name?: string
+
+  /**
+   * Initial status of the container. Defaults to `"created"`.
+   */
+  status?: ContainerStatus
+}
+
+/**
+ * Core entity representing a container in which LLM agents can operate.
+ *
+ * This entity holds the minimal state required to reason about a container
+ * without depending on any Docker specific implementation details. It can be
+ * extended with ports and services to actually manage a running container.
+ */
+export class Container {
+  private _id?: string
+  private readonly _image: string
+  private _name?: string
+  private _status: ContainerStatus
+
+  constructor({ id, image, name, status = "created" }: ContainerProps) {
+    if (!image) {
+      throw new Error("Container image is required")
+    }
+
+    this._id = id
+    this._image = image
+    this._name = name
+    this._status = status
+  }
+
+  get id(): string | undefined {
+    return this._id
+  }
+
+  get image(): string {
+    return this._image
+  }
+
+  get name(): string | undefined {
+    return this._name
+  }
+
+  get status(): ContainerStatus {
+    return this._status
+  }
+
+  /**
+   * Mark the container as started.
+   */
+  start(): void {
+    this._status = "running"
+  }
+
+  /**
+   * Mark the container as stopped.
+   */
+  stop(): void {
+    this._status = "stopped"
+  }
+
+  /**
+   * Mark the container as removed and clear its identifier.
+   */
+  remove(): void {
+    this._status = "removed"
+    this._id = undefined
+  }
+}
+
+export default Container


### PR DESCRIPTION
## Summary
- add Container entity to encapsulate docker container metadata and lifecycle
- expose methods to start, stop, and remove containers for future LLM worker management

## Testing
- `pnpm test`
- `pnpm test __tests__/api/stream/ping.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689c6a5f5aa08333a71d3ac2d5428101