### PR TITLE
Add resolve-merge-conflicts workflow and PR UI indicator/action

### DIFF
--- a/app/api/workflow/resolve-merge-conflicts/route.ts
+++ b/app/api/workflow/resolve-merge-conflicts/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server"
+import { v4 as uuidv4 } from "uuid"
+
+import { getUserOpenAIApiKey } from "@/lib/neo4j/services/user"
+import { resolveMergeConflicts } from "@/lib/workflows/resolveMergeConflicts"
+
+export async function POST(request: NextRequest) {
+  try {
+    const { repoFullName, pullNumber } = (await request.json()) as {
+      repoFullName: string
+      pullNumber: number
+    }
+
+    if (!repoFullName || !pullNumber) {
+      return NextResponse.json(
+        { error: "Missing repoFullName or pullNumber" },
+        { status: 400 }
+      )
+    }
+
+    const apiKey = await getUserOpenAIApiKey()
+    if (!apiKey) {
+      return NextResponse.json(
+        { error: "Missing OpenAI API key" },
+        { status: 401 }
+      )
+    }
+
+    const jobId = uuidv4()
+
+    // Run in background
+    ;(async () => {
+      try {
+        await resolveMergeConflicts({ repoFullName, pullNumber, apiKey, jobId })
+      } catch (err) {
+        console.error("resolve-merge-conflicts workflow error:", err)
+      }
+    })()
+
+    return NextResponse.json({ jobId })
+  } catch (error) {
+    console.error("Failed to start resolve-merge-conflicts:", error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Unknown error" },
+      { status: 500 }
+    )
+  }
+}
+

--- a/components/pull-requests/PullRequestRow.tsx
+++ b/components/pull-requests/PullRequestRow.tsx
@@ -1,13 +1,15 @@
 "use client"
 
 import { formatDistanceToNow } from "date-fns"
-import { ChevronDown, Loader2, PlayCircle } from "lucide-react"
+import { AlertTriangle, ChevronDown, GitMerge, Loader2, PlayCircle } from "lucide-react"
 import Link from "next/link"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
 import AlignmentCheckController from "@/components/pull-requests/controllers/AlignmentCheckController"
 import AnalyzePRController from "@/components/pull-requests/controllers/AnalyzePRController"
+import ResolveMergeConflictsController from "@/components/pull-requests/controllers/ResolveMergeConflictsController"
 import ReviewPRController from "@/components/pull-requests/controllers/ReviewPRController"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -21,6 +23,30 @@ import { PullRequest } from "@/lib/types/github"
 export default function PullRequestRow({ pr }: { pr: PullRequest }) {
   const [isLoading, setIsLoading] = useState(false)
   const [activeWorkflow, setActiveWorkflow] = useState<string | null>(null)
+  const [mergeableState, setMergeableState] = useState<string | null>(null)
+
+  useEffect(() => {
+    // Fetch mergeability for this PR (list API doesn't include it)
+    const fetchMergeable = async () => {
+      try {
+        const res = await fetch("/api/github/fetch", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ type: "pull", number: pr.number, fullName: pr.head.repo.full_name }),
+        })
+        if (res.ok) {
+          const data = await res.json()
+          if (data && typeof data.mergeable_state === "string") {
+            setMergeableState(data.mergeable_state)
+          }
+        }
+      } catch (e) {
+        // Ignore silently for badge; table remains usable
+      }
+    }
+    fetchMergeable()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pr.number, pr.head.repo.full_name])
 
   const analyzeWorkflow = AnalyzePRController({
     repoFullName: pr.head.repo.full_name,
@@ -73,11 +99,30 @@ export default function PullRequestRow({ pr }: { pr: PullRequest }) {
     },
   })
 
+  const resolveMergeConflictsWorkflow = ResolveMergeConflictsController({
+    repoFullName: pr.head.repo.full_name,
+    pullNumber: pr.number,
+    onStart: () => {
+      setIsLoading(true)
+      setActiveWorkflow("Resolving conflicts...")
+    },
+    onComplete: () => {
+      setIsLoading(false)
+      setActiveWorkflow(null)
+    },
+    onError: () => {
+      setIsLoading(false)
+      setActiveWorkflow(null)
+    },
+  })
+
+  const hasConflict = mergeableState === "dirty"
+
   return (
     <TableRow>
       <TableCell className="py-4">
         <div className="flex flex-col gap-1">
-          <div className="font-medium text-base">
+          <div className="font-medium text-base flex items-center gap-2">
             <Link
               href={`https://github.com/${pr.head.repo.full_name}/pull/${pr.number}`}
               target="_blank"
@@ -86,6 +131,11 @@ export default function PullRequestRow({ pr }: { pr: PullRequest }) {
             >
               {pr.title}
             </Link>
+            {hasConflict ? (
+              <Badge variant="destructive" className="flex items-center gap-1">
+                <AlertTriangle size={14} /> Conflict
+              </Badge>
+            ) : null}
           </div>
           <div className="text-sm text-muted-foreground flex items-center gap-2">
             <span>#{pr.number}</span>
@@ -126,7 +176,7 @@ export default function PullRequestRow({ pr }: { pr: PullRequest }) {
               )}
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-[220px]">
+          <DropdownMenuContent align="end" className="w-[260px]">
             <DropdownMenuItem onClick={reviewWorkflow.execute}>
               <div>
                 <div>Review Pull Request</div>
@@ -151,9 +201,23 @@ export default function PullRequestRow({ pr }: { pr: PullRequest }) {
                 </div>
               </div>
             </DropdownMenuItem>
+            <DropdownMenuItem onClick={resolveMergeConflictsWorkflow.execute} disabled={!hasConflict}>
+              <div className="flex items-start gap-2">
+                <GitMerge className="mt-0.5 h-4 w-4" />
+                <div>
+                  <div>{hasConflict ? "Resolve Merge Conflicts" : "No Conflicts Detected"}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {hasConflict
+                      ? "Gather context and attempt to auto-resolve conflicts"
+                      : "This PR currently has no reported conflicts with base"}
+                  </div>
+                </div>
+              </div>
+            </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       </TableCell>
     </TableRow>
   )
 }
+

--- a/components/pull-requests/controllers/ResolveMergeConflictsController.tsx
+++ b/components/pull-requests/controllers/ResolveMergeConflictsController.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import { toast } from "@/lib/hooks/use-toast"
+
+interface Props {
+  repoFullName: string
+  pullNumber: number
+  onStart: () => void
+  onComplete: () => void
+  onError: () => void
+}
+
+export default function ResolveMergeConflictsController({
+  repoFullName,
+  pullNumber,
+  onStart,
+  onComplete,
+  onError,
+}: Props) {
+  const execute = async () => {
+    try {
+      onStart()
+
+      const response = await fetch("/api/workflow/resolve-merge-conflicts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ repoFullName, pullNumber }),
+      })
+
+      if (!response.ok) {
+        throw new Error("Failed to start resolve-merge-conflicts workflow")
+      }
+
+      toast({
+        title: "Resolve Merge Conflicts started",
+        description:
+          "The workflow to analyze and resolve merge conflicts has started.",
+      })
+      onComplete()
+    } catch (error) {
+      toast({
+        title: "Failed to start workflow",
+        description:
+          error instanceof Error ? error.message : "An unexpected error occurred",
+        variant: "destructive",
+      })
+      onError()
+      console.error("ResolveMergeConflicts failed: ", error)
+    }
+  }
+
+  return { execute }
+}
+

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -42,6 +42,8 @@ export const workflowTypeEnum = z.enum([
   "identifyPRGoal",
   "reviewPullRequest",
   "alignmentCheck",
+  // New workflow type for resolving merge conflicts on PRs
+  "resolveMergeConflicts",
 ])
 
 export const workflowRunSchema = z.object({
@@ -324,3 +326,4 @@ export type WorkflowRun = z.infer<typeof workflowRunSchema>
 export type WorkflowRunState = z.infer<typeof workflowRunStateSchema>
 export type WorkflowStateEvent = z.infer<typeof workflowStateEventSchema>
 export type WorkflowType = z.infer<typeof workflowTypeEnum>
+

--- a/lib/workflows/resolveMergeConflicts.ts
+++ b/lib/workflows/resolveMergeConflicts.ts
@@ -1,0 +1,207 @@
+import { v4 as uuidv4 } from "uuid"
+
+import { ReviewerAgent } from "@/lib/agents/reviewer"
+import { createDirectoryTree } from "@/lib/fs"
+import { getRepoFromString } from "@/lib/github/content"
+import { getIssue } from "@/lib/github/issues"
+import {
+  getLinkedIssuesForPR,
+  getPullRequest,
+  getPullRequestComments,
+  getPullRequestDiff,
+  getPullRequestReviews,
+} from "@/lib/github/pullRequests"
+import { langfuse } from "@/lib/langfuse"
+import {
+  createStatusEvent,
+  createWorkflowStateEvent,
+} from "@/lib/neo4j/services/event"
+import { initializeWorkflowRun } from "@/lib/neo4j/services/workflow"
+import { createGetFileContentTool } from "@/lib/tools/GetFileContent"
+import { createRipgrepSearchTool } from "@/lib/tools/RipgrepSearchTool"
+import {
+  GitHubIssue,
+  IssueComment,
+  PullRequestReview,
+  PullRequestSingle,
+} from "@/lib/types/github"
+import { setupLocalRepository } from "@/lib/utils/utils-server"
+
+interface Params {
+  repoFullName: string
+  pullNumber: number
+  apiKey: string
+  jobId?: string
+}
+
+/**
+ * Resolve merge conflicts workflow
+ * - Detects merge conflict status for a PR
+ * - Gathers context for the LLM: linked issue(s), PR comments, reviews, diff, repo tree
+ * - Produces an analysis to guide automatic resolution (future step)
+ */
+export async function resolveMergeConflicts({
+  repoFullName,
+  pullNumber,
+  apiKey,
+  jobId,
+}: Params) {
+  const workflowId = jobId || uuidv4()
+
+  try {
+    await initializeWorkflowRun({
+      id: workflowId,
+      type: "resolveMergeConflicts",
+      issueNumber: undefined,
+      repoFullName,
+      postToGithub: false,
+    })
+
+    await createWorkflowStateEvent({ workflowId, state: "running" })
+
+    // Start trace
+    const trace = langfuse.trace({
+      name: `Resolve merge conflicts for PR#${pullNumber}`,
+      input: { repoFullName, pullNumber },
+    })
+    const span = trace.span({ name: "resolveMergeConflicts" })
+
+    // Fetch PR and mergeability
+    await createStatusEvent({ workflowId, content: "Fetching PR details" })
+    const pr = (await getPullRequest({
+      repoFullName,
+      pullNumber,
+    })) as unknown as PullRequestSingle
+
+    await createStatusEvent({
+      workflowId,
+      content: `PR mergeable: ${String(pr.mergeable)} | state: ${pr.mergeable_state}`,
+    })
+
+    // Fetch linked issues (via closing keywords)
+    const linkedIssueNumbers = await getLinkedIssuesForPR({
+      repoFullName,
+      pullNumber,
+    })
+
+    let linkedIssues: GitHubIssue[] = []
+    if (linkedIssueNumbers.length > 0) {
+      await createStatusEvent({
+        workflowId,
+        content: `Found linked issue(s): ${linkedIssueNumbers.join(", ")}`,
+      })
+      for (const issueNumber of linkedIssueNumbers) {
+        const res = await getIssue({ fullName: repoFullName, issueNumber })
+        if (res.type === "success") linkedIssues.push(res.issue)
+      }
+    } else {
+      await createStatusEvent({
+        workflowId,
+        content: "No linked issues found for this PR",
+      })
+    }
+
+    // Get PR diff, comments, reviews
+    await createStatusEvent({ workflowId, content: "Fetching PR diff" })
+    const diff = await getPullRequestDiff({ repoFullName, pullNumber })
+
+    await createStatusEvent({ workflowId, content: "Fetching PR comments" })
+    const comments: IssueComment[] = await getPullRequestComments({
+      repoFullName,
+      pullNumber,
+    })
+
+    await createStatusEvent({ workflowId, content: "Fetching PR reviews" })
+    const reviews: PullRequestReview[] = await getPullRequestReviews({
+      repoFullName,
+      pullNumber,
+    })
+
+    // Setup local repo and tools for context
+    await createStatusEvent({
+      workflowId,
+      content: "Setting up local repository and tools",
+    })
+
+    const repo = await getRepoFromString(repoFullName)
+    const baseDir = await setupLocalRepository({
+      repoFullName,
+      workingBranch: repo.default_branch,
+    })
+
+    const tree = await createDirectoryTree(baseDir || "")
+
+    // Initialize an LLM to analyze conflict context (uses ReviewerAgent for now)
+    const getFileContentTool = createGetFileContentTool(baseDir || "")
+    const searchCodeTool = createRipgrepSearchTool(repoFullName)
+
+    const agent = new ReviewerAgent({ apiKey })
+    await agent.addJobId(workflowId)
+    agent.addSpan({ span, generationName: "resolve-merge-conflicts" })
+
+    const formattedComments = comments
+      .map(
+        (c, i) => `Comment ${i + 1} by ${c.user?.login ?? "unknown"}:\n${c.body}`
+      )
+      .join("\n\n")
+
+    const formattedReviews = reviews
+      .map(
+        (r, i) =>
+          `Review ${i + 1} by ${r.user?.login ?? "unknown"} (${r.state}):\n${r.body || "No comment"}`
+      )
+      .join("\n\n")
+
+    const linkedIssuesSection =
+      linkedIssues.length > 0
+        ? linkedIssues
+            .map(
+              (iss) =>
+                `- #${iss.number} ${iss.title}\n${iss.body ? iss.body : ""}`
+            )
+            .join("\n\n")
+        : "None"
+
+    const message = `You are assisting with resolving merge conflicts for a pull request.`
+      + `\n\nRepo: ${repoFullName}`
+      + `\nPR #${pullNumber}: ${pr.title}`
+      + `\nPR URL: ${pr.html_url}`
+      + `\nPR mergeable: ${String(pr.mergeable)} | state: ${pr.mergeable_state}`
+      + `\n\nLinked issues:\n${linkedIssuesSection}`
+      + `\n\nRepository directory tree:\n${tree.join("\n")}`
+      + (formattedComments ? `\n\nPR Comments:\n${formattedComments}\n` : "")
+      + (formattedReviews ? `\n\nPR Reviews:\n${formattedReviews}\n` : "")
+      + `\n\nPull request diff:\n${diff}`
+      + `\n\nInstructions:`
+      + `\n- Identify likely conflicting sections in the diff (look for overlapping edits with base).`
+      + `\n- Propose concrete code edits to resolve conflicts while preserving the intent of the PR and linked issues.`
+      + `\n- If needed, request specific file contents using the available tools to fully resolve conflicts.`
+      + `\n- Output a concise plan and the exact patches to apply.`
+
+    await agent.addMessage({ role: "user", content: message })
+
+    agent.addTool(getFileContentTool)
+    agent.addTool(searchCodeTool)
+
+    await createStatusEvent({
+      workflowId,
+      content: "Starting merge conflict analysis",
+    })
+
+    const response = await agent.runWithFunctions()
+
+    await createWorkflowStateEvent({ workflowId, state: "completed" })
+
+    return response
+  } catch (error) {
+    await createWorkflowStateEvent({
+      workflowId,
+      state: "error",
+      content: String(error),
+    })
+    throw error
+  }
+}
+
+export default resolveMergeConflicts
+


### PR DESCRIPTION
Summary
- Adds a new workflow to analyze pull requests with merge conflicts and gather all relevant context (linked issues, comments, reviews, diff, repository tree) to assist an LLM in proposing conflict resolutions.
- Introduces a UI indicator on the Pull Requests table to detect and show merge conflicts and a new action to trigger the conflict resolution workflow.

What’s included
1) New workflow
- lib/workflows/resolveMergeConflicts.ts
  - Initializes a workflow run of type "resolveMergeConflicts".
  - Fetches PR details, including mergeability/mergeable_state, diff, comments, and reviews.
  - Finds linked issue(s) via GitHub GraphQL (closing keywords) and includes their content.
  - Sets up a local repository and tools (GetFileContent, Ripgrep) to supply context.
  - Uses an existing LLM agent (ReviewerAgent) to analyze the context and propose a resolution plan and patches.

2) API route to start the workflow
- app/api/workflow/resolve-merge-conflicts/route.ts
  - POST with { repoFullName, pullNumber } returns a jobId and runs the workflow in the background.

3) UI changes
- components/pull-requests/PullRequestRow.tsx
  - Fetches mergeable_state for each PR via /api/github/fetch to detect conflicts.
  - Shows a red Conflict badge (AlertTriangle) when mergeable_state is "dirty".
  - Adds a "Resolve Merge Conflicts" action to the Launch Workflow dropdown (enabled when conflicts are detected).
- components/pull-requests/controllers/ResolveMergeConflictsController.tsx
  - Client-side helper to invoke the new API route and show toasts.

4) Types
- lib/types/index.ts
  - Adds new WorkflowType: "resolveMergeConflicts".

Notes
- This initial version focuses on detection, context gathering, and analysis via LLM. It lays the foundation for fully automated in-repo conflict resolution by providing the agent the necessary tools and context to propose patches.
- The new action is only enabled when mergeable_state is "dirty". If GitHub hasn’t computed mergeability yet, the badge may not render; it will populate once mergeability is available.

Testing
- Type checks pass (pnpm run lint:tsc).
- The UI uses the existing GitHub fetch API to retrieve single PR details for mergeability state.

Future work
- Extend the workflow to automatically apply the proposed patches and push to the PR branch.
- Add an event renderer to show the proposed patch plan on Workflow Run details page.
- Optionally post a summary/comment back to the PR with the analysis result.

Closes #1066