### PR TITLE
Add Load More button to repository issues list

### DIFF
--- a/app/api/issues/list/route.ts
+++ b/app/api/issues/list/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+
+import {
+  getIssueListWithStatus,
+  getLinkedPRNumbersForIssues,
+} from "@/lib/github/issues"
+
+const RequestSchema = z.object({
+  repoFullName: z.string().min(3),
+  page: z.number().int().min(1).default(1),
+  per_page: z.number().int().min(1).max(100).default(25),
+})
+
+export async function POST(req: Request) {
+  try {
+    const json = await req.json()
+    const { repoFullName, page, per_page } = RequestSchema.parse(json)
+
+    const issues = await getIssueListWithStatus({
+      repoFullName,
+      page,
+      per_page,
+    })
+
+    const issueNumbers = issues.map((i) => i.number)
+    const prMap = await getLinkedPRNumbersForIssues({
+      repoFullName,
+      issueNumbers,
+    })
+
+    const hasMore = issues.length === per_page
+
+    return NextResponse.json({ issues, prMap, hasMore })
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: "Invalid request data", details: err.errors },
+        { status: 400 }
+      )
+    }
+    console.error("Failed to list issues:", err)
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Unknown error" },
+      { status: 500 }
+    )
+  }
+}
+

--- a/components/issues/IssueTable.tsx
+++ b/components/issues/IssueTable.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react"
 
 import IssueRows from "@/components/issues/IssueRows"
+import LoadMoreIssues from "@/components/issues/LoadMoreIssues"
 import RowsSkeleton from "@/components/issues/RowsSkeleton"
 import TaskRows from "@/components/issues/TaskRows"
 import { Table, TableBody } from "@/components/ui/table"
@@ -20,6 +21,9 @@ export default async function IssueTable({ repoFullName }: Props) {
             <IssueRows repoFullName={repoFullName} />
           </Suspense>
 
+          {/* Load more button and dynamically loaded issues */}
+          <LoadMoreIssues repoFullName={repoFullName.fullName} />
+
           <Suspense fallback={<RowsSkeleton rows={2} columns={3} />}>
             <TaskRows repoFullName={repoFullName} />
           </Suspense>
@@ -28,3 +32,4 @@ export default async function IssueTable({ repoFullName }: Props) {
     </div>
   )
 }
+

--- a/components/issues/LoadMoreIssues.tsx
+++ b/components/issues/LoadMoreIssues.tsx
@@ -1,0 +1,95 @@
+"use client"
+
+import { useState } from "react"
+
+import IssueRow from "@/components/issues/IssueRow"
+import PRStatusIndicator from "@/components/issues/PRStatusIndicator"
+import { Button } from "@/components/ui/button"
+import { TableCell, TableRow } from "@/components/ui/table"
+import type { IssueWithStatus } from "@/lib/github/issues"
+
+interface Props {
+  repoFullName: string
+  perPage?: number
+}
+
+export default function LoadMoreIssues({ repoFullName, perPage = 25 }: Props) {
+  const [page, setPage] = useState(1) // initial server rendered page is 1; next fetch will be 2
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [issues, setIssues] = useState<IssueWithStatus[]>([])
+  const [prMap, setPrMap] = useState<Record<number, number | null>>({})
+  const [hasMore, setHasMore] = useState<boolean | null>(null)
+
+  const loadMore = async () => {
+    if (loading) return
+    setLoading(true)
+    setError(null)
+    try {
+      const nextPage = page + 1
+      const resp = await fetch("/api/issues/list", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ repoFullName, page: nextPage, per_page: perPage }),
+      })
+      if (!resp.ok) {
+        throw new Error(`Failed to load issues: ${resp.status}`)
+      }
+      const data: {
+        issues: IssueWithStatus[]
+        prMap: Record<number, number | null>
+        hasMore: boolean
+      } = await resp.json()
+
+      setIssues((prev) => [...prev, ...data.issues])
+      setPrMap((prev) => ({ ...prev, ...data.prMap }))
+      setHasMore(data.hasMore)
+      setPage(nextPage)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Unknown error")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // If we already determined there are no more, hide the button.
+  // Initially null means unknown - show the button so users can try to load more.
+  const showButton = hasMore !== false
+
+  return (
+    <>
+      {issues.map((issue) => (
+        <IssueRow
+          key={`issue-more-${issue.id}`}
+          issue={issue}
+          repoFullName={repoFullName}
+          prSlot={
+            <PRStatusIndicator
+              repoFullName={repoFullName}
+              prNumber={prMap[issue.number]}
+            />
+          }
+        />
+      ))}
+
+      {error && (
+        <TableRow>
+          <TableCell colSpan={3} className="text-red-600">
+            {error}
+          </TableCell>
+        </TableRow>
+      )}
+
+      {showButton && (
+        <TableRow>
+          <TableCell colSpan={3} className="text-center py-4">
+            <Button onClick={loadMore} disabled={loading} variant="outline">
+              {loading ? "Loading..." : "Load more"}
+            </Button>
+          </TableCell>
+        </TableRow>
+      )}
+    </>
+  )
+}
+


### PR DESCRIPTION
Summary
- Added a Load More button at the bottom of the repository issues list to fetch and render additional issues on demand.

What changed
- New API route: POST /api/issues/list
  - Accepts { repoFullName, page, per_page }
  - Returns { issues, prMap, hasMore }
  - Internally uses existing GitHub helpers to fetch issues and resolve linked PR numbers.
- New client component: components/issues/LoadMoreIssues.tsx
  - Manages pagination state and appends fetched issues as additional rows.
  - Renders a table row with a centered Load more button and handles loading/error states.
- Updated components/issues/IssueTable.tsx
  - Injected LoadMoreIssues between initial IssueRows and TaskRows so tasks remain at the bottom.

Why
- Implements the requested feature: add a load more button to the issues list so users can view additional issues beyond the initial set.

Notes
- Initial server-rendered page still shows the first 25 issues. The button fetches subsequent pages (page 2+).
- Button hides itself once the API reports no more pages (hasMore=false). If the repo has < per_page issues total, users will see the button initially; on click it will disappear after confirming no more results.

Testing
- Type-checked with pnpm lint:tsc
- Linted with pnpm lint:eslint (only unrelated warnings present).

No breaking changes expected.

Closes #1015