### PR TITLE
Organize Playground cards into desktop grid layout

### DIFF
--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -69,26 +69,36 @@ export default async function PlaygroundPage() {
         <TestGithubUserFunctionsCard />
       </div>
       <AgentWorkflowClient defaultTools={DEFAULT_TOOLS} />
-      <Card>
-        <CardHeader>
-          <CardTitle>Test Repo Selector Component</CardTitle>
-        </CardHeader>
-        <CardContent>
-          Use this component to test the RepoSelector component. It should show
-          a button to install the Github App if no repos are available.
-          Uninstall the Github App to test the installation CTA.
-          <RepoSelector selectedRepo="issue-to-pr/test-repo" />
-        </CardContent>
-      </Card>
-      <IssueTitleCard />
-      <IssueSummaryCard />
-      <SpeechToTextCard />
-      <UserRolesCard />
-      <RipgrepSearchCard />
-      <DockerodeExecCard />
-      <WriteFileCard />
-      <ApplyPatchCard />
-      {token ? <OAuthTokenCard token={token} /> : null}
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">Repository & Issue Tools</h2>
+        <div className="grid gap-4 md:grid-cols-2">
+          <Card>
+            <CardHeader>
+              <CardTitle>Test Repo Selector Component</CardTitle>
+            </CardHeader>
+            <CardContent>
+              Use this component to test the RepoSelector component. It should
+              show a button to install the Github App if no repos are
+              available. Uninstall the Github App to test the installation CTA.
+              <RepoSelector selectedRepo="issue-to-pr/test-repo" />
+            </CardContent>
+          </Card>
+          <IssueTitleCard />
+          <IssueSummaryCard />
+          <RipgrepSearchCard />
+          <WriteFileCard />
+          <ApplyPatchCard />
+          <DockerodeExecCard />
+        </div>
+      </section>
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">User & Misc Tools</h2>
+        <div className="grid gap-4 md:grid-cols-2">
+          <SpeechToTextCard />
+          <UserRolesCard />
+          {token ? <OAuthTokenCard token={token} /> : null}
+        </div>
+      </section>
       <div>
         <Link href="/playground/evals">
           <Button variant="outline" size="sm">


### PR DESCRIPTION
## Summary
- group playground cards into Repository & Issue and User & Misc sections
- arrange cards in a responsive grid with two columns on desktop for easier navigation

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689c71fa9c088333b30f66d6306ea4b1