### PR TITLE
Add experimental simple auth configuration

### DIFF
--- a/app/api/auth-simple/[...nextauth]/route.ts
+++ b/app/api/auth-simple/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { simpleHandlers } from "@/auth-simple"
+
+export const { GET, POST } = simpleHandlers

--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -18,6 +18,7 @@ import Link from "next/link"
 import { redirect } from "next/navigation"
 
 import { auth } from "@/auth"
+import { simpleAuth } from "@/auth-simple"
 import OAuthTokenCard from "@/components/auth/OAuthTokenCard"
 import RepoSelector from "@/components/common/RepoSelector"
 import AgentWorkflowClient from "@/components/playground/AgentWorkflowClient"
@@ -36,8 +37,13 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { getGithubUser } from "@/lib/github/users"
 import { getUserRoles } from "@/lib/neo4j/services/user"
 
-export default async function PlaygroundPage() {
-  const session = await auth()
+export default async function PlaygroundPage({
+  searchParams,
+}: {
+  searchParams?: { [key: string]: string | string[] | undefined }
+}) {
+  const useSimple = searchParams?.simple === "1"
+  const session = await (useSimple ? simpleAuth() : auth())
   if (!session?.user) {
     redirect("/")
   }

--- a/auth-simple.ts
+++ b/auth-simple.ts
@@ -1,0 +1,103 @@
+import NextAuth from "next-auth"
+import GithubProvider from "next-auth/providers/github"
+import { NextResponse } from "next/server"
+import { JWT } from "next-auth/jwt"
+
+// A minimal NextAuth config without Redis/locking for experimentation
+
+async function refreshAccessToken(token: JWT): Promise<JWT> {
+  try {
+    const response = await fetch("https://github.com/login/oauth/access_token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+      },
+      body: new URLSearchParams({
+        client_id: process.env.GITHUB_APP_CLIENT_ID ?? "",
+        client_secret: process.env.GITHUB_APP_CLIENT_SECRET ?? "",
+        refresh_token: (token.refresh_token as string) ?? "",
+        grant_type: "refresh_token",
+      }),
+    })
+
+    const data = await response.json()
+    if (!response.ok) {
+      throw data
+    }
+
+    return {
+      ...token,
+      ...data,
+      expires_at: data.expires_in
+        ? Math.floor(Date.now() / 1000) + data.expires_in
+        : token.expires_at,
+    }
+  } catch (error) {
+    console.error("Error refreshing token", error)
+    return { ...token, error: "RefreshAccessTokenError" as const }
+  }
+}
+
+export const {
+  handlers: simpleHandlers,
+  auth: simpleAuth,
+  signIn: simpleSignIn,
+  signOut: simpleSignOut,
+} = NextAuth({
+  session: {
+    strategy: "jwt",
+  },
+  providers: [
+    GithubProvider({
+      id: "github-app-simple",
+      name: "GitHub App (Simple)",
+      clientId: process.env.GITHUB_APP_CLIENT_ID,
+      clientSecret: process.env.GITHUB_APP_CLIENT_SECRET,
+      authorization: {
+        url: "https://github.com/login/oauth/authorize",
+        params: {
+          client_id: process.env.GITHUB_APP_CLIENT_ID,
+        },
+      },
+      userinfo: {
+        url: "https://api.github.com/user",
+        params: { installation_id: process.env.GITHUB_APP_INSTALLATION_ID },
+      },
+    }),
+  ],
+  callbacks: {
+    async jwt({ token, account }) {
+      if (account) {
+        const newToken: JWT = {
+          ...token,
+          ...account,
+        }
+        if (account.expires_in) {
+          newToken.expires_at =
+            Math.floor(Date.now() / 1000) + account.expires_in
+        }
+        return newToken
+      }
+
+      if (
+        token.expires_at &&
+        (token.expires_at as number) < Date.now() / 1000
+      ) {
+        if (token.refresh_token) {
+          return await refreshAccessToken(token)
+        }
+        const url = new URL(
+          "/",
+          process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"
+        )
+        return NextResponse.redirect(url)
+      }
+      return token
+    },
+    async session({ session, token }) {
+      session.token = token
+      return session
+    },
+  },
+})

--- a/auth-simple.ts
+++ b/auth-simple.ts
@@ -1,25 +1,28 @@
-import NextAuth from "next-auth"
-import GithubProvider from "next-auth/providers/github"
 import { NextResponse } from "next/server"
+import NextAuth from "next-auth"
 import { JWT } from "next-auth/jwt"
+import GithubProvider from "next-auth/providers/github"
 
 // A minimal NextAuth config without Redis/locking for experimentation
 
 async function refreshAccessToken(token: JWT): Promise<JWT> {
   try {
-    const response = await fetch("https://github.com/login/oauth/access_token", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-        Accept: "application/json",
-      },
-      body: new URLSearchParams({
-        client_id: process.env.GITHUB_APP_CLIENT_ID ?? "",
-        client_secret: process.env.GITHUB_APP_CLIENT_SECRET ?? "",
-        refresh_token: (token.refresh_token as string) ?? "",
-        grant_type: "refresh_token",
-      }),
-    })
+    const response = await fetch(
+      "https://github.com/login/oauth/access_token",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Accept: "application/json",
+        },
+        body: new URLSearchParams({
+          client_id: process.env.GITHUB_APP_CLIENT_ID ?? "",
+          client_secret: process.env.GITHUB_APP_CLIENT_SECRET ?? "",
+          refresh_token: (token.refresh_token as string) ?? "",
+          grant_type: "refresh_token",
+        }),
+      }
+    )
 
     const data = await response.json()
     if (!response.ok) {

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -50,6 +50,16 @@ GithubProvider({
 5. Update Redis cache
 6. Release lock
 
+### Simple Auth (Experimental)
+
+For local testing there is a minimal `NextAuth` configuration that skips
+Redis caching and locking. It lives in [`auth-simple.ts`](../../auth-simple.ts)
+with its own API route at `/api/auth-simple`.
+
+- Visit `/playground?simple=1` to use the simple auth session.
+- Useful for experimenting with the built-in token refresh logic without the
+  additional Redis complexity.
+
 ## Configuration
 
 ### Environment Variables


### PR DESCRIPTION
## Summary
- introduce `auth-simple.ts` providing minimal NextAuth setup without Redis locking
- expose API route `/api/auth-simple` and allow Playground to switch via `?simple=1`
- document experimental simple auth option in authentication guide

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689c6aa3e4b483339bab37e21764e95a