### PR TITLE
feat: track reasoning events

### DIFF
--- a/components/workflow-runs/events/ReasoningEvent.tsx
+++ b/components/workflow-runs/events/ReasoningEvent.tsx
@@ -20,7 +20,7 @@ export function ReasoningEvent({ event }: Props) {
         </div>
         <EventTime timestamp={event.createdAt} />
       </div>
-      <CopyMarkdownButton content={`${event.title}\n\n${event.content}`} />
+      <CopyMarkdownButton content={(event.summary || event.content) ?? ""} />
     </div>
   )
 
@@ -30,11 +30,8 @@ export function ReasoningEvent({ event }: Props) {
       className="hover:bg-muted/50 border-l-2 border-muted-foreground/40"
     >
       <div className="space-y-2">
-        <div className="text-sm font-semibold text-muted-foreground">
-          {event.title}
-        </div>
         <div className="prose prose-sm dark:prose-invert max-w-none text-muted-foreground">
-          <ReactMarkdown>{event.content}</ReactMarkdown>
+          <ReactMarkdown>{event.summary || event.content || ""}</ReactMarkdown>
         </div>
       </div>
     </CollapsibleContent>

--- a/lib/agents/base/index.ts
+++ b/lib/agents/base/index.ts
@@ -15,7 +15,7 @@ import { ZodType } from "zod"
 import {
   createErrorEvent,
   createLLMResponseEvent,
-  createStatusEvent,
+  createReasoningEvent,
   createSystemPromptEvent,
   createToolCallEvent,
   createToolCallResultEvent,
@@ -478,10 +478,10 @@ export class ResponsesAPIAgent extends Agent {
         return event.id
 
       case "reasoning":
-        // TODO: Track reasoning with its own event on database
-        for (const summary of message.summary) {
-          event = await createStatusEvent({
+        for (const summary of message.summary as Array<{ text: string; title?: string }>) {
+          await createReasoningEvent({
             workflowId: this.jobId,
+            title: summary.title ?? "Reasoning",
             content: summary.text,
           })
         }

--- a/lib/agents/base/index.ts
+++ b/lib/agents/base/index.ts
@@ -478,7 +478,10 @@ export class ResponsesAPIAgent extends Agent {
         return event.id
 
       case "reasoning":
-        for (const summary of message.summary as Array<{ text: string; title?: string }>) {
+        for (const summary of message.summary as Array<{
+          text: string
+          title?: string
+        }>) {
           await createReasoningEvent({
             workflowId: this.jobId,
             title: summary.title ?? "Reasoning",

--- a/lib/agents/base/index.ts
+++ b/lib/agents/base/index.ts
@@ -478,14 +478,10 @@ export class ResponsesAPIAgent extends Agent {
         return event.id
 
       case "reasoning":
-        for (const summary of message.summary as Array<{
-          text: string
-          title?: string
-        }>) {
+        for (const summary of message.summary) {
           await createReasoningEvent({
             workflowId: this.jobId,
-            title: summary.title ?? "Reasoning",
-            content: summary.text,
+            summary: summary.text,
           })
         }
         return undefined

--- a/lib/neo4j/repositories/event.ts
+++ b/lib/neo4j/repositories/event.ts
@@ -9,6 +9,8 @@ import {
   llmResponseSchema,
   MessageEvent,
   messageEventSchema,
+  ReasoningEvent,
+  reasoningEventSchema,
   StatusEvent,
   statusEventSchema,
   SystemPrompt,
@@ -112,6 +114,21 @@ export async function createToolCallResultEvent(
     { id, type, toolCallId, toolName, content }
   )
   return toolCallResultSchema.parse(result.records[0]?.get("e")?.properties)
+}
+
+export async function createReasoningEvent(
+  tx: ManagedTransaction,
+  event: Omit<ReasoningEvent, "createdAt" | "workflowId" | "type">
+): Promise<ReasoningEvent> {
+  const { id, title, content } = event
+  const result = await tx.run<{ e: Node<Integer, ReasoningEvent, "Event"> }>(
+    `
+      CREATE (e:Event:Message {id: $id, createdAt: datetime(), type: 'reasoning', title: $title, content: $content})
+      RETURN e
+      `,
+    { id, title, content }
+  )
+  return reasoningEventSchema.parse(result.records[0]?.get("e")?.properties)
 }
 
 export async function createStatusEvent(

--- a/lib/neo4j/repositories/event.ts
+++ b/lib/neo4j/repositories/event.ts
@@ -120,13 +120,13 @@ export async function createReasoningEvent(
   tx: ManagedTransaction,
   event: Omit<ReasoningEvent, "createdAt" | "workflowId" | "type">
 ): Promise<ReasoningEvent> {
-  const { id, title, content } = event
+  const { id, summary } = event
   const result = await tx.run<{ e: Node<Integer, ReasoningEvent, "Event"> }>(
     `
-      CREATE (e:Event:Message {id: $id, createdAt: datetime(), type: 'reasoning', title: $title, content: $content})
+      CREATE (e:Event:Message {id: $id, createdAt: datetime(), type: 'reasoning', summary: $summary})
       RETURN e
       `,
-    { id, title, content }
+    { id, summary }
   )
   return reasoningEventSchema.parse(result.records[0]?.get("e")?.properties)
 }

--- a/lib/neo4j/services/event.ts
+++ b/lib/neo4j/services/event.ts
@@ -255,14 +255,12 @@ export async function createToolCallResultEvent({
 export async function createReasoningEvent({
   id = uuidv4(),
   workflowId,
-  title,
-  content,
+  summary,
   parentId,
 }: {
   id?: string
   workflowId: string
-  title: string
-  content: string
+  summary: string
   parentId?: string
 }): Promise<ReasoningEvent> {
   const session = await n4j.getSession()
@@ -272,8 +270,7 @@ export async function createReasoningEvent({
         // Create the event node
         const eventNode = await dbCreateReasoningEvent(tx, {
           id,
-          title,
-          content,
+          summary,
         })
 
         // Attach it to the workflow

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -123,8 +123,10 @@ export const llmResponseWithPlanSchema = baseEventSchema.merge(
 
 export const reasoningEventSchema = baseEventSchema.extend({
   type: z.literal("reasoning"),
-  title: z.string(),
-  content: z.string(),
+  // New field for all new events
+  summary: z.string().optional(),
+  // Legacy support: allow old events that used `content`
+  content: z.string().optional(),
 })
 
 export const statusEventSchema = baseEventSchema.extend({

--- a/lib/types/workflow.ts
+++ b/lib/types/workflow.ts
@@ -71,6 +71,15 @@ export interface StatusData {
  * @deprecated
  * Use WorkflowEvent from /lib/neo4j/service.ts instead
  */
+export interface ReasoningData {
+  title: string
+  content: string
+}
+
+/**
+ * @deprecated
+ * Use WorkflowEvent from /lib/neo4j/service.ts instead
+ */
 export type WorkflowEventType =
   | "workflow_start"
   | "system_prompt"
@@ -80,6 +89,7 @@ export type WorkflowEventType =
   | "tool_response"
   | "error"
   | "status"
+  | "reasoning"
 
 /**
  * @deprecated
@@ -93,6 +103,7 @@ export type WorkflowEventData =
   | ToolResponseData
   | ErrorData
   | StatusData
+  | ReasoningData
 
 interface BaseEventFields {
   id: string
@@ -141,6 +152,11 @@ export interface StatusEvent extends BaseEventFields {
   data: StatusData
 }
 
+export interface ReasoningEvent extends BaseEventFields {
+  type: "reasoning"
+  data: ReasoningData
+}
+
 /**
  * @deprecated
  * Use WorkflowEvent from /lib/neo4j/service.ts instead
@@ -159,6 +175,7 @@ export type WorkflowEvent =
   | ToolResponseEvent
   | ErrorEvent
   | StatusEvent
+  | ReasoningEvent
 
 /**
  * @deprecated


### PR DESCRIPTION
## Summary
- add ReasoningEvent type to workflow typings
- persist reasoning summaries via dedicated Neo4j event and service
- record reasoning events instead of status events in agent base

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm lint:tsc`
- `pnpm lint:prettier` *(fails: code style issues found in 10 files)*

------
https://chatgpt.com/codex/tasks/task_e_689c6e3ed5548333a92e5860422da794