### PR TITLE
Add merge-conflict detection badge and workflow trigger for PRs

### DIFF
--- a/components/pull-requests/MergeConflictBadge.tsx
+++ b/components/pull-requests/MergeConflictBadge.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+import { Badge } from "@/components/ui/badge"
+
+interface Props {
+  repoFullName: string
+  pullNumber: number
+}
+
+type MergeStatus = "unknown" | "conflicting" | "mergeable"
+
+export default function MergeConflictBadge({ repoFullName, pullNumber }: Props) {
+  const [status, setStatus] = useState<MergeStatus>("unknown")
+
+  useEffect(() => {
+    let isMounted = true
+
+    async function fetchStatus() {
+      try {
+        const response = await fetch("/api/github/fetch", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ type: "pull", number: pullNumber, fullName: repoFullName }),
+        })
+        if (!response.ok) throw new Error("Failed to fetch PR details")
+        const pr = await response.json()
+        // GitHub REST pulls.get returns mergeable (boolean | null) and mergeable_state
+        const mergeable: boolean | null = pr?.mergeable ?? null
+        const mergeableState: string | undefined = pr?.mergeable_state
+
+        let newStatus: MergeStatus = "unknown"
+        if (mergeable === false || mergeableState === "dirty" || mergeableState === "blocked") {
+          newStatus = "conflicting"
+        } else if (mergeable === true || mergeableState === "clean") {
+          newStatus = "mergeable"
+        }
+
+        if (isMounted) setStatus(newStatus)
+      } catch (e) {
+        // Ignore errors; keep unknown
+        if (isMounted) setStatus("unknown")
+      }
+    }
+
+    fetchStatus()
+
+    return () => {
+      isMounted = false
+    }
+  }, [repoFullName, pullNumber])
+
+  if (status !== "conflicting") return null
+
+  return <Badge variant="destructive">Merge conflict</Badge>
+}
+

--- a/components/pull-requests/PullRequestRow.tsx
+++ b/components/pull-requests/PullRequestRow.tsx
@@ -5,8 +5,10 @@ import { ChevronDown, Loader2, PlayCircle } from "lucide-react"
 import Link from "next/link"
 import { useState } from "react"
 
+import MergeConflictBadge from "@/components/pull-requests/MergeConflictBadge"
 import AlignmentCheckController from "@/components/pull-requests/controllers/AlignmentCheckController"
 import AnalyzePRController from "@/components/pull-requests/controllers/AnalyzePRController"
+import ResolveMergeConflictsController from "@/components/pull-requests/controllers/ResolveMergeConflictsController"
 import ReviewPRController from "@/components/pull-requests/controllers/ReviewPRController"
 import { Button } from "@/components/ui/button"
 import {
@@ -73,6 +75,23 @@ export default function PullRequestRow({ pr }: { pr: PullRequest }) {
     },
   })
 
+  const resolveConflictsWorkflow = ResolveMergeConflictsController({
+    repoFullName: pr.head.repo.full_name,
+    pullNumber: pr.number,
+    onStart: () => {
+      setIsLoading(true)
+      setActiveWorkflow("Resolving conflicts...")
+    },
+    onComplete: () => {
+      setIsLoading(false)
+      setActiveWorkflow(null)
+    },
+    onError: () => {
+      setIsLoading(false)
+      setActiveWorkflow(null)
+    },
+  })
+
   return (
     <TableRow>
       <TableCell className="py-4">
@@ -104,6 +123,10 @@ export default function PullRequestRow({ pr }: { pr: PullRequest }) {
                 addSuffix: true,
               })}
             </span>
+            <MergeConflictBadge
+              repoFullName={pr.head.repo.full_name}
+              pullNumber={pr.number}
+            />
           </div>
         </div>
       </TableCell>
@@ -126,7 +149,7 @@ export default function PullRequestRow({ pr }: { pr: PullRequest }) {
               )}
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-[220px]">
+          <DropdownMenuContent align="end" className="w-[240px]">
             <DropdownMenuItem onClick={reviewWorkflow.execute}>
               <div>
                 <div>Review Pull Request</div>
@@ -151,9 +174,18 @@ export default function PullRequestRow({ pr }: { pr: PullRequest }) {
                 </div>
               </div>
             </DropdownMenuItem>
+            <DropdownMenuItem onClick={resolveConflictsWorkflow.execute}>
+              <div>
+                <div>Resolve Merge Conflicts</div>
+                <div className="text-xs text-muted-foreground">
+                  Detect and attempt to automatically resolve conflicts
+                </div>
+              </div>
+            </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       </TableCell>
     </TableRow>
   )
 }
+

--- a/components/pull-requests/controllers/ResolveMergeConflictsController.tsx
+++ b/components/pull-requests/controllers/ResolveMergeConflictsController.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import { toast } from "@/lib/hooks/use-toast"
+import { ResolveMergeConflictsRequest } from "@/lib/types/api/schemas"
+
+interface Props {
+  repoFullName: string
+  pullNumber: number
+  onStart: () => void
+  onComplete: () => void
+  onError: () => void
+}
+
+export default function ResolveMergeConflictsController({
+  repoFullName,
+  pullNumber,
+  onStart,
+  onComplete,
+  onError,
+}: Props) {
+  const execute = async () => {
+    try {
+      onStart()
+      const body: ResolveMergeConflictsRequest = {
+        repoFullName,
+        pullNumber,
+      }
+
+      const response = await fetch("/api/workflow/resolve-merge-conflicts", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      })
+
+      if (!response.ok) {
+        throw new Error("Failed to start merge-conflict resolution")
+      }
+
+      toast({
+        title: "Merge-conflict resolution started",
+        description:
+          "The workflow has started. You can monitor progress in Workflow Runs.",
+      })
+      onComplete()
+    } catch (error) {
+      toast({
+        title: "Merge-conflict resolution failed",
+        description:
+          error instanceof Error
+            ? error.message
+            : "An unexpected error occurred",
+        variant: "destructive",
+      })
+      onError()
+      console.error("Resolve merge conflicts failed: ", error)
+    }
+  }
+
+  return { execute }
+}
+


### PR DESCRIPTION
Summary
- Adds a MergeConflictBadge component that detects and displays a "Merge conflict" badge for PRs with conflicts (via GitHub REST pulls.get -> mergeable/mergeable_state).
- Adds a ResolveMergeConflictsController to trigger the existing /api/workflow/resolve-merge-conflicts endpoint.
- Integrates both into PullRequestRow: badge appears inline with PR metadata, and a new dropdown item "Resolve Merge Conflicts" launches the workflow.

Why
This addresses the need to surface merge conflicts in the UI and to provide a one-click workflow to automatically resolve them using the existing MergeConflictResolverAgent and workflow implementation.

Notes
- The workflow already collects the original linked issue, full PR diff, comments, reviews, and conflict context via GraphQL and REST. Results can be monitored on the Workflow Runs pages.
- The badge queries a single PR on demand to avoid expanding the server-side payload for the PR list.
- Linting/types pass using repository-defined checks (next lint, prettier check, tsc --noEmit).

Closes #1066