### PR TITLE
Show “View PR” button after successful PR creation in workflow details

### DIFF
--- a/components/workflow-runs/events/ToolCallResultEvent.tsx
+++ b/components/workflow-runs/events/ToolCallResultEvent.tsx
@@ -1,7 +1,8 @@
 "use client"
 
-import { ArrowDownLeft } from "lucide-react"
+import { ArrowDownLeft, ExternalLink } from "lucide-react"
 
+import { Button } from "@/components/ui/button"
 import { CollapsibleContent } from "@/components/ui/collapsible-content"
 import { EventTime } from "@/components/workflow-runs/events/EventTime"
 import { ToolCallResult } from "@/lib/types"
@@ -10,7 +11,22 @@ export interface Props {
   event: ToolCallResult
 }
 
+function getCreatedPrUrl(event: ToolCallResult): string | null {
+  if (event.toolName !== "create_pull_request") return null
+  try {
+    const parsed = JSON.parse(event.content)
+    if (parsed?.status !== "success") return null
+    // GraphQL createPullRequest returns { data: { url } }
+    const url = parsed?.pullRequest?.data?.url || parsed?.pullRequest?.html_url
+    return typeof url === "string" ? url : null
+  } catch {
+    return null
+  }
+}
+
 export function ToolCallResultEvent({ event }: Props) {
+  const prUrl = getCreatedPrUrl(event)
+
   const headerContent = (
     <div className="flex items-center justify-between w-full">
       <div className="flex items-center gap-2">
@@ -30,9 +46,22 @@ export function ToolCallResultEvent({ event }: Props) {
       headerContent={headerContent}
       className="border-l-2 border-green-500 dark:border-green-400 hover:bg-muted/50"
     >
-      <div className="font-mono text-sm overflow-x-auto">
-        <div className="whitespace-pre-wrap">{event.content}</div>
+      <div className="space-y-3">
+        {prUrl && (
+          <div>
+            <Button asChild>
+              <a href={prUrl} target="_blank" rel="noopener noreferrer">
+                View PR
+                <ExternalLink className="h-4 w-4" />
+              </a>
+            </Button>
+          </div>
+        )}
+        <div className="font-mono text-sm overflow-x-auto">
+          <div className="whitespace-pre-wrap">{event.content}</div>
+        </div>
       </div>
     </CollapsibleContent>
   )
 }
+


### PR DESCRIPTION
Summary
- Adds a clearly highlighted “View PR” button to the workflow details page when a PR is successfully created by the create_pull_request tool.
- The button links directly to the created PR and opens in a new tab.

Details
- Updated components/workflow-runs/events/ToolCallResultEvent.tsx to:
  - Detect tool responses from create_pull_request.
  - Safely parse the tool response JSON.
  - On success, extract the PR URL from pullRequest.data.url (GraphQL) or pullRequest.html_url as a fallback.
  - Render a primary Button labeled “View PR” that links to the PR, above the raw tool response content.

Why
- Improves UX by reducing friction; users can navigate to the created PR with a single click from the workflow details page.

Notes
- Non-successful responses continue to render the original tool response content without the button.
- No API or backend changes were required.

Screens/UX
- The button uses the default (primary) shadcn UI Button styling to ensure it stands out as the main action.


Closes #1014