### PR TITLE
Extract hero section diagram into reusable WebsitePreview with navbar

### DIFF
--- a/components/landing-page/Hero.tsx
+++ b/components/landing-page/Hero.tsx
@@ -1,6 +1,7 @@
 import * as motion from "motion/react-client"
 
 import AuthButton from "@/components/landing-page/AuthButton"
+import WebsitePreview from "@/components/landing-page/WebsitePreview"
 
 export default async function Hero() {
   return (
@@ -51,22 +52,8 @@ export default async function Hero() {
             </p>
           </div>
         </div>
-        {/* Browser window mock */}
-        <div className="rounded-2xl border border-neutral-200 dark:border-neutral-800 overflow-hidden shadow-sm bg-white/50 dark:bg-neutral-900/40">
-          {/* Window header */}
-          <div className="flex items-center gap-2 px-3 py-2 border-b border-neutral-200 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-900/60">
-            <span className="h-3 w-3 rounded-full bg-red-400" />
-            <span className="h-3 w-3 rounded-full bg-yellow-400" />
-            <span className="h-3 w-3 rounded-full bg-green-400" />
-            <div className="ml-3 h-5 flex-1 rounded bg-neutral-200/70 dark:bg-neutral-800/70" />
-          </div>
-          {/* Window content that responds to the prompt */}
-          <div className="min-h-[220px] sm:min-h-[280px] md:min-h-[360px] bg-blue-600/80 flex items-center justify-center">
-            <div className="text-white/95 text-xl sm:text-2xl md:text-3xl font-semibold">
-              Your Website
-            </div>
-          </div>
-        </div>
+        {/* Website preview diagram */}
+        <WebsitePreview />
       </motion.div>
       <motion.div
         initial={{ y: 20, opacity: 0 }}
@@ -81,3 +68,4 @@ export default async function Hero() {
     </motion.section>
   )
 }
+

--- a/components/landing-page/WebsitePreview.tsx
+++ b/components/landing-page/WebsitePreview.tsx
@@ -1,0 +1,77 @@
+import React from "react"
+
+interface WebsitePreviewProps {
+  className?: string
+}
+
+// A simple, reusable mock website preview with a navbar and hero content.
+// Designed for the landing page hero but reusable elsewhere.
+export default function WebsitePreview({ className = "" }: WebsitePreviewProps) {
+  return (
+    <div className={`rounded-2xl border border-neutral-200 dark:border-neutral-800 overflow-hidden shadow-sm bg-white/50 dark:bg-neutral-900/40 ${className}`}>
+      {/* Window header */}
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-neutral-200 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-900/60">
+        <span className="h-3 w-3 rounded-full bg-red-400" />
+        <span className="h-3 w-3 rounded-full bg-yellow-400" />
+        <span className="h-3 w-3 rounded-full bg-green-400" />
+        <div className="ml-3 h-5 flex-1 rounded bg-neutral-200/70 dark:bg-neutral-800/70" />
+      </div>
+
+      {/* Mock website content */}
+      <div className="relative min-h-[220px] sm:min-h-[280px] md:min-h-[360px] overflow-hidden">
+        {/* Background */}
+        <div className="absolute inset-0 bg-gradient-to-br from-sky-600 via-blue-700 to-indigo-800" />
+
+        {/* Navbar */}
+        <div className="relative z-10">
+          <div className="mx-auto max-w-5xl px-4">
+            <div className="mt-4 md:mt-5 flex items-center justify-between rounded-full border border-white/15 bg-white/10 backdrop-blur shadow-sm px-3 py-2 text-white">
+              {/* Left: logo + brand */}
+              <div className="flex items-center gap-2">
+                <div className="h-6 w-6 rounded bg-white/90" aria-hidden />
+                <span className="hidden sm:inline text-sm font-semibold tracking-wide">Acme</span>
+              </div>
+
+              {/* Center: nav links */}
+              <nav className="hidden md:flex items-center gap-4 text-sm">
+                <span className="text-white/90">Home</span>
+                <span className="text-white/70">Projects</span>
+                <span className="text-white/70">About</span>
+                <span className="text-white/70">Contact</span>
+              </nav>
+
+              {/* Right: action */}
+              <div>
+                <button className="text-xs sm:text-sm font-medium rounded-full border border-white/20 bg-white/10 px-3 py-1.5 text-white/90 hover:bg-white/15 transition">Resume</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Hero content */}
+        <div className="relative z-10 flex h-full items-center justify-center">
+          <div className="mx-auto max-w-3xl px-6 py-10 sm:py-12 md:py-16 text-center">
+            <h3 className="text-white/95 text-2xl sm:text-3xl md:text-4xl font-extrabold tracking-tight">
+              Build. Ship. Repeat.
+            </h3>
+            <p className="mt-3 text-white/80 text-sm sm:text-base md:text-lg">
+              I craft delightful web experiences with great UX and strong engineering.
+            </p>
+            <div className="mt-5 flex items-center justify-center gap-3">
+              <button className="rounded-md bg-white/95 text-slate-900 text-xs sm:text-sm font-semibold px-3 sm:px-4 py-1.5 sm:py-2 shadow hover:bg-white">
+                View Work
+              </button>
+              <button className="rounded-md border border-white/30 text-white/95 text-xs sm:text-sm font-semibold px-3 sm:px-4 py-1.5 sm:py-2 hover:bg-white/10">
+                Contact
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* Decorative gradient flare */}
+        <div className="absolute -bottom-20 right-10 h-40 w-40 rounded-full bg-cyan-400/40 blur-2xl" aria-hidden />
+      </div>
+    </div>
+  )
+}
+


### PR DESCRIPTION
Summary
- Extracted the browser window mock in the landing page Hero into a new reusable component: WebsitePreview.
- Added a portfolio-style navbar (logo, links, action) and hero content so the diagram looks more like a real web page.
- Replaced the inline mock in Hero with the new component. The component is co-located in components/landing-page as it’s primarily used there.

Details
- New component: components/landing-page/WebsitePreview.tsx
  - Includes window chrome (traffic lights), a translucent navbar, and hero text with buttons.
  - Uses Tailwind classes already used across the project for consistent styling.
- Updated components/landing-page/Hero.tsx to import and render WebsitePreview in place of the previous inline layout.

Why
- Makes the hero diagram reusable and easier to iterate on.
- Aligns the visual with the request to look more like a generic portfolio website, including a navigation bar and hero headings.

Notes
- No behavior changes outside of the visual layout.
- Linting passes with only existing warnings unrelated to these files.

Closes #1061