### PR TITLE
Add retry option for failed audio transcription

### DIFF
--- a/components/common/VoiceDictationCard.tsx
+++ b/components/common/VoiceDictationCard.tsx
@@ -25,8 +25,10 @@ export default function VoiceDictationCard() {
     serverRawResponse,
     recordingInfo,
     iosSafariHint,
+    hasRecording,
     startRecording,
     stopRecording,
+    retryTranscription,
   } = useVoiceDictation()
 
   const { toast } = useToast()
@@ -88,7 +90,7 @@ export default function VoiceDictationCard() {
           </div>
         )}
 
-        <div className="flex items-center gap-4">
+        <div className="flex flex-wrap items-center gap-4">
           {isRecording ? (
             <Button
               variant="destructive"
@@ -104,6 +106,13 @@ export default function VoiceDictationCard() {
           )}
           <Button variant="outline" onClick={handleCopy} disabled={!transcript}>
             Copy
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={retryTranscription}
+            disabled={!hasRecording || isRecording || isTranscribing}
+          >
+            Retry Transcription
           </Button>
         </div>
 
@@ -150,3 +159,4 @@ export default function VoiceDictationCard() {
     </Card>
   )
 }
+


### PR DESCRIPTION
Summary
- Persist the last recorded audio file so users can retry transcription without re-recording
- Add retryTranscription() and hasRecording to useVoiceDictation hook
- Show a Retry action in the error toast when transcription fails
- Add a "Retry Transcription" button in the VoiceDictationCard UI for explicit retries

Why
Sometimes audio transcription fails. This change provides a straightforward way for users to retry transcription of the last recording, addressing the need described in the issue.

Details
- useVoiceDictation
  - Stores the last recorded File (lastAudioFile)
  - Extracts the transcription logic into doTranscribe(file)
  - Exposes retryTranscription() to resend the last audio to /api/openai/transcribe
  - Surfaces hasRecording boolean to help UIs enable/disable retry controls
  - On error, shows a toast with a Retry action when a recording is available
- VoiceDictationCard
  - Adds a "Retry Transcription" button (enabled when a recording exists and not currently transcribing or recording)
  - Keeps existing playback + debug experience

Scope
- No server/API changes required
- No changes to the simple VoiceDictationButton UI, to keep it small and focused. The toast Retry action ensures retry is available even when using the button-only UI (e.g., New Task Input).

Testing
- Manually verified state transitions: record -> stop -> transcribe -> failed -> Retry via toast or the new button -> success
- Ensured audio playback and object URL handling remain intact

Notes
- The hook continues to present detailed debug info and safeguards around MediaRecorder and object URL lifecycles.


Closes #1013