### PR TITLE
Add shared Summarize Workflow Run service (clean architecture)

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -28,6 +28,7 @@
     "@anthropic-ai/sdk": "^0.59.0",
     "bullmq": "^5.0.0",
     "ioredis": "^5.3.2",
+    "openai": "^5.12.2",
     "zod": "^3.22.4"
   },
   "devDependencies": {
@@ -35,3 +36,4 @@
     "typescript": "^5"
   }
 }
+

--- a/shared/src/adapters/openai.ts
+++ b/shared/src/adapters/openai.ts
@@ -1,0 +1,44 @@
+import OpenAI from "openai"
+
+import type { LLMMessage, LLMPort } from "@/shared/src/core/ports/llm"
+
+/**
+ * Minimal OpenAI adapter implementing the shared LLMPort interface.
+ */
+export class OpenAIAdapter implements LLMPort {
+  private client: OpenAI
+
+  constructor(apiKey: string | undefined = process.env.OPENAI_API_KEY) {
+    if (!apiKey) {
+      throw new Error("OpenAI API key is missing")
+    }
+    this.client = new OpenAI({ apiKey })
+  }
+
+  async createCompletion({
+    system,
+    messages,
+    model = "gpt-4.1-mini",
+    maxTokens = 1024,
+  }: {
+    system?: string
+    messages: LLMMessage[]
+    model?: string
+    maxTokens?: number
+  }): Promise<string> {
+    const result = await this.client.chat.completions.create({
+      model,
+      messages: [
+        ...(system ? [{ role: "system" as const, content: system }] : []),
+        ...messages,
+      ],
+      max_tokens: maxTokens,
+      temperature: 0.2,
+    })
+
+    return result.choices[0]?.message?.content ?? ""
+  }
+}
+
+export default OpenAIAdapter
+

--- a/shared/src/core/entities/workflow.ts
+++ b/shared/src/core/entities/workflow.ts
@@ -1,0 +1,70 @@
+import { z } from "zod"
+
+/**
+ * Minimal event types needed for summarization. These are intentionally
+ * decoupled from the app's internal event types to keep the shared package
+ * independent and portable.
+ */
+export const workflowEventBaseSchema = z.object({
+  createdAt: z.date(),
+  content: z.string().optional(),
+})
+
+export const simpleEventTypeSchema = z.enum([
+  "systemPrompt",
+  "userMessage",
+  "llmResponse",
+  "reasoning",
+  "status",
+  "error",
+  "reviewComment",
+  "workflowState",
+])
+
+export const simpleEventSchema = workflowEventBaseSchema.extend({
+  type: simpleEventTypeSchema,
+  content: z.string(),
+})
+
+export const toolCallEventSchema = workflowEventBaseSchema.extend({
+  type: z.literal("toolCall"),
+  toolName: z.string(),
+  args: z.string(), // JSON string of arguments
+})
+
+export const toolCallResultEventSchema = workflowEventBaseSchema.extend({
+  type: z.literal("toolCallResult"),
+  toolName: z.string(),
+  content: z.string(),
+})
+
+export const workflowEventSchema = z.discriminatedUnion("type", [
+  simpleEventSchema,
+  toolCallEventSchema,
+  toolCallResultEventSchema,
+])
+
+export type WorkflowEvent = z.infer<typeof workflowEventSchema>
+export type ToolCallEvent = z.infer<typeof toolCallEventSchema>
+export type ToolCallResultEvent = z.infer<typeof toolCallResultEventSchema>
+
+// Structured summary output for a workflow run
+export const workflowRunSummarySchema = z.object({
+  workflowRunId: z.string(),
+  actionsSummary: z
+    .string()
+    .describe(
+      "High-level narrative of what the agent attempted, the steps it took, and the outcome."
+    ),
+  filesRead: z
+    .array(z.string())
+    .describe("List of file paths the agent read or inspected during the run."),
+  interestingFindings: z
+    .array(z.string())
+    .describe(
+      "Notable observations about the codebase that were important to the agent's reasoning."
+    ),
+})
+
+export type WorkflowRunSummary = z.infer<typeof workflowRunSummarySchema>
+

--- a/shared/src/core/ports/workflow.ts
+++ b/shared/src/core/ports/workflow.ts
@@ -1,0 +1,23 @@
+import { z } from "zod"
+
+import {
+  toolCallEventSchema,
+  toolCallResultEventSchema,
+  workflowEventSchema,
+} from "@/shared/src/core/entities/workflow"
+
+// Re-export schemas for consumers
+export { workflowEventSchema } from "@/shared/src/core/entities/workflow"
+
+export type WorkflowEvent = z.infer<typeof workflowEventSchema>
+export type ToolCallEvent = z.infer<typeof toolCallEventSchema>
+export type ToolCallResultEvent = z.infer<typeof toolCallResultEventSchema>
+
+/**
+ * Port for retrieving workflow run data (events/messages) from any source
+ * (database, API, etc.).
+ */
+export interface WorkflowRunPort {
+  getEvents(workflowRunId: string): Promise<WorkflowEvent[]>
+}
+

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,4 +1,5 @@
 export { AnthropicAdapter } from "@/shared/src/adapters/anthropic"
+export { OpenAIAdapter } from "@/shared/src/adapters/openai"
 export {
   decorateWithTiming,
   TimedGitHubIssuesPort,
@@ -6,7 +7,14 @@ export {
 export { GitHubGraphQLAdapter } from "@/shared/src/adapters/github-graphql"
 export * from "@/shared/src/core/ports/github"
 export * from "@/shared/src/core/ports/llm"
-export { fetchIssueTitles } from "@/shared/src/services/github/issues"
+export * from "@/shared/src/core/ports/workflow"
+export {
+  fetchIssueTitles,
+} from "@/shared/src/services/github/issues"
+export {
+  summarizeWorkflowRun,
+  WorkflowRunSummarySchema,
+} from "@/shared/src/services/workflow/summarize"
 export type { LogMeta } from "@/shared/src/utils/telemetry"
 export {
   logEnd,
@@ -14,3 +22,4 @@ export {
   logStart,
   withTiming,
 } from "@/shared/src/utils/telemetry"
+

--- a/shared/src/services/workflow/summarize.ts
+++ b/shared/src/services/workflow/summarize.ts
@@ -1,0 +1,189 @@
+import { z } from "zod"
+
+import type { LLMPort } from "@/shared/src/core/ports/llm"
+import type { WorkflowRunPort, WorkflowEvent } from "@/shared/src/core/ports/workflow"
+import {
+  ToolCallEvent,
+  workflowRunSummarySchema,
+  type WorkflowRunSummary,
+} from "@/shared/src/core/entities/workflow"
+
+// Internal schema used to validate/parse LLM output
+const LLMOutputSchema = z.object({
+  actionsSummary: z.string(),
+  filesRead: z.array(z.string()).default([]),
+  interestingFindings: z.array(z.string()).default([]),
+})
+
+function tryParseJSON<T>(text: string): T | null {
+  try {
+    return JSON.parse(text) as T
+  } catch {
+    // Try to extract the first {...} JSON block
+    const match = text.match(/\{[\s\S]*\}/)
+    if (match) {
+      try {
+        return JSON.parse(match[0]) as T
+      } catch {
+        return null
+      }
+    }
+    return null
+  }
+}
+
+function unique<T>(arr: T[]): T[] {
+  return Array.from(new Set(arr))
+}
+
+// Best-effort extraction of files read from toolCall args
+function extractFilesRead(events: WorkflowEvent[]): string[] {
+  const files: string[] = []
+  for (const e of events) {
+    if (e.type === "toolCall") {
+      const call = e as ToolCallEvent
+      let args: unknown
+      try {
+        args = JSON.parse(call.args)
+      } catch {
+        args = null
+      }
+      if (args && typeof args === "object") {
+        const obj = args as Record<string, unknown>
+        // Common parameter names used across existing tools
+        const maybePath = obj["path"] ?? obj["file"] ?? obj["filePath"]
+        if (typeof maybePath === "string") files.push(maybePath)
+        // Some tools may accept multiple files
+        const maybeFiles = obj["paths"] ?? obj["files"]
+        if (Array.isArray(maybeFiles)) {
+          for (const p of maybeFiles) if (typeof p === "string") files.push(p)
+        }
+        // Ripgrep may include a directory root; skip unless explicitly a file
+      }
+    }
+  }
+  return unique(files)
+}
+
+function eventsDigest(events: WorkflowEvent[], maxChars = 6000): string {
+  // Create a compact textual digest of the run for the LLM
+  const lines: string[] = []
+  for (const e of events) {
+    const ts = e.createdAt instanceof Date ? e.createdAt.toISOString() : ""
+    switch (e.type) {
+      case "systemPrompt":
+      case "userMessage":
+      case "llmResponse":
+      case "reasoning":
+      case "status":
+      case "error":
+      case "reviewComment":
+      case "workflowState": {
+        const content = (e.content ?? "").slice(0, 800)
+        lines.push(`[${ts}] ${e.type}: ${content}`)
+        break
+      }
+      case "toolCall": {
+        const shortArgs = (e.args ?? "").slice(0, 400)
+        lines.push(`[${ts}] toolCall: ${e.toolName} args=${shortArgs}`)
+        break
+      }
+      case "toolCallResult": {
+        const content = (e.content ?? "").slice(0, 800)
+        lines.push(`[${ts}] toolCallResult: ${e.toolName} -> ${content}`)
+        break
+      }
+    }
+    // Truncate early if too long
+    const joined = lines.join("\n")
+    if (joined.length > maxChars) {
+      return joined.slice(joined.length - maxChars) // keep tail
+    }
+  }
+  return lines.join("\n")
+}
+
+const SYSTEM_PROMPT = `You are a precise log analyst. You will receive an ordered list of events from an agent workflow run (system prompts, user messages, reasoning, tool calls, tool results, statuses, errors).
+
+Your job:
+1) Summarize what the agent did at a high level (actionsSummary).
+2) List which files it read (filesRead). Only include paths you are confident about.
+3) Capture interesting findings about the codebase that materially impacted the final decision (interestingFindings).
+
+Output JSON only, with keys: actionsSummary (string), filesRead (string[]), interestingFindings (string[]).`
+
+export async function summarizeWorkflowRun({
+  workflowRunId,
+  llm,
+  port,
+  model,
+  maxTokens = 800,
+}: {
+  workflowRunId: string
+  llm: LLMPort
+  port: WorkflowRunPort
+  model?: string
+  maxTokens?: number
+}): Promise<WorkflowRunSummary> {
+  const events = await port.getEvents(workflowRunId)
+
+  const preExtractedFiles = extractFilesRead(events)
+  const digest = eventsDigest(events)
+
+  const userContent = [
+    preExtractedFiles.length
+      ? `Potential files read (pre-extracted):\n- ${preExtractedFiles.join("\n- ")}`
+      : "Potential files read (pre-extracted): none",
+    "\nEvent log:",
+    digest,
+  ].join("\n\n")
+
+  const raw = await llm.createCompletion({
+    system: SYSTEM_PROMPT,
+    messages: [{ role: "user", content: userContent }],
+    model,
+    maxTokens,
+  })
+
+  // Try to parse and validate LLM output
+  const json = tryParseJSON<unknown>(raw)
+  let parsed = json ? LLMOutputSchema.safeParse(json) : null
+
+  let output: z.infer<typeof LLMOutputSchema>
+  if (parsed?.success) {
+    output = parsed.data
+    // merge any extra files we pre-extracted
+    output.filesRead = unique([...(output.filesRead ?? []), ...preExtractedFiles])
+  } else {
+    // Fallback: heuristic summary from events
+    const statusLines = events
+      .filter((e) => e.type === "status")
+      .map((e) => e.content)
+      .filter(Boolean)
+      .slice(0, 5) as string[]
+
+    output = {
+      actionsSummary:
+        statusLines.length > 0
+          ? `Agent ran with notable statuses: ${statusLines.join(" | ")}`
+          : "Agent executed a workflow run; see event log for details.",
+      filesRead: preExtractedFiles,
+      interestingFindings: [],
+    }
+  }
+
+  // Final validation into public schema
+  const final = workflowRunSummarySchema.parse({
+    workflowRunId,
+    actionsSummary: output.actionsSummary.trim(),
+    filesRead: unique((output.filesRead ?? []).map((s) => s.trim()).filter(Boolean)),
+    interestingFindings: unique(
+      (output.interestingFindings ?? []).map((s) => s.trim()).filter(Boolean)
+    ),
+  })
+
+  return final
+}
+
+export { workflowRunSummarySchema as WorkflowRunSummarySchema }
+


### PR DESCRIPTION
Summary
- Introduces a reusable workflow summarization service in the shared package that produces a structured summary for each workflow run.
- Follows clean architecture principles: service depends only on ports; adapters implement ports.

What’s included
1) Entities and schemas
- shared/src/core/entities/workflow.ts
  - Minimal WorkflowEvent union (system/user/llm/reasoning/status/error/reviewComment/workflowState, toolCall, toolCallResult) purposely decoupled from app types.
  - WorkflowRunSummary schema and type with fields:
    - workflowRunId: string
    - actionsSummary: string
    - filesRead: string[]
    - interestingFindings: string[]

2) Ports
- shared/src/core/ports/workflow.ts
  - WorkflowRunPort with getEvents(workflowRunId: string): Promise<WorkflowEvent[]>.
  - Re-exports event schemas for convenience.

3) Service: Summarize Workflow Run
- shared/src/services/workflow/summarize.ts
  - summarizeWorkflowRun({ workflowRunId, llm, port, model?, maxTokens? }): Promise<WorkflowRunSummary>
  - Steps:
    - Fetches events via WorkflowRunPort.
    - Extracts files read from tool call args (path/file/filePath/paths/files keys).
    - Creates a compact digest of the event log (system prompts, user messages, tool calls/results, statuses).
    - Calls LLMPort.createCompletion with a strict system prompt asking for JSON output with keys: actionsSummary, filesRead, interestingFindings.
    - Parses and validates JSON with Zod; falls back to a heuristic summary if parsing fails.
    - Returns a WorkflowRunSummary with deduplicated files and trimmed strings.

4) LLM Adapter (optional use of GPT-4.1)
- shared/src/adapters/openai.ts
  - OpenAIAdapter implements LLMPort and defaults to model "gpt-4.1-mini".
  - Allows using GPT 4.1-family models to perform the summarization, per the issue request.

5) Exports
- shared/src/index.ts now exports:
  - OpenAIAdapter in addition to existing AnthropicAdapter
  - WorkflowRunPort and event schemas
  - summarizeWorkflowRun and WorkflowRunSummarySchema

Why this approach
- Clean separation of concerns: The summarizer depends only on ports and not on app-level DB/Neo4j implementations.
- Extensible: Any app can implement WorkflowRunPort (e.g., backed by Neo4j, HTTP API, or mocks for tests).
- Structured output: Enforced by Zod schema and a strict system prompt.
- Safety & resilience: If the LLM does not return valid JSON, we fall back to a heuristic summary and still return a valid structure.

How to wire it up (example)
- Implement WorkflowRunPort in your app layer, e.g.:

  class AppWorkflowRunAdapter implements WorkflowRunPort {
    async getEvents(workflowRunId: string): Promise<WorkflowEvent[]> {
      // Map your app's events (e.g., from Neo4j or an internal API)
      // into the minimal WorkflowEvent union defined in shared.
      // Return them sorted by createdAt ascending.
    }
  }

- Use an LLM adapter and call the service:

  import { OpenAIAdapter, summarizeWorkflowRun } from "shared"

  const llm = new OpenAIAdapter(process.env.OPENAI_API_KEY)
  const port = new AppWorkflowRunAdapter()
  const summary = await summarizeWorkflowRun({
    workflowRunId: "abc-123",
    llm,
    port,
    model: "gpt-4.1-mini", // optional; adapter defaults to this model
  })

  // summary has shape { workflowRunId, actionsSummary, filesRead, interestingFindings }

Notes
- No changes were made to the app layer, so this is non-breaking.
- The extraction of filesRead is conservative and works off toolCall args; you can improve adapter fidelity by ensuring paths are present in those args (e.g., for GetFileContent, RipgrepSearchTool, etc.).

Follow-ups (optional)
- Implement an app-level adapter that maps existing Neo4j events to shared WorkflowEvent and triggers summarizeWorkflowRun when a workflow completes.
- Persist summaries and surface them in the UI near the workflow run details.
- Extend ports if you want to fetch messages separately or to stream long logs.

Testing
- Repository compiles with tsc --noEmit.
- The shared code is isolated; no runtime hooks were added to the app/worker.


Closes #1043