### PR TITLE
Update hero section with new heading, image placeholder, and CTA

### DIFF
--- a/components/landing-page/AuthButton.tsx
+++ b/components/landing-page/AuthButton.tsx
@@ -23,13 +23,11 @@ export default function AuthButton() {
         <form action={signInWithGithub.bind(null, "/issues")}>
           <ShineButton className="text-base sm:text-lg px-4 sm:px-5 md:px-6 py-3 bg-accent text-accent-foreground hover:bg-accent/70">
             <Github size={20} />
-            Sign in with GitHub
+            Connect your code base to start
           </ShineButton>
         </form>
       )}
-      <p className="mt-3 text-sm text-stone-600 relative z-[1]">
-        {!isAuthenticated && "to start updating your code"}
-      </p>
     </>
   )
 }
+

--- a/components/landing-page/Hero.tsx
+++ b/components/landing-page/Hero.tsx
@@ -8,7 +8,7 @@ export default async function Hero() {
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.8 }}
-      className="relative text-center py-12 sm:py-16 md:py-20 px-4 sm:px-6 md:px-8 flex flex-col items-center overflow-hidden"
+      className="relative py-12 sm:py-16 md:py-20 px-4 sm:px-6 md:px-8 flex flex-col items-center overflow-hidden"
     >
       <motion.div
         animate={{
@@ -25,27 +25,61 @@ export default async function Hero() {
         initial={{ y: 20, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
         transition={{ duration: 0.5, delay: 0.2 }}
-        className="max-w-5xl mx-auto relative z-10"
+        className="max-w-6xl mx-auto relative z-10 w-full"
       >
-        <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl font-extrabold mb-3 sm:mb-6 md:mb-8 leading-tight">
-          <span>Update your code with natural language</span>
+        <h1 className="text-left sm:text-center text-5xl sm:text-6xl md:text-7xl font-extrabold mb-4 sm:mb-6 md:mb-8 leading-tight tracking-tight">
+          <span>Preview your ideas</span>
         </h1>
-        <p className="text-stone-600 text-sm sm:text-base md:text-lg mb-2 sm:mb-3 max-w-3xl mx-auto px-2 sm:px-4 md:px-5 w-full text-center leading-relaxed">
-          Issue To PR&#39;s background AI agents review your codebase, develop
-          an implementation plan, and create Pull Requests.
+        <p className="text-left sm:text-center text-stone-600 text-base sm:text-lg md:text-xl mb-4 sm:mb-6 max-w-3xl mx-auto px-0 sm:px-4 md:px-5 w-full leading-relaxed">
+          Automatically generate previews and PRs from every GitHub issue.
         </p>
       </motion.div>
 
       <motion.div
         initial={{ y: 20, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
-        transition={{ duration: 0.5, delay: 0.4 }}
-        className="mt-8 flex flex-col items-center"
+        transition={{ duration: 0.5, delay: 0.35 }}
+        className="mt-2 sm:mt-4 flex flex-col items-center relative z-10"
       >
         <div className="relative isolate">
           <AuthButton />
         </div>
       </motion.div>
+
+      {/* Visual placeholder under the CTA */}
+      <motion.div
+        initial={{ y: 20, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        transition={{ duration: 0.5, delay: 0.5 }}
+        className="relative z-0 mt-10 sm:mt-14 md:mt-16 w-full max-w-5xl px-0 sm:px-4"
+        aria-hidden
+      >
+        {/* Speech bubble */}
+        <div className="mb-3 sm:mb-4 md:mb-6 max-w-lg text-left mx-0 sm:mx-auto">
+          <div className="inline-block bg-white/70 dark:bg-neutral-900/70 backdrop-blur rounded-2xl px-4 py-3 shadow-sm ring-1 ring-black/5">
+            <p className="text-sm sm:text-base text-neutral-800 dark:text-neutral-200">
+              “Give me a jazzy blue background.”
+            </p>
+          </div>
+        </div>
+        {/* Browser window mock */}
+        <div className="rounded-2xl border border-neutral-200 dark:border-neutral-800 overflow-hidden shadow-sm bg-white/50 dark:bg-neutral-900/40">
+          {/* Window header */}
+          <div className="flex items-center gap-2 px-3 py-2 border-b border-neutral-200 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-900/60">
+            <span className="h-3 w-3 rounded-full bg-red-400" />
+            <span className="h-3 w-3 rounded-full bg-yellow-400" />
+            <span className="h-3 w-3 rounded-full bg-green-400" />
+            <div className="ml-3 h-5 flex-1 rounded bg-neutral-200/70 dark:bg-neutral-800/70" />
+          </div>
+          {/* Window content that responds to the prompt */}
+          <div className="min-h-[220px] sm:min-h-[280px] md:min-h-[360px] bg-blue-600/80 flex items-center justify-center">
+            <div className="text-white/95 text-xl sm:text-2xl md:text-3xl font-semibold">
+              Jazzy Blue Background
+            </div>
+          </div>
+        </div>
+      </motion.div>
     </motion.section>
   )
 }
+


### PR DESCRIPTION
This PR updates the landing page hero section to match the new design and copy requirements:

- Headline: Changed to “Preview your ideas”. On mobile it is left-aligned with larger typography (text-5xl on mobile, scaling up to text-7xl on desktop).
- Subheader: Updated to “Automatically generate previews and PRs from every GitHub issue.” and left-aligned on mobile.
- Visual placeholder: Added a simple browser-window mock with a speech bubble (“Give me a jazzy blue background.”) and a jazzy blue content area to indicate the preview concept.
- CTA: The unauthenticated call-to-action button now reads “Connect your code base to start” with a GitHub logo on the left. The authenticated state still shows “Go to issues”.

Implementation details:
- Edited components/landing-page/Hero.tsx to update layout, copy, alignment, and add the visual placeholder.
- Updated components/landing-page/AuthButton.tsx to change the unauthenticated CTA label and include the GitHub icon to the left of the text.

Notes:
- Kept the previous animated background and motion effects.
- Maintained responsive spacing and typography using Tailwind classes.
- Linted the project; no errors, only unrelated warnings remain.

If you want the CTA text to always be the same (even when authenticated), I can update the authenticated label as well.

Closes #1049