### PR TITLE
Add Benefits section to landing page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from "@/auth"
 import IssueDashboard from "@/components/home/IssueDashboard"
 import AgentArchitecture from "@/components/landing-page/AgentArchitecture"
+import Benefits from "@/components/landing-page/Benefits"
 import ComparisonToIDEAgents from "@/components/landing-page/ComparisonToIDEAgents"
 import Features from "@/components/landing-page/Features"
 import Footer from "@/components/landing-page/Footer"
@@ -35,6 +36,7 @@ export default async function LandingPage() {
           <AgentArchitecture />
           <PlanningFeature />
           <Steps />
+          <Benefits />
           <Features />
           <ComparisonToIDEAgents />
           <Pricing />
@@ -45,3 +47,4 @@ export default async function LandingPage() {
     </div>
   )
 }
+

--- a/components/landing-page/Benefits.tsx
+++ b/components/landing-page/Benefits.tsx
@@ -1,0 +1,75 @@
+import { CheckCircle2 } from "lucide-react"
+import * as motion from "motion/react-client"
+import React from "react"
+
+import TextLg from "@/components/ui/text-lg"
+
+const benefits: { title: string; description: string }[] = [
+  {
+    title: "Automatic first‑pass PRs for each issue",
+    description:
+      "Our agents turn every issue into an initial pull request so you can review concrete changes fast.",
+  },
+  {
+    title: "Surface unclear requirements early",
+    description:
+      "PRs and previews highlight missing details and assumptions before work goes too far.",
+  },
+  {
+    title: "30% of PRs merge as‑is",
+    description:
+      "A meaningful share of first‑pass PRs are merged without further edits—speed without sacrificing quality.",
+  },
+  {
+    title: "Cut resolution time by 50%",
+    description:
+      "Automated planning, search, and change generation reduce time spent per issue by half.",
+  },
+  {
+    title: "Preview how an agent would solve a task",
+    description:
+      "See the proposed plan and diffs up‑front—keep control while moving faster.",
+  },
+  {
+    title: "Smart research to find relevant files",
+    description:
+      "Agents scan your repo to identify impacted files, references, and context before writing code.",
+  },
+]
+
+export default function Benefits() {
+  return (
+    <section className="relative py-14 px-5 bg-white border-t-2 border-black flex flex-col items-center">
+      <TextLg className="text-center max-w-5xl">
+        <span className="block sm:inline">Have a large list of tasks</span>{" "}
+        <span className="block sm:inline">and don&apos;t know how to get started?</span>
+      </TextLg>
+
+      <p className="text-muted-foreground text-base sm:text-lg max-w-3xl text-center">
+        HTTPR turns your backlog into momentum—making it easy to start, review, and ship.
+      </p>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8 max-w-6xl w-full mt-10">
+        {benefits.map((b, idx) => (
+          <motion.div
+            key={`benefit-${idx}`}
+            initial={{ opacity: 0, y: 16 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, margin: "-50px" }}
+            transition={{ duration: 0.5, ease: "easeOut", delay: 0.05 * (idx % 3) }}
+            className="group relative rounded-xl border-2 border-black/10 bg-gradient-to-br from-white to-transparent p-6 hover:border-black/20 transition-colors"
+          >
+            <div className="flex items-start gap-4">
+              <CheckCircle2 className="h-6 w-6 text-accent mt-1 shrink-0" />
+              <div>
+                <h3 className="text-lg font-semibold leading-snug">{b.title}</h3>
+                <p className="mt-2 text-sm text-muted-foreground">{b.description}</p>
+              </div>
+            </div>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  )
+}
+


### PR DESCRIPTION
This PR adds a new Benefits section to the marketing landing page to clearly communicate the value of HTTPR for teams with large backlogs.

What’s included
- New component: components/landing-page/Benefits.tsx
  - Section headline: “Have a large list of tasks and don't know how to get started?”
  - Professional grid layout with concise benefit cards and subtle motion
  - Points covered:
    - Automatic first‑pass PRs for each issue
    - PRs and previews highlight unclear requirements
    - 30% of PRs merge without further modifications
    - 50% decrease in time spent resolving issues
    - Preview how an agent would solve a task
    - Agent does initial research to identify relevant files
- Landing integration: app/page.tsx now includes <Benefits /> after Steps and before Features
- Import order aligned with repo ESLint rules (simple-import-sort)

Quality checks
- Type check: pnpm lint:tsc (passed)
- ESLint: pnpm lint:eslint (passed; unrelated warnings remain unchanged)

This section aligns with the existing design system (TextLg, motion, Tailwind) and keeps a consistent visual rhythm with other sections. Let me know if you prefer a different position in the flow (e.g., immediately after Hero).

Closes #1050