### PR TITLE
Unlock OpenAI API key input when empty and mute Save until input

### DIFF
--- a/components/settings/APIKeyInput.tsx
+++ b/components/settings/APIKeyInput.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Loader2 } from "lucide-react"
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -19,16 +19,17 @@ const ApiKeyInput = ({ initialKey = "" }: Props) => {
   const [maskedKey, setMaskedKey] = useState(
     initialKey ? maskApiKey(initialKey) : ""
   )
-  const [isEditing, setIsEditing] = useState(false)
+  // If there's no initial key, start in editing mode so the user can type immediately
+  const [isEditing, setIsEditing] = useState(!initialKey)
   const [isVerifying, setIsVerifying] = useState(false)
 
   const { toast } = useToast()
 
   useEffect(() => {
-    if (initialKey) {
-      setApiKey(initialKey)
-      setMaskedKey(maskApiKey(initialKey))
-    }
+    // Keep local state in sync with prop changes
+    setApiKey(initialKey)
+    setMaskedKey(initialKey ? maskApiKey(initialKey) : "")
+    setIsEditing(!initialKey)
   }, [initialKey])
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -75,6 +76,11 @@ const ApiKeyInput = ({ initialKey = "" }: Props) => {
     }
   }
 
+  const isSaveDisabled = useMemo(() => {
+    // Disable save when verifying or when there's no input yet
+    return isVerifying || apiKey.trim().length === 0
+  }, [apiKey, isVerifying])
+
   return (
     <div className="flex items-end justify-end gap-2">
       <div>
@@ -95,7 +101,7 @@ const ApiKeyInput = ({ initialKey = "" }: Props) => {
         />
       </div>
       {isEditing ? (
-        <Button onClick={handleSave} disabled={isVerifying}>
+        <Button onClick={handleSave} disabled={isSaveDisabled}>
           {isVerifying ? <Loader2 className="w-4 h-4 animate-spin" /> : "Save"}
         </Button>
       ) : (
@@ -108,3 +114,4 @@ const ApiKeyInput = ({ initialKey = "" }: Props) => {
 }
 
 export default ApiKeyInput
+


### PR DESCRIPTION
Summary
- On the Settings page, if there is no existing OpenAI API key, the input field is now immediately editable. Users no longer need to click “Edit” first.
- While editing, the Save button is shown. It is muted/disabled until the user enters text, and remains disabled while the key is being verified.

Changes
- components/settings/APIKeyInput.tsx
  - Initialize editing mode to true when no initialKey is provided.
  - Keep local state in sync if initialKey changes at runtime.
  - Disable the Save button when there is no input or while verification is in progress.

Why
- Improves UX per the issue request: users shouldn’t need to click “Edit” when there isn’t a saved key, and the Save action should be visually muted until a key is entered.

Testing
- Manually verified in the Settings page:
  - With no key: field is editable on load, Save button is disabled until typing begins.
  - With an existing key: field is read-only showing a masked value; clicking Edit enables input and shows Save; Save is disabled only if the input is empty or verifying.

No server/API changes required.

Closes #1008