### PR TITLE
Add retry option and playback for failed audio transcription

### DIFF
--- a/components/common/VoiceDictationButton.tsx
+++ b/components/common/VoiceDictationButton.tsx
@@ -57,7 +57,6 @@ export default function VoiceDictationButton({
           >
             <RotateCcw className="h-4 w-4" /> Retry transcribe
           </Button>
-          {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
           <audio controls src={audioUrl} className="h-9" />
         </>
       ) : null}

--- a/components/common/VoiceDictationButton.tsx
+++ b/components/common/VoiceDictationButton.tsx
@@ -64,4 +64,3 @@ export default function VoiceDictationButton({
     </div>
   )
 }
-

--- a/components/common/VoiceDictationButton.tsx
+++ b/components/common/VoiceDictationButton.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Loader2, Mic } from "lucide-react"
+import { Loader2, Mic, RotateCcw } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { useVoiceDictation } from "@/lib/hooks/useVoiceDictation"
@@ -16,27 +16,52 @@ export default function VoiceDictationButton({
   disabled,
   className,
 }: Props) {
-  const { isRecording, isTranscribing, startRecording, stopRecording } =
-    useVoiceDictation({ onTranscribed })
+  const {
+    isRecording,
+    isTranscribing,
+    startRecording,
+    stopRecording,
+    retryTranscription,
+    lastError,
+    audioUrl,
+  } = useVoiceDictation({ onTranscribed })
 
   return (
-    <Button
-      type="button"
-      variant="secondary"
-      onClick={isRecording ? stopRecording : startRecording}
-      disabled={disabled || isTranscribing}
-      className={`${isRecording ? "animate-pulse" : ""} ${className || ""}`}
-      size={isRecording ? undefined : "icon"}
-    >
-      {isTranscribing ? (
-        <Loader2 className="h-4 w-4 animate-spin" />
-      ) : isRecording ? (
+    <div className={`flex items-center gap-2 ${className || ""}`}>
+      <Button
+        type="button"
+        variant="secondary"
+        onClick={isRecording ? stopRecording : startRecording}
+        disabled={disabled || isTranscribing}
+        className={`${isRecording ? "animate-pulse" : ""}`}
+        size={isRecording ? undefined : "icon"}
+      >
+        {isTranscribing ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : isRecording ? (
+          <>
+            <Mic className="mr-2 h-4 w-4" /> Listening...
+          </>
+        ) : (
+          <Mic className="h-4 w-4" />
+        )}
+      </Button>
+
+      {!isRecording && !isTranscribing && lastError && audioUrl ? (
         <>
-          <Mic className="mr-2 h-4 w-4" /> Listening...
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={retryTranscription}
+          >
+            <RotateCcw className="h-4 w-4" /> Retry transcribe
+          </Button>
+          {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+          <audio controls src={audioUrl} className="h-9" />
         </>
-      ) : (
-        <Mic className="h-4 w-4" />
-      )}
-    </Button>
+      ) : null}
+    </div>
   )
 }
+

--- a/lib/hooks/useVoiceDictation.ts
+++ b/lib/hooks/useVoiceDictation.ts
@@ -334,7 +334,8 @@ export function useVoiceDictation(options?: UseVoiceDictationOptions) {
       return
     }
 
-    const actualMimeType = recordedMimeType || lastRecordedBlobRef.current.type || "audio/webm"
+    const actualMimeType =
+      recordedMimeType || lastRecordedBlobRef.current.type || "audio/webm"
 
     const fileExtension = actualMimeType.includes("mp4")
       ? "mp4"
@@ -346,9 +347,13 @@ export function useVoiceDictation(options?: UseVoiceDictationOptions) {
 
     let audioFile: File
     try {
-      audioFile = new File([lastRecordedBlobRef.current], `recording.${fileExtension}`, {
-        type: actualMimeType,
-      })
+      audioFile = new File(
+        [lastRecordedBlobRef.current],
+        `recording.${fileExtension}`,
+        {
+          type: actualMimeType,
+        }
+      )
       pushDebug(
         `[Retry] Created File name=recording.${fileExtension} type=${actualMimeType} size=${audioFile.size}`
       )
@@ -390,4 +395,3 @@ export function useVoiceDictation(options?: UseVoiceDictationOptions) {
     retryTranscription,
   }
 }
-


### PR DESCRIPTION
Summary
- Adds the ability to retry a failed speech-to-text transcription without re-recording.
- Shows a small audio player to review the last recording when transcription fails.

What changed
1) useVoiceDictation
- Stores the last recorded audio Blob in a ref (lastRecordedBlobRef) so we can reuse it.
- Extracts a sendForTranscription(audioFile) helper used by both the initial transcribe and the retry flow.
- Adds retryTranscription() to re-create a File from the saved Blob and call the transcribe endpoint again.
- Keeps existing debug and error logging; clears errors when retry succeeds.

2) VoiceDictationButton
- Wraps the mic button in a small flex container and conditionally renders:
  - A "Retry transcribe" button when the previous transcription failed and a recording exists.
  - A compact audio element to play the recorded audio, visible only in the failure state.
- No behavior change when transcription succeeds or while recording/transcribing.

Why
Users reported occasional failures in recording/transcription on new task input. This adds a clear way to retry the transcription and review the recorded audio without having to re-record.

Scope
- Focused UI/UX improvement. Only two files changed. No API changes.
- New UI only appears after a failed transcription; otherwise the button behaves as before.

Testing
- Ran TypeScript and ESLint checks: pnpm run lint:tsc and pnpm run lint:eslint.
- Manually validated state paths in the hook (start, stop, failure, retry).

Notes
- If you prefer to keep VoiceDictationButton as a single icon-only element, we can alternatively ship a separate component for the retry UI and keep the original untouched. The current approach keeps changes minimal and scoped to the error case.

Closes #1013