### PR TITLE
feat: workflow + GraphQL queries for resolving PR merge conflicts

### DIFF
--- a/app/api/workflow/resolve-merge-conflicts/route.ts
+++ b/app/api/workflow/resolve-merge-conflicts/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { getUserOpenAIApiKey } from "@/lib/neo4j/services/user"
+import { ResolveMergeConflictsRequestSchema } from "@/lib/types/api/schemas"
+import { resolveMergeConflicts } from "@/lib/workflows/resolveMergeConflicts"
+
+export const dynamic = "force-dynamic"
+
+export async function POST(request: NextRequest) {
+  try {
+    const json = await request.json()
+    const parseResult = ResolveMergeConflictsRequestSchema.safeParse(json)
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { error: "Invalid request body.", details: parseResult.error.errors },
+        { status: 400 }
+      )
+    }
+
+    const { repoFullName, pullNumber, jobId } = parseResult.data
+
+    const apiKey = await getUserOpenAIApiKey()
+    if (!apiKey) {
+      return NextResponse.json(
+        { error: "Missing OpenAI API key" },
+        { status: 401 }
+      )
+    }
+
+    const result = await resolveMergeConflicts({
+      repoFullName,
+      pullNumber,
+      apiKey,
+      jobId,
+    })
+
+    return NextResponse.json({ success: true, result })
+  } catch (e) {
+    console.error("[resolve-merge-conflicts] Failed:", e)
+    return NextResponse.json(
+      { error: "Failed to start merge-conflict resolution." },
+      { status: 500 }
+    )
+  }
+}
+

--- a/lib/github/graphql/queries/getPullRequestConflictContext.ts
+++ b/lib/github/graphql/queries/getPullRequestConflictContext.ts
@@ -1,0 +1,195 @@
+"use server"
+
+import { z } from "zod"
+
+import { getGraphQLClient } from "@/lib/github"
+import { withTiming } from "@/shared/src"
+
+const PullRequestConflictContextQuery = `
+  query PullRequestConflictContext($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        number
+        title
+        body
+        state
+        isDraft
+        url
+        createdAt
+        updatedAt
+        author { login }
+        baseRefName
+        headRefName
+        headRepositoryOwner { login }
+        headRepository { nameWithOwner }
+        mergeable
+        mergeStateStatus
+        reviewDecision
+        files(first: 100) {
+          nodes {
+            path
+            changeType
+            additions
+            deletions
+          }
+          pageInfo { hasNextPage endCursor }
+        }
+        closingIssuesReferences(first: 10) {
+          nodes { number title state url }
+        }
+      }
+    }
+  }
+` as const
+
+// Zod schemas for a subset of fields we rely on
+const FileNodeSchema = z.object({
+  path: z.string(),
+  changeType: z.string().nullable().optional(),
+  additions: z.number().optional().default(0),
+  deletions: z.number().optional().default(0),
+})
+
+const LinkedIssueSchema = z.object({
+  number: z.number(),
+  title: z.string().nullable().optional(),
+  state: z.string().nullable().optional(),
+  url: z.string().nullable().optional(),
+})
+
+const PullRequestSchema = z.object({
+  number: z.number(),
+  title: z.string(),
+  body: z.string().nullable(),
+  state: z.string(),
+  isDraft: z.boolean(),
+  url: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  author: z.object({ login: z.string().nullable() }).nullable(),
+  baseRefName: z.string(),
+  headRefName: z.string(),
+  headRepositoryOwner: z.object({ login: z.string().nullable() }).nullable(),
+  headRepository: z.object({ nameWithOwner: z.string().nullable() }).nullable(),
+  mergeable: z.enum(["MERGEABLE", "CONFLICTING", "UNKNOWN"]),
+  mergeStateStatus: z.string().nullable().optional(),
+  reviewDecision: z.string().nullable().optional(),
+  files: z.object({ nodes: z.array(FileNodeSchema) }).nullable().optional(),
+  closingIssuesReferences: z
+    .object({ nodes: z.array(LinkedIssueSchema) })
+    .nullable()
+    .optional(),
+})
+
+const ResponseSchema = z.object({
+  repository: z
+    .object({
+      pullRequest: PullRequestSchema.nullable(),
+    })
+    .nullable(),
+})
+
+export type PullRequestConflictContext = z.infer<typeof PullRequestSchema> & {
+  linkedIssueNumbers: number[]
+}
+
+export async function getPullRequestConflictContext({
+  repoFullName,
+  pullNumber,
+}: {
+  repoFullName: string
+  pullNumber: number
+}): Promise<PullRequestConflictContext> {
+  const [owner, repo] = repoFullName.split("/")
+  const graphqlWithAuth = await getGraphQLClient()
+  if (!graphqlWithAuth) {
+    throw new Error("Could not initialize GraphQL client")
+  }
+
+  const data = await withTiming(
+    `GitHub GraphQL: PullRequestConflictContext ${repoFullName}#${pullNumber}`,
+    () =>
+      graphqlWithAuth<unknown>(PullRequestConflictContextQuery, {
+        owner,
+        repo,
+        number: pullNumber,
+      })
+  )
+
+  const parsed = ResponseSchema.parse(data)
+  const pr = parsed.repository?.pullRequest
+  if (!pr) {
+    throw new Error(
+      `Pull request not found for ${repoFullName}#${pullNumber} (GraphQL)`
+    )
+  }
+
+  const linkedIssueNumbers =
+    pr.closingIssuesReferences?.nodes?.map((n) => n.number) || []
+
+  return {
+    ...pr,
+    linkedIssueNumbers,
+  }
+}
+
+// Optional helper to scan for conflicting PRs quickly (useful for batch automation)
+const ListConflictingPRsQuery = `
+  query ListConflictingPRs($owner: String!, $repo: String!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequests(first: 50, states: OPEN, orderBy: { field: UPDATED_AT, direction: DESC }) {
+        nodes {
+          number
+          title
+          author { login }
+          mergeable
+          baseRefName
+          headRefName
+          createdAt
+          updatedAt
+        }
+      }
+    }
+  }
+` as const
+
+const ConflictingPRNodeSchema = z.object({
+  number: z.number(),
+  title: z.string(),
+  author: z.object({ login: z.string().nullable() }).nullable(),
+  mergeable: z.enum(["MERGEABLE", "CONFLICTING", "UNKNOWN"]),
+  baseRefName: z.string(),
+  headRefName: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+})
+
+const ListConflictingPRsResponseSchema = z.object({
+  repository: z
+    .object({
+      pullRequests: z.object({ nodes: z.array(ConflictingPRNodeSchema) }),
+    })
+    .nullable(),
+})
+
+export type ConflictingPR = z.infer<typeof ConflictingPRNodeSchema>
+
+export async function listConflictingPullRequests({
+  repoFullName,
+}: {
+  repoFullName: string
+}): Promise<ConflictingPR[]> {
+  const [owner, repo] = repoFullName.split("/")
+  const graphqlWithAuth = await getGraphQLClient()
+  if (!graphqlWithAuth) throw new Error("Could not initialize GraphQL client")
+
+  const data = await withTiming(
+    `GitHub GraphQL: listConflictingPRs ${repoFullName}`,
+    () => graphqlWithAuth<unknown>(ListConflictingPRsQuery, { owner, repo })
+  )
+
+  const parsed = ListConflictingPRsResponseSchema.parse(data)
+  const nodes = parsed.repository?.pullRequests?.nodes || []
+  return nodes.filter((n) => n.mergeable === "CONFLICTING")
+}
+

--- a/lib/types/api/schemas.ts
+++ b/lib/types/api/schemas.ts
@@ -58,3 +58,14 @@ export const IssueTitleResponseSchema = z.object({
   title: z.string().trim().min(1),
 })
 export type IssueTitleResponse = z.infer<typeof IssueTitleResponseSchema>
+
+// POST /api/workflow/resolve-merge-conflicts request body
+export const ResolveMergeConflictsRequestSchema = z.object({
+  repoFullName: z.string().min(1),
+  pullNumber: z.number(),
+  jobId: z.string().optional(),
+})
+export type ResolveMergeConflictsRequest = z.infer<
+  typeof ResolveMergeConflictsRequestSchema
+>
+

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -42,6 +42,7 @@ export const workflowTypeEnum = z.enum([
   "identifyPRGoal",
   "reviewPullRequest",
   "alignmentCheck",
+  "resolveMergeConflicts",
 ])
 
 export const workflowRunSchema = z.object({
@@ -324,3 +325,4 @@ export type WorkflowRun = z.infer<typeof workflowRunSchema>
 export type WorkflowRunState = z.infer<typeof workflowRunStateSchema>
 export type WorkflowStateEvent = z.infer<typeof workflowStateEventSchema>
 export type WorkflowType = z.infer<typeof workflowTypeEnum>
+

--- a/lib/workflows/resolveMergeConflicts.ts
+++ b/lib/workflows/resolveMergeConflicts.ts
@@ -1,0 +1,208 @@
+import { v4 as uuidv4 } from "uuid"
+
+import { MergeConflictResolverAgent } from "@/lib/agents/MergeConflictResolverAgent"
+import { getRepoFromString } from "@/lib/github/content"
+import { getPullRequestConflictContext } from "@/lib/github/graphql/queries/getPullRequestConflictContext"
+import { getInstallationTokenFromRepo } from "@/lib/github/installation"
+import { getIssue } from "@/lib/github/issues"
+import {
+  getPullRequestComments,
+  getPullRequestDiff,
+  getPullRequestReviews,
+} from "@/lib/github/pullRequests"
+import { langfuse } from "@/lib/langfuse"
+import {
+  createErrorEvent,
+  createStatusEvent,
+  createWorkflowStateEvent,
+} from "@/lib/neo4j/services/event"
+import { initializeWorkflowRun } from "@/lib/neo4j/services/workflow"
+import { RepoEnvironment } from "@/lib/types"
+import { GitHubIssue } from "@/lib/types/github"
+import {
+  createContainerizedDirectoryTree,
+  createContainerizedWorkspace,
+} from "@/lib/utils/container"
+import { setupLocalRepository } from "@/lib/utils/utils-server"
+
+interface ResolveMergeConflictsParams {
+  repoFullName: string
+  pullNumber: number
+  apiKey: string
+  jobId?: string
+}
+
+export async function resolveMergeConflicts({
+  repoFullName,
+  pullNumber,
+  apiKey,
+  jobId,
+}: ResolveMergeConflictsParams) {
+  const workflowId = jobId || uuidv4()
+
+  let containerCleanup: (() => Promise<void>) | null = null
+
+  try {
+    // Initialize workflow run
+    await initializeWorkflowRun({
+      id: workflowId,
+      type: "resolveMergeConflicts",
+      repoFullName,
+      postToGithub: false,
+    })
+
+    await createWorkflowStateEvent({ workflowId, state: "running" })
+
+    await createStatusEvent({
+      workflowId,
+      content: `Starting merge-conflict resolution workflow for ${repoFullName}#${pullNumber}`,
+    })
+
+    // Ensure local repository exists and is up-to-date
+    const repo = await getRepoFromString(repoFullName)
+    const hostRepoPath = await setupLocalRepository({
+      repoFullName,
+      workingBranch: repo.default_branch,
+    })
+
+    // Setup containerized workspace using the local copy
+    const { containerName, cleanup } = await createContainerizedWorkspace({
+      repoFullName,
+      branch: repo.default_branch,
+      workflowId,
+      hostRepoPath,
+    })
+    const env: RepoEnvironment = { kind: "container", name: containerName }
+    containerCleanup = cleanup
+
+    // Fetch PR core context via GraphQL (mergeable field etc.)
+    await createStatusEvent({
+      workflowId,
+      content: `Fetching pull request details (GraphQL)`,
+    })
+    const pr = await getPullRequestConflictContext({
+      repoFullName,
+      pullNumber,
+    })
+
+    // Fetch linked issue (first closing reference if any)
+    let linkedIssue: GitHubIssue | undefined
+    if (pr.linkedIssueNumbers.length > 0) {
+      const res = await getIssue({
+        fullName: repoFullName,
+        issueNumber: pr.linkedIssueNumbers[0],
+      })
+      if (res.type === "success") linkedIssue = res.issue
+    }
+
+    // Fetch diff, comments, and reviews
+    await createStatusEvent({ workflowId, content: `Fetching PR diff` })
+    const diff = await getPullRequestDiff({ repoFullName, pullNumber })
+
+    await createStatusEvent({ workflowId, content: `Fetching PR comments` })
+    const comments = await getPullRequestComments({
+      repoFullName,
+      pullNumber,
+    })
+
+    await createStatusEvent({ workflowId, content: `Fetching PR reviews` })
+    const reviews = await getPullRequestReviews({ repoFullName, pullNumber })
+
+    // Generate a directory tree of the codebase
+    const tree = await createContainerizedDirectoryTree(containerName)
+
+    // Prepare initial LLM message consolidating all context
+    const formattedComments = comments
+      .map(
+        (c, i) =>
+          `Comment ${i + 1} by ${c.user?.login || "unknown"} at ${new Date(c.created_at || new Date().toISOString()).toLocaleString()}\n${c.body}`
+      )
+      .join("\n\n")
+
+    const formattedReviews = reviews
+      .map(
+        (r, i) =>
+          `Review ${i + 1} by ${r.user?.login || "unknown"} (${r.state}) at ${new Date(r.submitted_at || new Date().toISOString()).toLocaleString()}\n${r.body || "No comment provided"}`
+      )
+      .join("\n\n")
+
+    const message = `
+# Pull Request Context
+- Repository: ${repoFullName}
+- PR: #${pr.number} ${pr.title}
+- State: ${pr.state}${pr.isDraft ? " (draft)" : ""}
+- Base -> Head: ${pr.baseRefName} <- ${pr.headRefName}
+- Author: ${pr.author?.login || "unknown"}
+- Mergeable: ${pr.mergeable}${pr.reviewDecision ? `, reviewDecision: ${pr.reviewDecision}` : ""}
+- URL: ${pr.url}
+- Updated: ${new Date(pr.updatedAt).toLocaleString()}
+
+## Merge State Notes
+- mergeStateStatus (GitHub): ${pr.mergeStateStatus || "n/a"}
+- Files (first 100):\n${(pr.files?.nodes || [])
+      .map((f) => `  - ${f.path} (+${f.additions}, -${f.deletions}) ${f.changeType ? ` [${f.changeType}]` : ""}`)
+      .join("\n")}
+
+${linkedIssue ? `## Linked Issue\n- #${linkedIssue.number} ${linkedIssue.title}\n${linkedIssue.body}\n` : ""}
+
+## Codebase Directory
+${tree.join("\n")}
+
+## Diff
+${diff}
+
+${formattedComments ? `## Comments\n${formattedComments}\n` : ""}
+${formattedReviews ? `## Reviews\n${formattedReviews}\n` : ""}
+`
+
+    // Get token for pushing back to PR branch
+    const [owner, repoName] = repoFullName.split("/")
+    const sessionToken = await getInstallationTokenFromRepo({
+      owner,
+      repo: repoName,
+    })
+
+    // Initialize agent
+    const agent = new MergeConflictResolverAgent({
+      apiKey,
+      repository: repo,
+      env,
+      defaultBranch: repo.default_branch,
+      issueNumber: linkedIssue?.number,
+      sessionToken,
+      jobId: workflowId,
+    })
+
+    // Start a trace
+    const trace = langfuse.trace({
+      name: `Resolve merge conflicts for PR #${pullNumber}`,
+      input: { repoFullName, pullNumber },
+    })
+    const span = trace.span({ name: "resolveMergeConflicts" })
+    agent.addSpan({ span, generationName: "resolveMergeConflicts" })
+
+    // Seed the agent with context
+    await agent.addMessage({ role: "user", content: message })
+
+    await createStatusEvent({
+      workflowId,
+      content: "Starting MergeConflictResolverAgent",
+    })
+
+    const response = await agent.runWithFunctions()
+
+    await createWorkflowStateEvent({ workflowId, state: "completed" })
+    return response
+  } catch (error) {
+    await createErrorEvent({ workflowId, content: String(error) })
+    await createWorkflowStateEvent({
+      workflowId,
+      state: "error",
+      content: String(error),
+    })
+    throw error
+  } finally {
+    if (containerCleanup) await containerCleanup()
+  }
+}
+


### PR DESCRIPTION
This PR introduces a dedicated workflow to resolve GitHub pull request merge conflicts and the GraphQL queries required to collect rich conflict context for the agent.

What's included
- GraphQL queries
  - getPullRequestConflictContext: Retrieves the PR with the descriptive mergeable state (MERGEABLE | CONFLICTING | UNKNOWN), mergeStateStatus, base/head refs, author, files changed (first 100), and linked issues via closingIssuesReferences.
  - listConflictingPullRequests (optional helper): Lists open PRs for a repo and filters to those currently in a CONFLICTING state, enabling batch conflict scans/automation.

- New workflow: resolveMergeConflicts
  - Gathers all context needed for conflict resolution:
    - Pull request details via GraphQL (including mergeable)
    - Linked issue (if any) via closing keywords and then full issue details
    - PR diff
    - Issue/PR comments and reviews
    - Codebase directory tree
  - Initializes a containerized workspace based on the repository's default branch
  - Seeds the MergeConflictResolverAgent with the compiled context and provides tools (setup, file read/write, search, commit, sync, container exec, etc.)
  - Streams status and state updates to workflow run events (running/completed/error)

- API endpoint
  - POST /api/workflow/resolve-merge-conflicts
  - Request body: { repoFullName: string, pullNumber: number, jobId?: string }
  - Validated via ResolveMergeConflictsRequestSchema

- Types updates
  - Adds "resolveMergeConflicts" to WorkflowType to allow the new workflow to be created and tracked.

Why GraphQL
- GraphQL returns mergeable as MERGEABLE, CONFLICTING, or UNKNOWN, which is more descriptive than the REST boolean and fits the need to quickly identify and prioritize conflicted PRs.
- We also fetch closingIssuesReferences to surface the underlying issue when available.

Notes and edge cases
- If mergeable is UNKNOWN, GitHub may still be computing mergeability. The workflow still collects context; the agent can retry after syncing with the base branch.
- When auto-merge or branch rules affect mergeability, mergeable may not reflect all blocking conditions; we surface reviewDecision and mergeStateStatus to give the agent additional signals.

How to use
- Trigger via the new endpoint:
  curl -X POST \
    -H "Content-Type: application/json" \
    -d '{"repoFullName":"owner/repo","pullNumber":123}' \
    /api/workflow/resolve-merge-conflicts

This sets up the environment, collects all PR/issue/review context, and runs the MergeConflictResolverAgent to resolve conflicts and push fixes to the PR branch.

Let me know if you want the UI wiring (button/controller) added as well; I focused this PR on the server workflow + GraphQL building blocks as requested.

Closes #1072