### PR TITLE
Add workflow and UI to detect and resolve PR merge conflicts

### DIFF
--- a/app/api/resolve-merge-conflicts/route.ts
+++ b/app/api/resolve-merge-conflicts/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server"
+import { v4 as uuidv4 } from "uuid"
+
+import { resolveMergeConflicts } from "@/lib/workflows/resolveMergeConflicts"
+
+export async function POST(request: NextRequest) {
+  try {
+    const { repoFullName, pullNumber } = await request.json()
+
+    if (!repoFullName || typeof pullNumber !== "number") {
+      return NextResponse.json(
+        { error: "repoFullName and pullNumber are required" },
+        { status: 400 }
+      )
+    }
+
+    const jobId = uuidv4()
+
+    // Kick off workflow asynchronously
+    resolveMergeConflicts({
+      repoFullName,
+      pullNumber,
+      apiKey: process.env.OPENAI_API_KEY!,
+      jobId,
+    }).catch(console.error)
+
+    return NextResponse.json({ jobId })
+  } catch (error) {
+    console.error("Failed to start resolve-merge-conflicts:", error)
+    return NextResponse.json(
+      { error: `Failed to start resolve-merge-conflicts: ${String(error)}` },
+      { status: 500 }
+    )
+  }
+}
+

--- a/components/pull-requests/controllers/ResolveMergeConflictsController.tsx
+++ b/components/pull-requests/controllers/ResolveMergeConflictsController.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import { toast } from "@/lib/hooks/use-toast"
+
+interface Props {
+  repoFullName: string
+  pullNumber: number
+  onStart: () => void
+  onComplete: () => void
+  onError: () => void
+}
+
+export default function ResolveMergeConflictsController({
+  repoFullName,
+  pullNumber,
+  onStart,
+  onComplete,
+  onError,
+}: Props) {
+  const execute = async () => {
+    try {
+      onStart()
+      const res = await fetch("/api/resolve-merge-conflicts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ repoFullName, pullNumber }),
+      })
+      if (!res.ok) throw new Error("Failed to start merge conflict resolver")
+      toast({
+        title: "Conflict resolution started",
+        description:
+          "We'll analyze the PR and attempt to resolve merge conflicts automatically.",
+      })
+      onComplete()
+    } catch (err) {
+      toast({
+        title: "Failed to start",
+        description: err instanceof Error ? err.message : String(err),
+        variant: "destructive",
+      })
+      onError()
+    }
+  }
+
+  return { execute }
+}
+

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -42,6 +42,7 @@ export const workflowTypeEnum = z.enum([
   "identifyPRGoal",
   "reviewPullRequest",
   "alignmentCheck",
+  "resolveMergeConflicts",
 ])
 
 export const workflowRunSchema = z.object({
@@ -324,3 +325,4 @@ export type WorkflowRun = z.infer<typeof workflowRunSchema>
 export type WorkflowRunState = z.infer<typeof workflowRunStateSchema>
 export type WorkflowStateEvent = z.infer<typeof workflowStateEventSchema>
 export type WorkflowType = z.infer<typeof workflowTypeEnum>
+

--- a/lib/workflows/resolveMergeConflicts.ts
+++ b/lib/workflows/resolveMergeConflicts.ts
@@ -1,0 +1,198 @@
+import { PlanAndCodeAgent } from "@/lib/agents/PlanAndCodeAgent"
+import { getRepoFromString } from "@/lib/github/content"
+import {
+  getLinkedIssuesForPR,
+  getPullRequest,
+  getPullRequestComments,
+  getPullRequestDiff,
+} from "@/lib/github/pullRequests"
+import { getInstallationTokenFromRepo } from "@/lib/github/installation"
+import { langfuse } from "@/lib/langfuse"
+import {
+  createErrorEvent,
+  createStatusEvent,
+  createWorkflowStateEvent,
+} from "@/lib/neo4j/services/event"
+import { initializeWorkflowRun } from "@/lib/neo4j/services/workflow"
+import { createContainerizedWorkspace } from "@/lib/utils/container"
+import { setupLocalRepository } from "@/lib/utils/utils-server"
+import { RepoEnvironment } from "@/lib/types"
+import { getIssue } from "@/lib/github/issues"
+import { execInContainer } from "@/lib/docker"
+
+interface ResolveMergeConflictsParams {
+  repoFullName: string
+  pullNumber: number
+  apiKey: string
+  jobId: string
+}
+
+export async function resolveMergeConflicts({
+  repoFullName,
+  pullNumber,
+  apiKey,
+  jobId,
+}: ResolveMergeConflictsParams) {
+  const workflowId = jobId
+
+  let containerCleanup: (() => Promise<void>) | null = null
+
+  try {
+    await initializeWorkflowRun({
+      id: workflowId,
+      type: "resolveMergeConflicts",
+      repoFullName,
+    })
+
+    await createWorkflowStateEvent({ workflowId, state: "running" })
+
+    await createStatusEvent({
+      workflowId,
+      content: `Fetching PR #${pullNumber} details for ${repoFullName}`,
+    })
+
+    const repo = await getRepoFromString(repoFullName)
+    const pr = await getPullRequest({ repoFullName, pullNumber })
+
+    // If PR is mergeable and clean, no conflicts to resolve
+    if (pr.mergeable && pr.mergeable_state === "clean") {
+      await createStatusEvent({
+        workflowId,
+        content: `No merge conflicts detected for PR #${pullNumber}. mergeable_state=${pr.mergeable_state}`,
+      })
+      await createWorkflowStateEvent({ workflowId, state: "completed" })
+      return
+    }
+
+    // Fetch linked issue (first one if any)
+    const linkedIssues = await getLinkedIssuesForPR({
+      repoFullName,
+      pullNumber,
+    })
+
+    let linkedIssueBody = ""
+    if (linkedIssues.length > 0) {
+      const issueNum = linkedIssues[0]
+      const issue = await getIssue({ fullName: repoFullName, issueNumber: issueNum })
+      if (issue.type === "success") {
+        linkedIssueBody = `Linked Issue #${issueNum}: ${issue.issue.title}\n\n${issue.issue.body || ""}`
+      }
+    }
+
+    const comments = await getPullRequestComments({ repoFullName, pullNumber })
+    const diff = await getPullRequestDiff({ repoFullName, pullNumber })
+
+    // Prepare local+container workspace on PR branch
+    await createStatusEvent({
+      workflowId,
+      content: `Setting up repository workspace on branch ${pr.head.ref}`,
+    })
+
+    const hostRepoPath = await setupLocalRepository({
+      repoFullName,
+      workingBranch: pr.head.ref,
+    })
+
+    const { containerName, cleanup } = await createContainerizedWorkspace({
+      repoFullName,
+      branch: pr.head.ref,
+      workflowId,
+      hostRepoPath,
+    })
+    containerCleanup = cleanup
+
+    const env: RepoEnvironment = { kind: "container", name: containerName }
+
+    // Attempt to merge main into the PR branch inside container to surface conflicts
+    await createStatusEvent({
+      workflowId,
+      content: `Attempting to merge origin/${repo.default_branch} into ${pr.head.ref} to surface conflicts...`,
+    })
+
+    await execInContainer({ name: containerName, command: "git fetch origin" })
+    const mergeResult = await execInContainer({
+      name: containerName,
+      command: `git merge origin/${repo.default_branch} || true`,
+    })
+
+    await createStatusEvent({
+      workflowId,
+      content: `Git merge exitCode=${mergeResult.exitCode}. stderr: ${mergeResult.stderr?.slice(0, 500) || ""}`,
+    })
+
+    // List files with conflict markers
+    const grepResult = await execInContainer({
+      name: containerName,
+      command: `git ls-files -u | awk '{print $4}' | sort -u`,
+    })
+
+    const conflictedFiles = grepResult.stdout
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean)
+
+    await createStatusEvent({
+      workflowId,
+      content: conflictedFiles.length
+        ? `Conflicted files detected: \n${conflictedFiles.join("\n")}`
+        : `No conflicted files detected by git (mergeable_state was ${pr.mergeable_state}). Proceeding with agent-based resolution if needed.`,
+    })
+
+    // Prepare agent to resolve conflicts
+    const [owner, repoName] = repoFullName.split("/")
+    const sessionToken = await getInstallationTokenFromRepo({ owner, repo: repoName })
+
+    const trace = langfuse.trace({ name: "Resolve merge conflicts" })
+    const span = trace.span({ name: "resolve_merge_conflicts" })
+
+    const agent = new PlanAndCodeAgent({
+      apiKey,
+      env,
+      defaultBranch: repo.default_branch,
+      repository: repo,
+      sessionToken: sessionToken || undefined,
+      model: "gpt-5",
+    })
+    await agent.addJobId(workflowId)
+    agent.addSpan({ span, generationName: "resolve_merge_conflicts" })
+
+    // Provide detailed context and instructions
+    const contextMessage = `You are tasked with resolving merge conflicts for this pull request so it can be merged cleanly into ${repo.default_branch}.
+
+PR Title: ${pr.title}
+PR Body:\n${pr.body || "(no description)"}
+
+${linkedIssueBody ? linkedIssueBody + "\n\n" : ""}Diff (against base):\n${diff}
+
+Comments (${comments.length}):\n${comments.map((c) => `- ${c.user?.login}: ${c.body}`).join("\n")}
+
+Current branch: ${pr.head.ref}
+Base branch: ${repo.default_branch}
+GitHub indicated mergeable_state='${pr.mergeable_state}'. We attempted a local merge; conflicted files reported by git:\n${conflictedFiles.join(", ") || "(none)"}
+
+Instructions:
+- Use the codebase tools to open and edit files containing conflict markers like '<<<<<<<', '=======', '>>>>>>>' and resolve them in line with the PR intent and the linked issue context.
+- Make minimal, correct changes that preserve both sides' intentional logic where appropriate.
+- After resolving, stage and commit your changes with a message like "Resolve merge conflicts for PR #${pullNumber}".
+- Finally, push the branch using the sync_branch_to_remote tool with branch='${pr.head.ref}'.
+- Do not open a new pull request; update the existing branch.
+`
+
+    await agent.addMessage({ role: "user", content: contextMessage })
+
+    await createStatusEvent({ workflowId, content: "Starting agent to resolve conflicts" })
+
+    await agent.runWithFunctions()
+
+    await createWorkflowStateEvent({ workflowId, state: "completed" })
+  } catch (error) {
+    await createErrorEvent({ workflowId, content: String(error) })
+    await createWorkflowStateEvent({ workflowId, state: "error", content: String(error) })
+    throw error
+  } finally {
+    if (containerCleanup) {
+      await containerCleanup()
+    }
+  }
+}
+


### PR DESCRIPTION
Summary
- Adds a new resolveMergeConflicts workflow that identifies merge conflicts for a pull request and attempts to resolve them automatically using our PlanAndCodeAgent.
- Introduces a new API endpoint: POST /api/resolve-merge-conflicts to trigger the workflow.
- Enhances the Pull Requests table UI to detect and display merge conflict status with a badge, and exposes a “Resolve Merge Conflicts” action when appropriate.
- Extends the workflow type enum to include 'resolveMergeConflicts'.

Details
Workflow (lib/workflows/resolveMergeConflicts.ts)
- Initializes a workflow run, fetches PR details, diff, comments, and linked issues.
- Sets up a containerized workspace on the PR branch and performs a best‑effort `git merge origin/<default_branch>` to surface conflicts.
- Logs any conflicted files and instructs the PlanAndCodeAgent to resolve conflict markers, commit, and push to the PR branch using SyncBranchTool.
- Uses the GitHub App installation token to push back to the branch; does not create a new PR.

API
- app/api/resolve-merge-conflicts/route.ts: Starts the workflow asynchronously and returns a jobId.

UI
- components/pull-requests/PullRequestRow.tsx:
  - Fetches mergeable_state for each PR using /api/github/fetch.
  - Shows a red “Merge conflicts” badge when mergeable_state === 'dirty'.
  - Adds a dropdown action to start the new conflict resolution workflow.
- New controller at components/pull-requests/controllers/ResolveMergeConflictsController.tsx.

Types
- lib/types/index.ts: Added 'resolveMergeConflicts' to workflowType enum.

Notes
- GitHub’s REST API does not expose detailed conflict messages; we use mergeable_state and a local merge attempt to enumerate conflicted files for the agent.
- The agent receives PR title/body, linked issue context (if any), full diff, comments, and the list of conflicted files.

This should provide an end-to-end UX where users can see PRs with merge conflicts and trigger an automated resolution workflow aligned with the linked issue context.

Closes #1066