### PR TITLE
Add second GitHub App auth provider and landing page button

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -12,13 +12,13 @@ export const runtime = "nodejs"
 declare module "next-auth" {
   interface Session {
     token?: JWT
-    authMethod?: "github-app"
+    authMethod?: "github-app" | "github-app-2"
   }
 }
 
 declare module "next-auth/jwt" {
   interface JWT {
-    authMethod?: "github-app"
+    authMethod?: "github-app" | "github-app-2"
   }
 }
 
@@ -66,6 +66,32 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         }
       },
     }),
+    // Basic second GitHub App provider for testing, without Redis/refresh logic
+    GithubProvider({
+      id: "github-app-2",
+      name: "GitHub App 2",
+      clientId: process.env.GITHUB_APP_CLIENT_ID,
+      clientSecret: process.env.GITHUB_APP_CLIENT_SECRET,
+      authorization: {
+        url: "https://github.com/login/oauth/authorize",
+        params: {
+          client_id: process.env.GITHUB_APP_CLIENT_ID,
+          redirect_uri: `${getRedirectBaseUrl()}/api/auth/callback/github-app-2`,
+        },
+      },
+      userinfo: {
+        url: "https://api.github.com/user",
+        params: { installation_id: process.env.GITHUB_APP_INSTALLATION_ID },
+      },
+      profile(profile) {
+        return {
+          id: profile.id.toString(),
+          name: profile.name || profile.login,
+          email: profile.email,
+          image: profile.avatar_url,
+        }
+      },
+    }),
   ],
   callbacks: {
     async jwt({ token, account }) {
@@ -77,42 +103,48 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           accessToken: !!account.access_token,
           scope: account.scope,
         })
-        const newToken = {
+        const authMethod = (account.provider as "github-app" | "github-app-2")
+        const newToken: JWT & { expires_at?: number } = {
           ...token,
           ...account,
           // Store which auth method was used
-          authMethod: "github-app",
+          authMethod,
         }
         if (account.expires_in) {
           newToken.expires_at =
             Math.floor(Date.now() / 1000) + account.expires_in
         }
 
-        await redis.set(`token_${token.sub}`, JSON.stringify(newToken), {
-          ex: account.expires_in || AUTH_CONFIG.tokenCacheTtlSeconds,
-        })
+        // Only use Redis caching for the primary provider
+        if (authMethod === "github-app") {
+          await redis.set(`token_${token.sub}`, JSON.stringify(newToken), {
+            ex: account.expires_in || AUTH_CONFIG.tokenCacheTtlSeconds,
+          })
+        }
         return newToken
       }
 
-      // Check if this is an old OAuth App token (migration cleanup)
-      if (token.authMethod !== "github-app") {
+      // If this is a session from an unsupported/old auth method, force re-auth
+      if (
+        token.authMethod !== "github-app" &&
+        token.authMethod !== "github-app-2"
+      ) {
         console.log(
-          "Invalidating old OAuth App token, forcing re-authentication"
+          "Invalidating session from unsupported auth method, forcing re-authentication"
         )
-        throw new Error("OAuth App token detected - please sign in again")
+        throw new Error("Unsupported auth token detected - please sign in again")
       }
 
+      // Handle token expiry differently based on provider
       if (
         token.expires_at &&
         (token.expires_at as number) < Date.now() / 1000
       ) {
-        // Try to refresh when we have a refresh token available
-        if (token.refresh_token) {
+        if (token.authMethod === "github-app" && token.refresh_token) {
           try {
             return await refreshTokenWithLock(token)
           } catch (error) {
             console.error("Error refreshing token. Sign in again", error)
-            // Use NextURL for proper URL handling
             const url = new URL(
               "/",
               process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"
@@ -120,6 +152,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
             return NextResponse.redirect(url)
           }
         }
+        // For the basic provider, don't attempt refresh – just expire
         throw new Error("Token expired")
       }
       return token
@@ -127,8 +160,9 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     async session({ session, token }) {
       session.token = token
       // Add auth method to session for frontend usage
-      session.authMethod = token.authMethod
+      session.authMethod = token.authMethod as "github-app" | "github-app-2"
       return session
     },
   },
 })
+

--- a/components/landing-page/AuthButton.tsx
+++ b/components/landing-page/AuthButton.tsx
@@ -5,7 +5,7 @@ import Link from "next/link"
 import { useSession } from "next-auth/react"
 
 import ShineButton from "@/components/ui/shine-button"
-import { signInWithGithub } from "@/lib/actions/auth"
+import { signInWithGithub, signInWithGithub2 } from "@/lib/actions/auth"
 
 export default function AuthButton() {
   const { data: session } = useSession()
@@ -20,12 +20,20 @@ export default function AuthButton() {
           </ShineButton>
         </Link>
       ) : (
-        <form action={signInWithGithub.bind(null, "/issues")}>
-          <ShineButton className="text-base sm:text-lg px-4 sm:px-5 md:px-6 py-3 bg-accent text-accent-foreground hover:bg-accent/70">
-            <Github size={20} />
-            Connect your code base to start
-          </ShineButton>
-        </form>
+        <div className="flex flex-col sm:flex-row gap-3">
+          <form action={signInWithGithub.bind(null, "/issues")}>
+            <ShineButton className="text-base sm:text-lg px-4 sm:px-5 md:px-6 py-3 bg-accent text-accent-foreground hover:bg-accent/70">
+              <Github size={20} />
+              Connect your code base to start
+            </ShineButton>
+          </form>
+          <form action={signInWithGithub2.bind(null, "/issues")}>
+            <ShineButton className="text-base sm:text-lg px-4 sm:px-5 md:px-6 py-3 bg-secondary text-secondary-foreground hover:bg-secondary/70">
+              <Github size={20} />
+              Login with GitHub App 2
+            </ShineButton>
+          </form>
+        </div>
       )}
     </>
   )

--- a/lib/actions/auth.ts
+++ b/lib/actions/auth.ts
@@ -9,6 +9,13 @@ export async function signInWithGithub(redirectTo?: string) {
   })
 }
 
+export async function signInWithGithub2(redirectTo?: string) {
+  await signIn("github-app-2", {
+    redirectTo: redirectTo || "/redirect",
+  })
+}
+
 export async function signOutAndRedirect() {
   await signOut({ redirectTo: "/" })
 }
+


### PR DESCRIPTION
Summary
- Adds a second NextAuth provider (id: github-app-2) that uses the same GitHub App credentials but a basic implementation without Redis caching or refresh-token logic.
- Updates NextAuth callbacks to:
  - Tag tokens with the authMethod used (github-app or github-app-2).
  - Only use Redis caching/refresh flow for the primary provider github-app.
  - Treat github-app-2 as a simple provider: if the token expires, we do not refresh and require sign-in again.
- Adds a new server action signInWithGithub2.
- Updates the landing page to show a second "Login with GitHub App 2" button so you can easily switch between the two in development.

Details
- Both providers share the same clientId/clientSecret and userinfo configuration.
- The second provider uses a distinct callback route: /api/auth/callback/github-app-2.
- Session/JWT typing extended to recognize both auth methods.

Why
This enables testing a lightweight GitHub App auth flow, without the custom Redis token cache and refresh mechanics, while keeping the existing, more robust flow intact.

Testing
- Navigate to the landing page; if logged out, you should see two buttons:
  - Existing GitHub App button (uses provider github-app with Redis/refresh)
  - New "Login with GitHub App 2" button (uses provider github-app-2 without Redis/refresh)
- Sign in with each button independently and confirm the session.authMethod reflects the chosen provider.

Notes
- No migrations required.
- Lint/type checks pass via `pnpm run check:all`.

Closes #1084