### PR TITLE
Add shared PR comments analysis workflow to propose issue updates

### DIFF
--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -42,6 +42,7 @@ export const workflowTypeEnum = z.enum([
   "identifyPRGoal",
   "reviewPullRequest",
   "alignmentCheck",
+  "analyzePRComments",
 ])
 
 export const workflowRunSchema = z.object({
@@ -324,3 +325,4 @@ export type WorkflowRun = z.infer<typeof workflowRunSchema>
 export type WorkflowRunState = z.infer<typeof workflowRunStateSchema>
 export type WorkflowStateEvent = z.infer<typeof workflowStateEventSchema>
 export type WorkflowType = z.infer<typeof workflowTypeEnum>
+

--- a/lib/workflows/analyzePRComments.ts
+++ b/lib/workflows/analyzePRComments.ts
@@ -1,0 +1,145 @@
+import { v4 as uuidv4 } from "uuid"
+
+import { createIssueComment, getIssue } from "@/lib/github/issues"
+import {
+  getLinkedIssuesForPR,
+  getPullRequest,
+  getPullRequestComments,
+  getPullRequestReviewCommentsGraphQL,
+} from "@/lib/github/pullRequests"
+import {
+  createErrorEvent,
+  createLLMResponseEvent,
+  createStatusEvent,
+  createWorkflowStateEvent,
+} from "@/lib/neo4j/services/event"
+import { initializeWorkflowRun } from "@/lib/neo4j/services/workflow"
+import { AnthropicAdapter, analyzePRAndProposeIssueUpdates } from "@/shared/src"
+
+interface AnalyzePRCommentsParams {
+  repoFullName: string
+  pullNumber: number
+  jobId?: string
+  anthropicApiKey?: string
+}
+
+export async function analyzePRCommentsWorkflow({
+  repoFullName,
+  pullNumber,
+  jobId,
+  anthropicApiKey,
+}: AnalyzePRCommentsParams): Promise<void> {
+  const workflowId = jobId || uuidv4()
+
+  try {
+    await initializeWorkflowRun({
+      id: workflowId,
+      type: "analyzePRComments",
+      repoFullName,
+    })
+
+    await createWorkflowStateEvent({ workflowId, state: "running" })
+
+    await createStatusEvent({
+      workflowId,
+      content: `Fetching PR #${pullNumber} details and comments`,
+    })
+
+    const [pr, generalComments, reviewNodes, linkedIssues] = await Promise.all([
+      getPullRequest({ repoFullName, pullNumber }),
+      getPullRequestComments({ repoFullName, pullNumber }),
+      getPullRequestReviewCommentsGraphQL({ repoFullName, pullNumber }),
+      getLinkedIssuesForPR({ repoFullName, pullNumber }),
+    ])
+
+    if (!linkedIssues.length) {
+      await createStatusEvent({
+        workflowId,
+        content: "No linked issues found for this PR. Skipping analysis.",
+      })
+      await createWorkflowStateEvent({ workflowId, state: "completed" })
+      return
+    }
+
+    // For now, handle the first linked issue
+    const issueNumber = linkedIssues[0]
+    const issueRes = await getIssue({ fullName: repoFullName, issueNumber })
+    if (issueRes.type !== "success") {
+      await createStatusEvent({
+        workflowId,
+        content: `Linked issue #${issueNumber} not accessible (${issueRes.type}).`,
+      })
+      await createWorkflowStateEvent({ workflowId, state: "error" })
+      return
+    }
+
+    // Flatten review comments
+    const reviewComments = (reviewNodes || []).flatMap((r) =>
+      (r.comments || []).map((c) => ({
+        author: c.author,
+        body: c.body,
+        file: c.file,
+        diffHunk: c.diffHunk,
+        createdAt: c.createdAt,
+      }))
+    )
+
+    // Prepare LLM adapter and input
+    const llm = new AnthropicAdapter(anthropicApiKey || process.env.ANTHROPIC_API_KEY)
+
+    const analysis = await analyzePRAndProposeIssueUpdates(llm, {
+      repoFullName,
+      pullNumber,
+      prTitle: pr.title,
+      prBody: pr.body ?? undefined,
+      issue: {
+        repoFullName,
+        number: issueNumber,
+        title: issueRes.issue.title ?? undefined,
+        body: issueRes.issue.body ?? undefined,
+      },
+      generalComments: generalComments.map((c) => ({
+        author: c.user?.login,
+        body: c.body || "",
+        createdAt: c.created_at,
+      })),
+      reviewComments,
+      model: "claude-3-5-sonnet-latest",
+    })
+
+    await createLLMResponseEvent({
+      workflowId,
+      content: analysis.suggestedIssueUpdateMarkdown,
+      model: "claude-3-5-sonnet-latest",
+    })
+
+    await createStatusEvent({
+      workflowId,
+      content: `Posting proposed updates to Issue #${issueNumber}`,
+    })
+
+    const commentBody = [
+      `PR #${pullNumber} Review-driven Issue Update Proposal`,
+      "",
+      analysis.suggestedIssueUpdateMarkdown,
+    ].join("\n")
+
+    await createIssueComment({
+      repoFullName,
+      issueNumber,
+      comment: commentBody,
+    })
+
+    await createWorkflowStateEvent({ workflowId, state: "completed" })
+  } catch (error) {
+    await createErrorEvent({
+      workflowId,
+      content: String(error),
+    })
+    await createWorkflowStateEvent({ workflowId, state: "error" })
+    throw error
+  }
+}
+
+export default analyzePRCommentsWorkflow
+

--- a/shared/src/core/ports/github-pr.ts
+++ b/shared/src/core/ports/github-pr.ts
@@ -1,0 +1,59 @@
+// Minimal GitHub port interfaces used by PR comment analysis workflows.
+// Keeping ports small and focused supports clean-architecture layering.
+
+export type MinimalIssue = {
+  repoFullName: string
+  number: number
+  title?: string | null
+  body?: string | null
+}
+
+export type MinimalPR = {
+  repoFullName: string
+  number: number
+  title: string
+  body?: string | null
+}
+
+export type MinimalPRGeneralComment = {
+  author?: string | null
+  body: string
+  createdAt?: string
+}
+
+export type MinimalPRReviewComment = {
+  author?: string | null
+  body: string
+  file?: string | null
+  diffHunk?: string | null
+  createdAt?: string
+}
+
+export interface GitHubPRReadPort {
+  getPR(params: { repoFullName: string; pullNumber: number }): Promise<MinimalPR>
+  getPRComments(params: {
+    repoFullName: string
+    pullNumber: number
+  }): Promise<MinimalPRGeneralComment[]>
+  getPRReviewComments?(params: {
+    repoFullName: string
+    pullNumber: number
+  }): Promise<MinimalPRReviewComment[]>
+  getLinkedIssuesForPR(params: {
+    repoFullName: string
+    pullNumber: number
+  }): Promise<number[]>
+  getIssue(params: {
+    repoFullName: string
+    issueNumber: number
+  }): Promise<MinimalIssue | null>
+}
+
+export interface GitHubIssueWritePort {
+  createIssueComment(params: {
+    repoFullName: string
+    issueNumber: number
+    body: string
+  }): Promise<void>
+}
+

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -6,6 +6,7 @@ export {
 export { GitHubGraphQLAdapter } from "@/shared/src/adapters/github-graphql"
 export * from "@/shared/src/core/ports/github"
 export * from "@/shared/src/core/ports/llm"
+export * from "@/shared/src/core/ports/github-pr"
 export { fetchIssueTitles } from "@/shared/src/services/github/issues"
 export type { LogMeta } from "@/shared/src/utils/telemetry"
 export {
@@ -14,3 +15,7 @@ export {
   logStart,
   withTiming,
 } from "@/shared/src/utils/telemetry"
+export {
+  analyzePRAndProposeIssueUpdates,
+} from "@/shared/src/services/pr-comments-analysis"
+

--- a/shared/src/services/pr-comments-analysis.ts
+++ b/shared/src/services/pr-comments-analysis.ts
@@ -1,0 +1,125 @@
+import type { LLMPort } from "@/shared/src/core/ports/llm"
+
+export type PRGeneralComment = {
+  author?: string | null
+  body: string
+  createdAt?: string
+}
+
+export type PRReviewComment = {
+  author?: string | null
+  body: string
+  file?: string | null
+  diffHunk?: string | null
+  createdAt?: string
+}
+
+export type IssueContext = {
+  repoFullName: string
+  number: number
+  title?: string | null
+  body?: string | null
+}
+
+export type AnalyzePRCommentsInput = {
+  repoFullName: string
+  pullNumber: number
+  prTitle: string
+  prBody?: string | null
+  diff?: string | null
+  issue: IssueContext
+  generalComments: PRGeneralComment[]
+  reviewComments?: PRReviewComment[]
+  model?: string // allow callers to request a specific model like "gpt-5"
+}
+
+export type AnalyzePRCommentsOutput = {
+  summary: string
+  misconceptions?: string[]
+  missingRequirements?: string[]
+  verificationGaps?: string[]
+  suggestedIssueUpdateMarkdown: string
+}
+
+/**
+ * Pure service that analyzes a PR and its comments to propose improvements
+ * to the original issue. Depends only on the LLMPort and plain data types.
+ */
+export async function analyzePRAndProposeIssueUpdates(
+  llm: LLMPort,
+  input: AnalyzePRCommentsInput
+): Promise<AnalyzePRCommentsOutput> {
+  const {
+    repoFullName,
+    pullNumber,
+    prTitle,
+    prBody,
+    diff,
+    issue,
+    generalComments,
+    reviewComments = [],
+    model = "gpt-5", // caller can override; default hints at a strong thinking model
+  } = input
+
+  const system = [
+    "You are a senior engineering analyst.",
+    "Given a pull request and its comments, identify problems in the original issue and propose concrete, actionable updates.",
+    "Return concise, high-signal findings and a ready-to-post Markdown update for the issue.",
+  ].join(" ")
+
+  // Prepare a compact textual context for the model
+  const commentsText = [
+    generalComments.length
+      ? `General PR Comments (latest first):\n${generalComments
+          .slice(-50)
+          .map((c) => `- ${c.author ?? "anon"}: ${c.body}`)
+          .join("\n")}`
+      : "General PR Comments: (none)",
+    reviewComments.length
+      ? `\n\nReview Comments (latest first):\n${reviewComments
+          .slice(-100)
+          .map((c) => `- ${c.author ?? "anon"} on ${c.file ?? "(no-file)"}: ${c.body}`)
+          .join("\n")}`
+      : "",
+  ]
+    .filter(Boolean)
+    .join("")
+
+  const prompt = [
+    `Repository: ${repoFullName}`,
+    `Pull Request #${pullNumber}: ${prTitle}`,
+    prBody ? `\nPR Description:\n${prBody}` : "",
+    diff ? `\n\nDiff (truncated if large):\n${diff.slice(0, 30_000)}` : "",
+    `\n\nLinked Issue #${issue.number}${
+      issue.title ? `: ${issue.title}` : ""
+    }`,
+    issue.body ? `\nCurrent Issue Body:\n${issue.body}` : "",
+    `\n\n${commentsText}`,
+    `\n\nTASK: Based on the PR and discussion, analyze what was missing, incorrect, or ambiguous in the original issue. Identify:\n- Misconceptions or incorrect assumptions\n- Missing or updated requirements\n- Unverified constraints or acceptance criteria that should be explicit\n\nThen propose a Markdown update that can be posted as a comment to the issue including:\n- Summary of key findings\n- Bullet list of concrete, actionable updates to the issue\n- Optional clarifying questions if more info is needed`,
+  ].join("\n")
+
+  const content = await llm.createCompletion({
+    system,
+    model,
+    messages: [
+      { role: "user", content: prompt },
+    ],
+    maxTokens: 1200,
+  })
+
+  // We keep parsing light-touch to avoid coupling to a specific model.
+  // Heuristically split out sections from the returned text.
+  const suggestedIssueUpdateMarkdown = content.trim()
+
+  // Provide an extremely lightweight summary extraction as best-effort.
+  const summary = suggestedIssueUpdateMarkdown.split("\n")[0]?.slice(0, 240) ||
+    "Proposed updates based on PR comments."
+
+  return {
+    summary,
+    suggestedIssueUpdateMarkdown,
+  }
+}
+
+export default analyzePRAndProposeIssueUpdates
+


### PR DESCRIPTION
Summary
- Added a new workflow type analyzePRComments that analyzes a pull request and its comments to propose updates to the original issue.
- Core analysis is implemented in the shared package (clean architecture) as analyzePRAndProposeIssueUpdates depending only on LLMPort and plain data types.
- Introduced minimal GitHub PR ports (shared/src/core/ports/github-pr.ts) for future adapters without coupling to Next/Octokit.
- App-level wrapper lib/workflows/analyzePRComments.ts orchestrates fetching PR/issue data, invokes the shared analysis, posts a proposed update comment to the linked issue, and records workflow events in Neo4j.
- Extended workflowTypeEnum with "analyzePRComments".

Implementation details
- The shared service takes PR title/body, general + review comments, and issue context and returns a concise summary and a ready-to-post Markdown proposal of issue updates.
- The wrapper resolves the first linked issue using closing keywords via GitHub GraphQL, gathers general comments (REST) and review comments (GraphQL), and posts the result using createIssueComment.
- LLM integration uses the AnthropicAdapter (Claude 3.5 Sonnet) by default, but the shared service accepts a model string (e.g., "gpt-5") for extensibility.

Why this approach
- Keeps the reasoning/analysis logic in shared to be reusable (workers, web, CLI) and cleanly decoupled from GitHub/Next.js specifics.
- Keeps the effectful IO (GitHub API calls, event logging) in the app layer.

Notes
- ESLint import-order shows warnings (non-blocking); TypeScript checks pass.
- No UI trigger added in this PR; the workflow can be scheduled or called from an API route in a follow-up.

How to use
- From server-side code, call analyzePRCommentsWorkflow({ repoFullName, pullNumber, jobId?, anthropicApiKey? }) to run the analysis and post a comment back to the linked issue.


Closes #1044