### PR TITLE
Show “View PR” button after successful PR creation in workflow details

### DIFF
--- a/.cursor/rules/container-use.mdc
+++ b/.cursor/rules/container-use.mdc
@@ -1,7 +1,5 @@
 ---
-description: "Container-use rules for safe containerized development"
-globs: 
-alwaysApply: true
+alwaysApply: false
 ---
 
 ALWAYS use ONLY Environments for ANY and ALL file, code, or shell operations—NO EXCEPTIONS—even for simple or generic requests.

--- a/app/playground/components/page.tsx
+++ b/app/playground/components/page.tsx
@@ -1,0 +1,119 @@
+import Link from "next/link"
+import { redirect } from "next/navigation"
+
+import { auth } from "@/auth"
+import CreatedPullRequestCard from "@/components/pull-requests/CreatedPullRequestCard"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { ToolCallResultEvent } from "@/components/workflow-runs/events/ToolCallResultEvent"
+import { getGithubUser } from "@/lib/github/users"
+import { getUserRoles } from "@/lib/neo4j/services/user"
+import { type ToolCallResult } from "@/lib/types"
+
+export default async function ComponentsLibraryPage() {
+  const session = await auth()
+  if (!session?.user) {
+    redirect("/")
+  }
+
+  const githubUser = await getGithubUser()
+  const roles = githubUser
+    ? await getUserRoles(githubUser.login).catch(() => [])
+    : []
+  const isAdmin = roles.includes("admin")
+  if (!isAdmin) {
+    redirect("/")
+  }
+
+  // Mock success event for create_pull_request
+  const prSuccessEvent: ToolCallResult = {
+    id: "mock-success",
+    createdAt: new Date(),
+    workflowId: "mock-workflow",
+    type: "toolCallResult",
+    toolCallId: "mock-tool-call-id",
+    toolName: "create_pull_request",
+    content: JSON.stringify({
+      status: "success",
+      pullRequest: {
+        data: {
+          number: 42,
+          title: "Add error UI for PR creation",
+          body: "This PR adds clear error handling to the tool result UI.",
+          url: "https://github.com/issue-to-pr/test-repo/pull/42",
+        },
+      },
+      message: "PR created; label added.",
+    }),
+  }
+
+  // Mock error event for create_pull_request
+  const prErrorEvent: ToolCallResult = {
+    id: "mock-error",
+    createdAt: new Date(),
+    workflowId: "mock-workflow",
+    type: "toolCallResult",
+    toolCallId: "mock-tool-call-id-2",
+    toolName: "create_pull_request",
+    content: JSON.stringify({
+      status: "error",
+      message:
+        "Failed to create pull request: A pull request already exists for branch 'feature/error-ui'",
+    }),
+  }
+
+  return (
+    <div className="space-y-8 px-4 py-8 md:container md:mx-auto">
+      <div>
+        <h1 className="text-2xl font-bold">Components Library</h1>
+        <p className="text-muted-foreground">
+          Preview commonly used UI components with mock data.
+        </p>
+        <div className="mt-3">
+          <Link href="/playground">
+            <Button variant="secondary" size="sm">
+              Back to Playground
+            </Button>
+          </Link>
+        </div>
+      </div>
+
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">Pull Request</h2>
+        <div className="grid gap-4 md:grid-cols-2">
+          <Card>
+            <CardHeader>
+              <CardTitle>CreatedPullRequestCard</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <CreatedPullRequestCard
+                number={123}
+                title="Implement components library playground"
+                body="Adds a new /playground/components page to preview UI components with mock data."
+                url="https://github.com/issue-to-pr/test-repo/pull/123"
+              />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>ToolCallResultEvent (Success)</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ToolCallResultEvent event={prSuccessEvent} />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>ToolCallResultEvent (Error)</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ToolCallResultEvent event={prErrorEvent} />
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -1,43 +1,13 @@
-"use server"
-const DEFAULT_TOOLS = [
-  "apply_patch",
-  "manage_branch",
-  "commit_changes",
-  "container_exec",
-  "create_pull_request",
-  "file_check",
-  "get_file_content",
-  "get_issue",
-  "create_issue_comment",
-  "ripgrep_search",
-  "sync_branch_to_remote",
-  "write_file",
-]
-
 import Link from "next/link"
 import { redirect } from "next/navigation"
 
 import { auth } from "@/auth"
-import OAuthTokenCard from "@/components/auth/OAuthTokenCard"
-import RepoSelector from "@/components/common/RepoSelector"
-import AgentWorkflowClient from "@/components/playground/AgentWorkflowClient"
-import AnthropicIssueTitleCard from "@/components/playground/AnthropicIssueTitleCard"
-import ApplyPatchCard from "@/components/playground/ApplyPatchCard"
-import DockerodeExecCard from "@/components/playground/DockerodeExecCard"
-import IssueSummaryCard from "@/components/playground/IssueSummaryCard"
-import IssueTitleCard from "@/components/playground/IssueTitleCard"
-import NewLocalTaskInput from "@/components/playground/NewLocalTaskInput"
-import RipgrepSearchCard from "@/components/playground/RipgrepSearchCard"
-import SpeechToTextCard from "@/components/playground/SpeechToTextCard"
-import TestGithubUserFunctionsCard from "@/components/playground/TestGithubUserFunctionsCard"
-import UserRolesCard from "@/components/playground/UserRolesCard"
-import WriteFileCard from "@/components/playground/WriteFileCard"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { getGithubUser } from "@/lib/github/users"
 import { getUserRoles } from "@/lib/neo4j/services/user"
 
-export default async function PlaygroundPage() {
+export default async function PlaygroundHubPage() {
   const session = await auth()
   if (!session?.user) {
     redirect("/")
@@ -52,61 +22,57 @@ export default async function PlaygroundPage() {
     redirect("/")
   }
 
-  const token = session?.token?.access_token as string | undefined
-
   return (
     <div className="space-y-8 px-4 py-8 md:container md:mx-auto">
       <div>
-        <h2 className="text-lg font-semibold mb-2">
-          Create Local Task (Neo4j)
-        </h2>
-        <NewLocalTaskInput
-          repoFullName={{
-            owner: "issue-to-pr",
-            repo: "test-repo",
-            fullName: "issue-to-pr/test-repo",
-          }}
-        />
-        <TestGithubUserFunctionsCard />
+        <h1 className="text-2xl font-bold">Playground</h1>
+        <p className="text-muted-foreground">
+          Explore tools, UI components, and evaluation sandboxes.
+        </p>
       </div>
-      <AgentWorkflowClient defaultTools={DEFAULT_TOOLS} />
-      <section className="space-y-4">
-        <h2 className="text-lg font-semibold">Repository & Issue Tools</h2>
-        <div className="grid gap-4 md:grid-cols-2">
-          <Card>
-            <CardHeader>
-              <CardTitle>Test Repo Selector Component</CardTitle>
-            </CardHeader>
-            <CardContent>
-              Use this component to test the RepoSelector component. It should
-              show a button to install the Github App if no repos are available.
-              Uninstall the Github App to test the installation CTA.
-              <RepoSelector selectedRepo="issue-to-pr/test-repo" />
-            </CardContent>
-          </Card>
-          <IssueTitleCard />
-          <AnthropicIssueTitleCard />
-          <IssueSummaryCard />
-          <RipgrepSearchCard />
-          <WriteFileCard />
-          <ApplyPatchCard />
-          <DockerodeExecCard />
-        </div>
-      </section>
-      <section className="space-y-4">
-        <h2 className="text-lg font-semibold">User & Misc Tools</h2>
-        <div className="grid gap-4 md:grid-cols-2">
-          <SpeechToTextCard />
-          <UserRolesCard />
-          {token ? <OAuthTokenCard token={token} /> : null}
-        </div>
-      </section>
-      <div>
-        <Link href="/playground/evals">
-          <Button variant="outline" size="sm">
-            LLM Evaluations
-          </Button>
-        </Link>
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        <Card>
+          <CardHeader>
+            <CardTitle>Tools</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-2">
+            <p className="text-sm text-muted-foreground">
+              Try agent tools, repo utilities, and workflow actions.
+            </p>
+            <Link href="/playground/tools">
+              <Button size="sm">Open Tools</Button>
+            </Link>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Components</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-2">
+            <p className="text-sm text-muted-foreground">
+              Preview reusable UI components with mock data.
+            </p>
+            <Link href="/playground/components">
+              <Button size="sm">Open Components</Button>
+            </Link>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Evals</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-2">
+            <p className="text-sm text-muted-foreground">
+              Run LLM-as-judge style evaluations.
+            </p>
+            <Link href="/playground/evals">
+              <Button size="sm">Open Evals</Button>
+            </Link>
+          </CardContent>
+        </Card>
       </div>
     </div>
   )

--- a/app/playground/tools/page.tsx
+++ b/app/playground/tools/page.tsx
@@ -1,0 +1,112 @@
+"use server"
+const DEFAULT_TOOLS = [
+  "apply_patch",
+  "manage_branch",
+  "commit_changes",
+  "container_exec",
+  "create_pull_request",
+  "file_check",
+  "get_file_content",
+  "get_issue",
+  "create_issue_comment",
+  "ripgrep_search",
+  "sync_branch_to_remote",
+  "write_file",
+]
+
+import Link from "next/link"
+import { redirect } from "next/navigation"
+
+import { auth } from "@/auth"
+import OAuthTokenCard from "@/components/auth/OAuthTokenCard"
+import RepoSelector from "@/components/common/RepoSelector"
+import AgentWorkflowClient from "@/components/playground/AgentWorkflowClient"
+import AnthropicIssueTitleCard from "@/components/playground/AnthropicIssueTitleCard"
+import ApplyPatchCard from "@/components/playground/ApplyPatchCard"
+import DockerodeExecCard from "@/components/playground/DockerodeExecCard"
+import IssueSummaryCard from "@/components/playground/IssueSummaryCard"
+import IssueTitleCard from "@/components/playground/IssueTitleCard"
+import NewLocalTaskInput from "@/components/playground/NewLocalTaskInput"
+import RipgrepSearchCard from "@/components/playground/RipgrepSearchCard"
+import SpeechToTextCard from "@/components/playground/SpeechToTextCard"
+import TestGithubUserFunctionsCard from "@/components/playground/TestGithubUserFunctionsCard"
+import UserRolesCard from "@/components/playground/UserRolesCard"
+import WriteFileCard from "@/components/playground/WriteFileCard"
+import { Button } from "@/components/ui/button"
+import { getGithubUser } from "@/lib/github/users"
+import { getUserRoles } from "@/lib/neo4j/services/user"
+
+export default async function PlaygroundToolsPage() {
+  const session = await auth()
+  if (!session?.user) {
+    redirect("/")
+  }
+
+  const githubUser = await getGithubUser()
+  const roles = githubUser
+    ? await getUserRoles(githubUser.login).catch(() => [])
+    : []
+  const isAdmin = roles.includes("admin")
+  if (!isAdmin) {
+    redirect("/")
+  }
+
+  const token = session?.token?.access_token as string | undefined
+
+  return (
+    <div className="space-y-8 px-4 py-8 md:container md:mx-auto">
+      <div>
+        <h2 className="text-lg font-semibold mb-2">
+          Create Local Task (Neo4j)
+        </h2>
+        <NewLocalTaskInput
+          repoFullName={{
+            owner: "issue-to-pr",
+            repo: "test-repo",
+            fullName: "issue-to-pr/test-repo",
+          }}
+        />
+        <TestGithubUserFunctionsCard />
+      </div>
+      <AgentWorkflowClient defaultTools={DEFAULT_TOOLS} />
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">Repository & Issue Tools</h2>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="col-span-1">
+            <div className="rounded-lg border p-4">
+              <h3 className="font-medium mb-2">Test Repo Selector Component</h3>
+              <p className="text-sm text-muted-foreground mb-2">
+                Use this to test the RepoSelector component. It should show a
+                button to install the GitHub App if no repos are available.
+                Uninstall the GitHub App to test the installation CTA.
+              </p>
+              <RepoSelector selectedRepo="issue-to-pr/test-repo" />
+            </div>
+          </div>
+          <IssueTitleCard />
+          <AnthropicIssueTitleCard />
+          <IssueSummaryCard />
+          <RipgrepSearchCard />
+          <WriteFileCard />
+          <ApplyPatchCard />
+          <DockerodeExecCard />
+        </div>
+      </section>
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">User & Misc Tools</h2>
+        <div className="grid gap-4 md:grid-cols-2">
+          <SpeechToTextCard />
+          <UserRolesCard />
+          {token ? <OAuthTokenCard token={token} /> : null}
+        </div>
+      </section>
+      <div>
+        <Link href="/playground/evals">
+          <Button variant="outline" size="sm">
+            LLM Evaluations
+          </Button>
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/components/pull-requests/CreatedPullRequestCard.tsx
+++ b/components/pull-requests/CreatedPullRequestCard.tsx
@@ -1,0 +1,49 @@
+import { ExternalLink } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+export interface CreatedPullRequestCardProps {
+  number: number
+  title: string
+  body?: string | null
+  url: string
+}
+
+export default function CreatedPullRequestCard({
+  number,
+  title,
+  body,
+  url,
+}: CreatedPullRequestCardProps) {
+  const preview = (body || "").trim()
+  const previewText = preview
+    ? preview.length > 280
+      ? preview.slice(0, 280) + "…"
+      : preview
+    : "No description provided."
+
+  return (
+    <Card className="border-blue-200 dark:border-blue-900">
+      <CardHeader>
+        <div className="flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 mb-1">
+              <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200">
+                Pull Request
+              </span>
+              <span className="text-xs text-muted-foreground">#{number}</span>
+            </div>
+            <CardTitle className="">{title}</CardTitle>
+          </div>
+          <Button asChild size="sm">
+            <a href={url} target="_blank" rel="noopener noreferrer">
+              View PR
+              <ExternalLink className="ml-2 h-4 w-4" />
+            </a>
+          </Button>
+        </div>
+      </CardHeader>
+    </Card>
+  )
+}

--- a/components/workflow-runs/events/ToolCallResultEvent.tsx
+++ b/components/workflow-runs/events/ToolCallResultEvent.tsx
@@ -2,6 +2,7 @@
 
 import { ArrowDownLeft } from "lucide-react"
 
+import { Button } from "@/components/ui/button"
 import { CollapsibleContent } from "@/components/ui/collapsible-content"
 import { EventTime } from "@/components/workflow-runs/events/EventTime"
 import { ToolCallResult } from "@/lib/types"
@@ -25,14 +26,41 @@ export function ToolCallResultEvent({ event }: Props) {
     </div>
   )
 
+  // Attempt to parse the tool response content to detect PR creation success
+  let prUrl: string | null = null
+  try {
+    const parsed = JSON.parse(event.content || "{}") as any
+    if (
+      event.toolName === "create_pull_request" &&
+      parsed?.status === "success" &&
+      parsed?.pullRequest?.data?.url
+    ) {
+      prUrl = String(parsed.pullRequest.data.url)
+    }
+  } catch {
+    // Ignore parse errors; we'll just render the raw content below
+  }
+
   return (
     <CollapsibleContent
       headerContent={headerContent}
       className="border-l-2 border-green-500 dark:border-green-400 hover:bg-muted/50"
     >
-      <div className="font-mono text-sm overflow-x-auto">
-        <div className="whitespace-pre-wrap">{event.content}</div>
+      <div className="space-y-3">
+        {prUrl && (
+          <div>
+            <Button asChild size="sm" variant="default">
+              <a href={prUrl} target="_blank" rel="noopener noreferrer">
+                View PR
+              </a>
+            </Button>
+          </div>
+        )}
+        <div className="font-mono text-sm overflow-x-auto">
+          <div className="whitespace-pre-wrap">{event.content}</div>
+        </div>
       </div>
     </CollapsibleContent>
   )
 }
+

--- a/components/workflow-runs/events/ToolCallResultEvent.tsx
+++ b/components/workflow-runs/events/ToolCallResultEvent.tsx
@@ -2,7 +2,7 @@
 
 import { ArrowDownLeft } from "lucide-react"
 
-import { Button } from "@/components/ui/button"
+import CreatedPullRequestCard from "@/components/pull-requests/CreatedPullRequestCard"
 import { CollapsibleContent } from "@/components/ui/collapsible-content"
 import { EventTime } from "@/components/workflow-runs/events/EventTime"
 import { ToolCallResult } from "@/lib/types"
@@ -27,40 +27,56 @@ export function ToolCallResultEvent({ event }: Props) {
   )
 
   // Attempt to parse the tool response content to detect PR creation success
-  let prUrl: string | null = null
+  let prData: {
+    number: number
+    title: string
+    body?: string | null
+    url: string
+  } | null = null
   try {
-    const parsed = JSON.parse(event.content || "{}") as any
+    const parsed = JSON.parse(event.content || "{}")
     if (
       event.toolName === "create_pull_request" &&
       parsed?.status === "success" &&
       parsed?.pullRequest?.data?.url
     ) {
-      prUrl = String(parsed.pullRequest.data.url)
+      const pr = parsed.pullRequest?.data
+      if (pr?.number && pr?.title && pr?.url) {
+        prData = {
+          number: Number(pr.number),
+          title: String(pr.title),
+          body: pr.body ?? null,
+          url: String(pr.url),
+        }
+      }
     }
   } catch {
     // Ignore parse errors; we'll just render the raw content below
   }
 
   return (
-    <CollapsibleContent
-      headerContent={headerContent}
-      className="border-l-2 border-green-500 dark:border-green-400 hover:bg-muted/50"
-    >
-      <div className="space-y-3">
-        {prUrl && (
-          <div>
-            <Button asChild size="sm" variant="default">
-              <a href={prUrl} target="_blank" rel="noopener noreferrer">
-                View PR
-              </a>
-            </Button>
-          </div>
-        )}
-        <div className="font-mono text-sm overflow-x-auto">
-          <div className="whitespace-pre-wrap">{event.content}</div>
+    <>
+      {prData ? (
+        <div className="space-y-3">
+          <CreatedPullRequestCard
+            number={prData.number}
+            title={prData.title}
+            body={prData.body}
+            url={prData.url}
+          />
         </div>
-      </div>
-    </CollapsibleContent>
+      ) : (
+        <CollapsibleContent
+          headerContent={headerContent}
+          className="border-l-2 border-green-500 dark:border-green-400 hover:bg-muted/50"
+        >
+          <div className="space-y-3">
+            <div className="font-mono text-sm overflow-x-auto">
+              <div className="whitespace-pre-wrap">{event.content}</div>
+            </div>
+          </div>
+        </CollapsibleContent>
+      )}
+    </>
   )
 }
-


### PR DESCRIPTION
Summary
- When the Create PR tool succeeds within a workflow run, show a primary "View PR" button in the Tool Response card that links directly to the newly created PR.

Details
- Updated components/workflow-runs/events/ToolCallResultEvent.tsx to:
  - Parse the tool response content for create_pull_request events.
  - If status === "success" and a URL exists (pullRequest.data.url), render a highlighted primary button linking to that PR.
  - Keep rendering the raw tool response content underneath for transparency/debugging.

Why
- Improves UX by providing a clear, immediate call-to-action on the workflow details page when a PR is successfully created.

Notes
- Uses existing Button component with default (primary) variant for highlighting.
- Opens PR in a new tab (target="_blank").

Closes #1014