### PR TITLE
Add landing page section for non-developers (PM-friendly benefits)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import Features from "@/components/landing-page/Features"
 import Footer from "@/components/landing-page/Footer"
 import GetStarted from "@/components/landing-page/GetStarted"
 import Hero from "@/components/landing-page/Hero"
+import NonDeveloperBenefits from "@/components/landing-page/NonDeveloperBenefits"
 import PlanningFeature from "@/components/landing-page/PlanningFeature"
 import Pricing from "@/components/landing-page/Pricing"
 import Steps from "@/components/landing-page/Steps"
@@ -36,6 +37,7 @@ export default async function LandingPage() {
           <PlanningFeature />
           <Steps />
           <Features />
+          <NonDeveloperBenefits />
           <ComparisonToIDEAgents />
           <Pricing />
           <GetStarted />
@@ -45,3 +47,4 @@ export default async function LandingPage() {
     </div>
   )
 }
+

--- a/components/landing-page/NonDeveloperBenefits.tsx
+++ b/components/landing-page/NonDeveloperBenefits.tsx
@@ -1,0 +1,76 @@
+import { GitPullRequest, Rocket, Share2, ShieldCheck, SquareDashedBottomCode } from "lucide-react"
+import * as motion from "motion/react-client"
+import React from "react"
+
+import TextLg from "@/components/ui/text-lg"
+
+const points = [
+  {
+    icon: GitPullRequest,
+    title: "Preview builds for every PR",
+    description:
+      "Each pull request comes with its own preview build you can open in the browser and review end‑to‑end.",
+  },
+  {
+    icon: Rocket,
+    title: "Iterate on ideas in parallel",
+    description:
+      "Test multiple directions at once, compare options side‑by‑side, and move faster with evidence, not guesswork.",
+  },
+  {
+    icon: Share2,
+    title: "Share links for instant feedback",
+    description:
+      "Send a preview URL to teammates or stakeholders—no local setup, no installs, just click and try.",
+  },
+  {
+    icon: ShieldCheck,
+    title: "Safe by design",
+    description:
+      "Previews are isolated from production and can be turned off anytime, keeping your main app safe.",
+  },
+]
+
+export default function NonDeveloperBenefits() {
+  return (
+    <section className="relative py-14 px-5 bg-white border-t-2 border-black flex flex-col items-center">
+      <TextLg className="text-center max-w-4xl">
+        <span className="block sm:inline">Want to preview an app idea</span>{" "}
+        <span className="block sm:inline italic text-accent">without relying on developers?</span>
+      </TextLg>
+
+      <p className="text-muted-foreground text-lg md:text-xl text-center max-w-3xl mt-4">
+        Explore feature ideas, validate flows, and collect feedback using reviewable preview builds—no code required.
+      </p>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-5xl w-full mt-10">
+        {points.map((p, idx) => (
+          <motion.div
+            key={`ndb-${idx}`}
+            initial={{ opacity: 0, y: 12 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.45, ease: "easeOut", delay: 0.05 * idx }}
+            className="rounded-xl border-2 border-black/10 bg-gradient-to-br from-white/60 to-transparent p-5 hover:border-black/20 transition-colors"
+          >
+            <div className="flex items-start gap-4">
+              <div className="mt-1 shrink-0 rounded-lg bg-accent/10 text-accent p-2">
+                {React.createElement(p.icon, { className: "w-5 h-5" })}
+              </div>
+              <div>
+                <h3 className="text-xl font-semibold mb-1">{p.title}</h3>
+                <p className="text-muted-foreground">{p.description}</p>
+              </div>
+            </div>
+          </motion.div>
+        ))}
+      </div>
+
+      <div className="mt-8 text-sm text-muted-foreground flex items-center gap-2">
+        <SquareDashedBottomCode className="w-4 h-4" />
+        <span>Every preview is tied to a plan and PR for full traceability.</span>
+      </div>
+    </section>
+  )
+}
+


### PR DESCRIPTION
Summary
- Added a new NonDeveloperBenefits section to the landing page to highlight value for product managers and non-developers.
- Integrated the section into app/page.tsx after the Features area and before the ComparisonToIDEAgents section.

Details
- Title copy: "Want to preview an app idea without relying on developers?"
- Key points:
  - Each pull request comes with its own preview build that you can review.
  - Iterate further and faster by testing many ideas in parallel.
  - Share preview links for instant feedback—no installs or local setup.
  - Safe by design: previews are isolated from production and can be turned off.
- Clean, professional layout using existing design tokens/components (TextLg, lucide-react icons, motion transitions).

Files Changed
- components/landing-page/NonDeveloperBenefits.tsx (new)
- app/page.tsx (import and render new section)

Notes
- Linted with `pnpm lint:eslint`; only warnings in unrelated files.
- The content and layout follow the existing landing page style to ensure visual consistency.

Screenshots/Preview
- Section appears under Features and above the IDE comparison, with a 2-column card grid of benefits and a subtle traceability note at the bottom.


Closes #1051