### PR TITLE
feat: add service for issue title generation

### DIFF
--- a/app/api/playground/issue-title-anthropic/route.ts
+++ b/app/api/playground/issue-title-anthropic/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server"
 
-import { IssueTitleRequestSchema, IssueTitleResponseSchema } from "@/lib/types/api/schemas"
+import {
+  IssueTitleRequestSchema,
+  IssueTitleResponseSchema,
+} from "@/lib/types/api/schemas"
 import { AnthropicAdapter } from "@/shared/src/adapters/anthropic"
 import { generateIssueTitle } from "@/shared/src/services/issue-title"
 
@@ -11,7 +14,7 @@ export async function POST(req: NextRequest) {
     if (!validation.success) {
       return NextResponse.json(
         { error: "Invalid request body", details: validation.error.errors },
-        { status: 400 },
+        { status: 400 }
       )
     }
 
@@ -29,7 +32,7 @@ export async function POST(req: NextRequest) {
     if (!responseValidation.success) {
       return NextResponse.json(
         { error: "Invalid response format" },
-        { status: 500 },
+        { status: 500 }
       )
     }
 
@@ -44,7 +47,7 @@ export async function POST(req: NextRequest) {
               ? err.message
               : "Unknown error",
       },
-      { status: 500 },
+      { status: 500 }
     )
   }
 }

--- a/app/api/playground/issue-title-anthropic/route.ts
+++ b/app/api/playground/issue-title-anthropic/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { IssueTitleRequestSchema, IssueTitleResponseSchema } from "@/lib/types/api/schemas"
+import { AnthropicAdapter } from "@/shared/src/adapters/anthropic"
+import { generateIssueTitle } from "@/shared/src/services/issue-title"
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json()
+    const validation = IssueTitleRequestSchema.safeParse(body)
+    if (!validation.success) {
+      return NextResponse.json(
+        { error: "Invalid request body", details: validation.error.errors },
+        { status: 400 },
+      )
+    }
+
+    const { description } = validation.data
+    const llm = new AnthropicAdapter()
+    const title = await generateIssueTitle(llm, description, {
+      model: "claude-3-haiku-20240307",
+      maxTokens: 64,
+    })
+
+    const responseValidation = IssueTitleResponseSchema.safeParse({
+      title: title.trim(),
+    })
+
+    if (!responseValidation.success) {
+      return NextResponse.json(
+        { error: "Invalid response format" },
+        { status: 500 },
+      )
+    }
+
+    return NextResponse.json(responseValidation.data)
+  } catch (err) {
+    return NextResponse.json(
+      {
+        error:
+          typeof err === "string"
+            ? err
+            : err instanceof Error
+              ? err.message
+              : "Unknown error",
+      },
+      { status: 500 },
+    )
+  }
+}

--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -21,6 +21,7 @@ import { auth } from "@/auth"
 import OAuthTokenCard from "@/components/auth/OAuthTokenCard"
 import RepoSelector from "@/components/common/RepoSelector"
 import AgentWorkflowClient from "@/components/playground/AgentWorkflowClient"
+import AnthropicIssueTitleCard from "@/components/playground/AnthropicIssueTitleCard"
 import ApplyPatchCard from "@/components/playground/ApplyPatchCard"
 import DockerodeExecCard from "@/components/playground/DockerodeExecCard"
 import IssueSummaryCard from "@/components/playground/IssueSummaryCard"
@@ -81,6 +82,7 @@ export default async function PlaygroundPage() {
         </CardContent>
       </Card>
       <IssueTitleCard />
+      <AnthropicIssueTitleCard />
       <IssueSummaryCard />
       <SpeechToTextCard />
       <UserRolesCard />

--- a/components/playground/AnthropicIssueTitleCard.tsx
+++ b/components/playground/AnthropicIssueTitleCard.tsx
@@ -1,0 +1,69 @@
+"use client"
+
+import { useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+
+export default function AnthropicIssueTitleCard() {
+  const [description, setDescription] = useState("")
+  const [title, setTitle] = useState<string | null>(null)
+  const [isRunning, setIsRunning] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleGenerate = async () => {
+    if (!description.trim()) return
+    setIsRunning(true)
+    setError(null)
+    setTitle(null)
+    try {
+      const res = await fetch("/api/playground/issue-title-anthropic", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ description }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || "Unknown error")
+      setTitle(data.title as string)
+    } catch (err) {
+      setError(String(err))
+    } finally {
+      setIsRunning(false)
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Issue Description ➜ Title (Anthropic)</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label>Description</Label>
+          <Textarea
+            rows={6}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Paste GitHub issue description here..."
+          />
+        </div>
+        <Button
+          onClick={handleGenerate}
+          disabled={isRunning || !description.trim()}
+        >
+          {isRunning ? "Generating..." : "Generate Title"}
+        </Button>
+        {error && <p className="text-destructive text-sm">{error}</p>}
+        {title && (
+          <div className="space-y-2">
+            <Label>Suggested Title</Label>
+            <Input readOnly value={title} onFocus={(e) => e.target.select()} />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/shared/src/services/issue-title.ts
+++ b/shared/src/services/issue-title.ts
@@ -1,0 +1,31 @@
+import type { LLMPort } from "@/shared/src/core/ports/llm"
+
+const SYSTEM_PROMPT = `You are an expert technical writer tasked with crafting clear, concise GitHub issue titles.
+
+You will be given ONLY the body/description of an issue. Your job is to derive a short, descriptive title that summarises the core problem or request so that maintainers can understand it at a glance.
+
+Guidelines:
+- Keep the title under 10 words when possible.
+- Focus on the *what* and, if important, the *where* (e.g. “Fix crash in user login flow”).
+- Do NOT include backticks, quotes or trailing punctuation.
+- Use imperative, present-tense phrasing (e.g. “Add”, “Fix”, “Support”).
+- Never start with words like “Issue:” or “Bug:”. The returned text will be inserted directly as the issue title.
+
+Return ONLY the title text with no additional commentary.`
+
+export async function generateIssueTitle(
+  llm: LLMPort,
+  description: string,
+  options: { model?: string; maxTokens?: number } = {},
+): Promise<string> {
+  const { model, maxTokens } = options
+  const response = await llm.createCompletion({
+    system: SYSTEM_PROMPT,
+    messages: [{ role: "user", content: description }],
+    model,
+    maxTokens,
+  })
+  return response.trim()
+}
+
+export default generateIssueTitle

--- a/shared/src/services/issue-title.ts
+++ b/shared/src/services/issue-title.ts
@@ -13,6 +13,10 @@ Guidelines:
 
 Return ONLY the title text with no additional commentary.`
 
+// TODO: `model` and `maxTokens` belongs to the `Agent` core entity (not defined yet).
+// I don't know how clean architecture works, but there's a relationship between `Agent` and `LLMPort` (or `AgentPort`)
+// So somewhere between those 2, the `model` and `maxTokens` should be defined, not in this service-level function.
+
 export async function generateIssueTitle(
   llm: LLMPort,
   description: string,

--- a/shared/src/services/issue-title.ts
+++ b/shared/src/services/issue-title.ts
@@ -16,7 +16,7 @@ Return ONLY the title text with no additional commentary.`
 export async function generateIssueTitle(
   llm: LLMPort,
   description: string,
-  options: { model?: string; maxTokens?: number } = {},
+  options: { model?: string; maxTokens?: number } = {}
 ): Promise<string> {
   const { model, maxTokens } = options
   const response = await llm.createCompletion({


### PR DESCRIPTION
## Summary
- add shared service for generating issue titles with injected LLM
- expose Anthropics-backed API route and playground card for issue titles
- render Anthropics card on playground page

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm lint:tsc`


------
https://chatgpt.com/codex/tasks/task_e_689c6fc8597c833387e461c96f821fa6