### PR TITLE
Show PR icon only for open connected PRs

### DIFF
--- a/lib/github/issues.ts
+++ b/lib/github/issues.ts
@@ -271,13 +271,14 @@ export async function getLinkedPRNumberForIssue({
                   __typename
                   ... on PullRequest {
                     number
+                    state
                   }
                 }
               }
               ... on ReferencedEvent {
                 subject {
                   __typename
-                  ... on PullRequest { number }
+                  ... on PullRequest { number state }
                 }
               }
             }
@@ -292,11 +293,11 @@ export async function getLinkedPRNumberForIssue({
         __typename: "CrossReferencedEvent"
         isCrossRepository: boolean
         willCloseTarget: boolean
-        source: { __typename: string; number?: number } | null
+        source: { __typename: string; number?: number; state?: string } | null
       }
     | {
         __typename: "ReferencedEvent"
-        subject: { __typename: string; number?: number } | null
+        subject: { __typename: string; number?: number; state?: string } | null
       }
 
   interface Resp {
@@ -315,23 +316,38 @@ export async function getLinkedPRNumberForIssue({
 
   const nodes = resp.repository?.issue?.timelineItems?.nodes || []
 
-  // Prefer PRs that will close this issue when merged
+  // helper to check OPEN state
+  const isOpen = (state?: string) => state === "OPEN"
+
+  // Prefer PRs that will close this issue when merged and are open
   for (const n of nodes) {
     if (n.__typename === "CrossReferencedEvent" && n.willCloseTarget) {
-      if (n.source?.__typename === "PullRequest" && n.source.number) {
+      if (
+        n.source?.__typename === "PullRequest" &&
+        n.source.number &&
+        isOpen(n.source.state)
+      ) {
         return n.source.number
       }
     }
   }
-  // Fallback: any PR reference
+  // Fallback: any PR reference that is open
   for (const n of nodes) {
     if (n.__typename === "ReferencedEvent") {
-      if (n.subject?.__typename === "PullRequest" && n.subject.number) {
+      if (
+        n.subject?.__typename === "PullRequest" &&
+        n.subject.number &&
+        isOpen(n.subject.state)
+      ) {
         return n.subject.number
       }
     }
     if (n.__typename === "CrossReferencedEvent") {
-      if (n.source?.__typename === "PullRequest" && n.source.number) {
+      if (
+        n.source?.__typename === "PullRequest" &&
+        n.source.number &&
+        isOpen(n.source.state)
+      ) {
         return n.source.number
       }
     }
@@ -365,13 +381,13 @@ export async function getLinkedPRNumbersForIssues({
                 willCloseTarget
                 source {
                   __typename
-                  ... on PullRequest { number }
+                  ... on PullRequest { number state }
                 }
               }
               ... on ReferencedEvent {
                 subject {
                   __typename
-                  ... on PullRequest { number }
+                  ... on PullRequest { number state }
                 }
               }
             }
@@ -394,11 +410,11 @@ export async function getLinkedPRNumbersForIssues({
         __typename: "CrossReferencedEvent"
         isCrossRepository: boolean
         willCloseTarget: boolean
-        source: { __typename: string; number?: number } | null
+        source: { __typename: string; number?: number; state?: string } | null
       }
     | {
         __typename: "ReferencedEvent"
-        subject: { __typename: string; number?: number } | null
+        subject: { __typename: string; number?: number; state?: string } | null
       }
 
   type Resp = {
@@ -412,12 +428,14 @@ export async function getLinkedPRNumbersForIssues({
 
   const variables = { owner, repo }
   const resp = (await withTiming(
-    `GitHub GraphQL: getLinkedPRNumbersForIssues ${repoFullName} [${issueNumbers.join(",")}]`,
+    `GitHub GraphQL: getLinkedPRNumbersForIssues ${repoFullName} [${issueNumbers.join(",")} ]`,
     () => graphqlWithAuth<Resp>(query, variables)
   )) as Resp
 
   const repository = resp.repository || {}
   const result: Record<number, number | null> = {}
+
+  const isOpen = (state?: string) => state === "OPEN"
 
   for (const issueNumber of issueNumbers) {
     const key = `i_${issueNumber}`
@@ -434,7 +452,9 @@ export async function getLinkedPRNumbersForIssues({
       if (n.__typename === "CrossReferencedEvent" && n.willCloseTarget) {
         const prNum =
           n.source?.__typename === "PullRequest" ? n.source.number : undefined
-        if (typeof prNum === "number") {
+        const prState =
+          n.source?.__typename === "PullRequest" ? n.source.state : undefined
+        if (typeof prNum === "number" && isOpen(prState)) {
           found = prNum
           break
         }
@@ -448,7 +468,11 @@ export async function getLinkedPRNumbersForIssues({
             n.subject?.__typename === "PullRequest"
               ? n.subject.number
               : undefined
-          if (typeof prNum === "number") {
+          const prState =
+            n.subject?.__typename === "PullRequest"
+              ? n.subject.state
+              : undefined
+          if (typeof prNum === "number" && isOpen(prState)) {
             found = prNum
             break
           }
@@ -456,7 +480,9 @@ export async function getLinkedPRNumbersForIssues({
         if (n.__typename === "CrossReferencedEvent") {
           const prNum =
             n.source?.__typename === "PullRequest" ? n.source.number : undefined
-          if (typeof prNum === "number") {
+          const prState =
+            n.source?.__typename === "PullRequest" ? n.source.state : undefined
+          if (typeof prNum === "number" && isOpen(prState)) {
             found = prNum
             break
           }
@@ -469,3 +495,4 @@ export async function getLinkedPRNumbersForIssues({
 
   return result
 }
+


### PR DESCRIPTION
Summary
- Update GitHub GraphQL queries used to find linked PRs so they also fetch the PR state.
- Only treat a PR as linked when its state is OPEN. If the PR is closed or merged, we return null and the icon will not render.

Why
Previously, the PR icon on the issues list was shown whenever an issue had any connected PR reference, regardless of whether that PR was still open. This caused the icon to appear for closed/merged PRs. The product requirement is to show the icon only when there is an open PR.

Implementation details
- lib/github/issues.ts
  - getLinkedPRNumberForIssue and getLinkedPRNumbersForIssues now request the PullRequest.state field in GraphQL and filter for state === "OPEN".
  - The rest of the UI remains unchanged. IssueRows passes the PR number from the map, and PRStatusIndicator renders the icon only when a PR number exists. Since we now return a number only for open PRs, the icon appears only in that case.

Testing
- TypeScript checks pass (pnpm run lint:tsc).
- Jest test suite passes locally.

Notes
- No UI or API contracts were changed besides the behavior of the linked PR helpers. The API route /api/issues/[issueId]/pullRequest will now return null if the linked PR is not open, which matches the desired behavior.


Closes #1075