### PR TITLE
Prompt new users to provide OpenAI API key after sign-in

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import nextDynamic from "next/dynamic"
 import { auth } from "@/auth"
 import IssueDashboard from "@/components/home/IssueDashboard"
 import AgentArchitecture from "@/components/landing-page/AgentArchitecture"
@@ -9,13 +10,53 @@ import Hero from "@/components/landing-page/Hero"
 import PlanningFeature from "@/components/landing-page/PlanningFeature"
 import Pricing from "@/components/landing-page/Pricing"
 import Steps from "@/components/landing-page/Steps"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import GridBackground from "@/components/ui/grid-background"
+import { getUserOpenAIApiKey } from "@/lib/neo4j/services/user"
+
+const ApiKeyInput = nextDynamic(
+  () => import("@/components/settings/APIKeyInput"),
+  { ssr: false }
+)
 
 export default async function LandingPage() {
   const session = await auth()
 
   if (session?.user) {
-    return <IssueDashboard />
+    const existingKey = await getUserOpenAIApiKey()
+
+    return (
+      <div className="min-h-screen bg-background text-foreground">
+        <main className="container mx-auto px-4 sm:px-6 lg:px-8 py-4 space-y-4">
+          {!existingKey && (
+            <Card className="max-w-2xl">
+              <CardHeader>
+                <CardTitle>Set your OpenAI API Key</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-2">
+                  <p className="text-sm text-muted-foreground mb-1">
+                    You need an OpenAI API key to generate plans and code. Create a key {""}
+                    <a
+                      href="https://platform.openai.com/api-keys"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline hover:text-blue-600"
+                    >
+                      here
+                    </a>
+                    , then paste it below.
+                  </p>
+                  <ApiKeyInput initialKey="" />
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          <IssueDashboard />
+        </main>
+      </div>
+    )
   }
 
   return (
@@ -36,3 +77,4 @@ export default async function LandingPage() {
     </div>
   )
 }
+


### PR DESCRIPTION
Summary
- Adds a lightweight prompt on the authenticated home page to ask users for their OpenAI API key if none is saved yet.
- The prompt appears above the main IssueDashboard and uses the existing APIKeyInput component (dynamically imported) for consistent UX and validation.

Details
- Updated app/page.tsx to:
  - Detect authenticated users.
  - Fetch the user’s saved OpenAI API key via getUserOpenAIApiKey().
  - If missing, render a Card with brief guidance and an APIKeyInput box.
  - Always render the IssueDashboard below so normal usage continues once the key is set.

Why this approach
- Keeps the change localized and non-invasive: no global banners or intrusive modals.
- Leverages the already existing APIKeyInput component and OpenAI key verification API.
- Matches the request to "include the openai api key input box above the main page after they sign in if there's no value".

Notes
- Styling and copy mirror the Settings page for familiarity.
- No breaking changes to existing routes or components.

Future enhancements (optional)
- Consider showing the same prompt on other authenticated pages until the key is provided.
- Add dismissible info banner linking to Settings if users prefer to set the key later.

Closes #998