### PR TITLE
Apply accent color to all h1 headers across the app

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -126,6 +126,14 @@ body {
   body {
     @apply bg-background text-foreground;
   }
+  /* Apply accent color to all h1 headers by default */
+  h1 {
+    @apply text-accent;
+  }
+  /* Ensure h1 inside typography (prose) also use accent */
+  .prose :where(h1) {
+    @apply text-accent;
+  }
 }
 
 .moving-border-card {
@@ -163,3 +171,4 @@ body {
     background-position: 0% 50%;
   }
 }
+


### PR DESCRIPTION
Summary
- Applied the design accent color to all h1 headers globally to match the requested “horizon-accent” styling across the deck.

What changed
- Updated app/globals.css
  - Added a base-layer rule to set h1 { @apply text-accent } so all h1 elements default to the accent color.
  - Ensured compatibility with Tailwind Typography by explicitly applying the same style within .prose h1 so blog/article pages also reflect the accent.

Notes
- This is a non-breaking, style-only change. Any h1 with an explicit text color (e.g., text-red-600) will continue to use its explicit color due to specificity rules, so contextual styling like errors remain intact.

Why this approach
- Centralized styling avoids touching individual components/pages and ensures consistent h1 appearance everywhere, including current and future pages.

Testing
- Verified via code search that all h1 occurrences will inherit the global style.
- The accent color is already defined via CSS variables and Tailwind config, so no configuration or dependency changes are required.

Closes #1029