### PR TITLE
Track user repository access and permissions in Neo4j (shared package)

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -28,6 +28,7 @@
     "@anthropic-ai/sdk": "^0.59.0",
     "bullmq": "^5.0.0",
     "ioredis": "^5.3.2",
+    "neo4j-driver": "^5.23.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {
@@ -35,3 +36,4 @@
     "typescript": "^5"
   }
 }
+

--- a/shared/src/adapters/neo4j.ts
+++ b/shared/src/adapters/neo4j.ts
@@ -1,0 +1,106 @@
+import neo4j, { Driver } from "neo4j-driver"
+
+import type {
+  UserRepoAccessInput,
+  UserRepoAccessRecord,
+  UserRepositoryAccessPort,
+} from "@/shared/src/core/ports/graph"
+
+/**
+ * Minimal Neo4j adapter that implements UserRepositoryAccessPort.
+ * Env vars (aligns with the app's existing lib/neo4j client):
+ * - NEO4J_URI (default bolt://localhost:7687)
+ * - NEO4J_USER (default neo4j)
+ * - NEO4J_PASSWORD (default password)
+ */
+export class Neo4jGraphAdapter implements UserRepositoryAccessPort {
+  private driver: Driver | null = null
+
+  private async getDriver(): Promise<Driver> {
+    if (this.driver) return this.driver
+    const uri = process.env.NEO4J_URI || "bolt://localhost:7687"
+    const user = process.env.NEO4J_USER || process.env.NEO4J_USERNAME || "neo4j"
+    const password = process.env.NEO4J_PASSWORD || "password"
+    this.driver = neo4j.driver(uri, neo4j.auth.basic(user, password), {
+      maxConnectionPoolSize: 25,
+      connectionAcquisitionTimeout: 5000,
+    })
+    // verify connectivity once
+    await this.driver.verifyConnectivity()
+    return this.driver
+  }
+
+  async syncUserRepositoryAccess(input: UserRepoAccessInput): Promise<void> {
+    const driver = await this.getDriver()
+    const session = driver.session()
+    try {
+      await session.executeWrite(async (tx) => {
+        // Ensure user exists
+        await tx.run(
+          `MERGE (u:User {username: $username})`,
+          { username: input.username }
+        )
+
+        // Upsert repositories and relationships with permissions
+        await tx.run(
+          `
+          UNWIND $repos AS repo
+          MERGE (r:Repository {fullName: repo.fullName})
+          SET r.repoId = coalesce(repo.id, r.repoId)
+          WITH r, repo
+          MATCH (u:User {username: $username})
+          MERGE (u)-[rel:HAS_ACCESS]->(r)
+          SET rel.permission = repo.permission,
+              rel.updatedAt = datetime()
+          `,
+          { username: input.username, repos: input.repos }
+        )
+
+        // Remove stale relationships not present in the provided list
+        await tx.run(
+          `
+          MATCH (u:User {username: $username})-[rel:HAS_ACCESS]->(r:Repository)
+          WHERE NOT r.fullName IN [x IN $repos | x.fullName]
+          DELETE rel
+          `,
+          { username: input.username, repos: input.repos }
+        )
+      })
+    } finally {
+      await session.close()
+    }
+  }
+
+  async getUserRepositoryAccess(username: string): Promise<UserRepoAccessRecord[]> {
+    const driver = await this.getDriver()
+    const session = driver.session()
+    try {
+      const res = await session.executeRead(async (tx) => {
+        return tx.run(
+          `
+          MATCH (u:User {username: $username})-[rel:HAS_ACCESS]->(r:Repository)
+          RETURN r.fullName AS fullName, r.repoId AS id, rel.permission AS permission
+          ORDER BY toLower(fullName)
+          `,
+          { username }
+        )
+      })
+
+      return res.records.map((rec) => ({
+        fullName: rec.get("fullName"),
+        id: rec.get("id") ?? undefined,
+        permission: rec.get("permission"),
+      }))
+    } finally {
+      await session.close()
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.driver) {
+      await this.driver.close()
+      this.driver = null
+    }
+  }
+}
+

--- a/shared/src/core/entities/repository.ts
+++ b/shared/src/core/entities/repository.ts
@@ -1,0 +1,10 @@
+// Minimal domain entities for repositories and users, used by services/ports
+export type RepositoryRef = {
+  fullName: string // owner/name
+  id?: number
+}
+
+export type UserRef = {
+  username: string
+}
+

--- a/shared/src/core/ports/graph.ts
+++ b/shared/src/core/ports/graph.ts
@@ -1,0 +1,30 @@
+// Clean-architecture port for graph database operations we need now
+// Focus: tracking which repositories a user can access and at what permission level
+
+export type RepoPermission = "ADMIN" | "MAINTAIN" | "WRITE" | "TRIAGE" | "READ"
+
+export interface UserRepoAccessInput {
+  username: string
+  repos: Array<{
+    fullName: string // e.g., "owner/name"
+    id?: number // optional GitHub repo id
+    permission: RepoPermission
+  }>
+}
+
+export interface UserRepoAccessRecord {
+  fullName: string
+  id?: number
+  permission: RepoPermission
+}
+
+// Port (interface) the application/service layer depends on
+export interface UserRepositoryAccessPort {
+  // Upsert user, repositories and access edges.
+  // Also remove any access edges not present in the provided list (authoritative sync).
+  syncUserRepositoryAccess(input: UserRepoAccessInput): Promise<void>
+
+  // Read repositories connected to a user, with permissions
+  getUserRepositoryAccess(username: string): Promise<UserRepoAccessRecord[]>
+}
+

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,16 +1,12 @@
 export { AnthropicAdapter } from "@/shared/src/adapters/anthropic"
-export {
-  decorateWithTiming,
-  TimedGitHubIssuesPort,
-} from "@/shared/src/adapters/decorators/timing"
+export { decorateWithTiming, TimedGitHubIssuesPort } from "@/shared/src/adapters/decorators/timing"
 export { GitHubGraphQLAdapter } from "@/shared/src/adapters/github-graphql"
+export { Neo4jGraphAdapter } from "@/shared/src/adapters/neo4j"
 export * from "@/shared/src/core/ports/github"
+export * from "@/shared/src/core/ports/graph"
 export * from "@/shared/src/core/ports/llm"
 export { fetchIssueTitles } from "@/shared/src/services/github/issues"
+export { getUserRepositoryAccess, syncUserRepositoryAccess } from "@/shared/src/services/neo4j/userRepositoryAccess"
 export type { LogMeta } from "@/shared/src/utils/telemetry"
-export {
-  logEnd,
-  logError,
-  logStart,
-  withTiming,
-} from "@/shared/src/utils/telemetry"
+export { logEnd, logError, logStart, withTiming } from "@/shared/src/utils/telemetry"
+

--- a/shared/src/services/neo4j/userRepositoryAccess.ts
+++ b/shared/src/services/neo4j/userRepositoryAccess.ts
@@ -1,0 +1,24 @@
+import { Neo4jGraphAdapter } from "@/shared/src/adapters/neo4j"
+import type {
+  UserRepoAccessInput,
+  UserRepoAccessRecord,
+  UserRepositoryAccessPort,
+} from "@/shared/src/core/ports/graph"
+
+// Application/service layer API. Accepts the Port so it can be unit tested.
+// Provides a default that uses the Neo4jGraphAdapter.
+
+export async function syncUserRepositoryAccess(
+  input: UserRepoAccessInput,
+  port: UserRepositoryAccessPort = new Neo4jGraphAdapter()
+): Promise<void> {
+  return port.syncUserRepositoryAccess(input)
+}
+
+export async function getUserRepositoryAccess(
+  username: string,
+  port: UserRepositoryAccessPort = new Neo4jGraphAdapter()
+): Promise<UserRepoAccessRecord[]> {
+  return port.getUserRepositoryAccess(username)
+}
+


### PR DESCRIPTION
Summary
- Introduces a clean-architecture foundation in the shared package to track which repositories a user can access and with what permission level, persisted in Neo4j.
- The goal is to avoid extra GitHub network calls later by reading from graph data directly.

What’s included
1) New port (interface)
- shared/src/core/ports/graph.ts
  - UserRepositoryAccessPort with
    - syncUserRepositoryAccess(input) — authoritative upsert of User → Repository edges and permissions
    - getUserRepositoryAccess(username) — list repositories and permissions for a user
  - Strongly typed RepoPermission and simple data structures.

2) Neo4j adapter
- shared/src/adapters/neo4j.ts
  - Neo4jGraphAdapter implements the port using neo4j-driver.
  - Uses env vars aligned with existing app: NEO4J_URI, NEO4J_USER (or NEO4J_USERNAME), NEO4J_PASSWORD.
  - Schema: (User {username}) -[:HAS_ACCESS {permission, updatedAt}]-> (Repository {fullName, repoId?}).
  - syncUserRepositoryAccess removes stale relationships not included in the given list, ensuring the graph mirrors the GitHub app permissions.

3) Service layer helpers
- shared/src/services/neo4j/userRepositoryAccess.ts
  - syncUserRepositoryAccess(..., port = new Neo4jGraphAdapter())
  - getUserRepositoryAccess(..., port = new Neo4jGraphAdapter())
  - Keeps adapters swappable for testing and future migrations.

4) Exports & dependency
- Exported from shared/src/index.ts.
- Added neo4j-driver to shared/package.json.

Why this approach
- Lives in shared (not lib), as requested, to start migrating graph-related services into the shared package while following clean architecture.
- Keeps domain logic adapter-agnostic; only the adapter knows about neo4j-driver.
- Minimal and focused: a single relationship type and basic sync/read ops to unblock usage by workflows and pages that need quick access checks.

Cypher details
- Upsert user and repos, and MERGE relationships with permission:
  - MERGE (u:User {username})
  - MERGE (r:Repository {fullName}) SET r.repoId = coalesce(repo.id, r.repoId)
  - MERGE (u)-[rel:HAS_ACCESS]->(r) SET rel.permission = repo.permission, rel.updatedAt = datetime()
- Prune stale edges:
  - MATCH (u)-[rel:HAS_ACCESS]->(r:Repository) WHERE NOT r.fullName IN [x IN $repos | x.fullName] DELETE rel

How to use (example)
- After fetching repos + permissions via GitHub, call from server code:
  import { syncUserRepositoryAccess } from "shared"
  await syncUserRepositoryAccess({
    username: "octocat",
    repos: [
      { fullName: "org/app", id: 123, permission: "WRITE" },
      { fullName: "org/infra", id: 456, permission: "READ" },
    ],
  })

- Later, to read what the user can access:
  import { getUserRepositoryAccess } from "shared"
  const repos = await getUserRepositoryAccess("octocat")

Notes
- No breaking changes to existing lib/* code.
- Lint and type checks pass for the new files.

Future
- We can expand the port to support org/team scoping or other relationships as we migrate more services into shared.


Closes #1038