### PR TITLE
feat: track reasoning events

### DIFF
--- a/lib/agents/base/index.ts
+++ b/lib/agents/base/index.ts
@@ -15,7 +15,7 @@ import { ZodType } from "zod"
 import {
   createErrorEvent,
   createLLMResponseEvent,
-  createStatusEvent,
+  createReasoningEvent,
   createSystemPromptEvent,
   createToolCallEvent,
   createToolCallResultEvent,
@@ -478,10 +478,10 @@ export class ResponsesAPIAgent extends Agent {
         return event.id
 
       case "reasoning":
-        // TODO: Track reasoning with its own event on database
-        for (const summary of message.summary) {
-          event = await createStatusEvent({
+        for (const summary of message.summary as Array<{ text: string; title?: string }>) {
+          await createReasoningEvent({
             workflowId: this.jobId,
+            title: summary.title ?? "Reasoning",
             content: summary.text,
           })
         }

--- a/lib/neo4j/repositories/event.ts
+++ b/lib/neo4j/repositories/event.ts
@@ -9,6 +9,8 @@ import {
   llmResponseSchema,
   MessageEvent,
   messageEventSchema,
+  ReasoningEvent,
+  reasoningEventSchema,
   StatusEvent,
   statusEventSchema,
   SystemPrompt,
@@ -112,6 +114,21 @@ export async function createToolCallResultEvent(
     { id, type, toolCallId, toolName, content }
   )
   return toolCallResultSchema.parse(result.records[0]?.get("e")?.properties)
+}
+
+export async function createReasoningEvent(
+  tx: ManagedTransaction,
+  event: Omit<ReasoningEvent, "createdAt" | "workflowId" | "type">
+): Promise<ReasoningEvent> {
+  const { id, title, content } = event
+  const result = await tx.run<{ e: Node<Integer, ReasoningEvent, "Event"> }>(
+    `
+      CREATE (e:Event:Message {id: $id, createdAt: datetime(), type: 'reasoning', title: $title, content: $content})
+      RETURN e
+      `,
+    { id, title, content }
+  )
+  return reasoningEventSchema.parse(result.records[0]?.get("e")?.properties)
 }
 
 export async function createStatusEvent(

--- a/lib/types/workflow.ts
+++ b/lib/types/workflow.ts
@@ -71,6 +71,15 @@ export interface StatusData {
  * @deprecated
  * Use WorkflowEvent from /lib/neo4j/service.ts instead
  */
+export interface ReasoningData {
+  title: string
+  content: string
+}
+
+/**
+ * @deprecated
+ * Use WorkflowEvent from /lib/neo4j/service.ts instead
+ */
 export type WorkflowEventType =
   | "workflow_start"
   | "system_prompt"
@@ -80,6 +89,7 @@ export type WorkflowEventType =
   | "tool_response"
   | "error"
   | "status"
+  | "reasoning"
 
 /**
  * @deprecated
@@ -93,6 +103,7 @@ export type WorkflowEventData =
   | ToolResponseData
   | ErrorData
   | StatusData
+  | ReasoningData
 
 interface BaseEventFields {
   id: string
@@ -141,6 +152,11 @@ export interface StatusEvent extends BaseEventFields {
   data: StatusData
 }
 
+export interface ReasoningEvent extends BaseEventFields {
+  type: "reasoning"
+  data: ReasoningData
+}
+
 /**
  * @deprecated
  * Use WorkflowEvent from /lib/neo4j/service.ts instead
@@ -159,6 +175,7 @@ export type WorkflowEvent =
   | ToolResponseEvent
   | ErrorEvent
   | StatusEvent
+  | ReasoningEvent
 
 /**
  * @deprecated


### PR DESCRIPTION
## Summary
- add ReasoningEvent type to workflow typings
- persist reasoning summaries via dedicated Neo4j event and service
- record reasoning events instead of status events in agent base

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm lint:tsc`
- `pnpm lint:prettier` *(fails: code style issues found in 10 files)*

------
https://chatgpt.com/codex/tasks/task_e_689c6e3ed5548333a92e5860422da794