### PR TITLE
Use ShadCN VoiceDictationButton in Storybook (replace Microphone)

### DIFF
--- a/apps/storybook/src/stories/Microphone.stories.tsx
+++ b/apps/storybook/src/stories/Microphone.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react"
-import React, { useState } from "react"
-import { Microphone, type MicrophoneState } from "@shared/ui/Microphone"
+import React from "react"
+import VoiceDictationButton from "@/components/common/VoiceDictationButton"
 
-const meta: Meta<typeof Microphone> = {
-  title: "Shared/Microphone",
-  component: Microphone,
+const meta: Meta<typeof VoiceDictationButton> = {
+  title: "App/VoiceDictationButton",
+  component: VoiceDictationButton,
   parameters: {
     layout: "padded",
   },
@@ -12,73 +12,19 @@ const meta: Meta<typeof Microphone> = {
 
 export default meta
 
-type Story = StoryObj<typeof Microphone>
+type Story = StoryObj<typeof VoiceDictationButton>
 
-export const Interactive: Story = {
-  render: (args) => {
-    return (
-      <Microphone
-        {...args}
-        onTranscribe={async () => {
-          // Simulate network + random outcome
-          await new Promise((r) => setTimeout(r, 1200))
-          if (Math.random() < 0.2) {
-            throw new Error("Network error")
-          }
-        }}
-      />
-    )
+export const Default: Story = {
+  args: {
+    onTranscribed: (text: string) => console.log("Transcribed:", text),
   },
+  render: (args) => <VoiceDictationButton {...args} />,
 }
 
-export const AllStates: Story = {
-  render: () => {
-    const states: MicrophoneState[] = [
-      "idle",
-      "recording",
-      "transcribing",
-      "success",
-      "error",
-    ]
-    return (
-      <div className="grid grid-cols-2 gap-8">
-        {states.map((s) => (
-          <div key={s} className="flex flex-col items-center">
-            <Microphone state={s} />
-            <div className="mt-2 text-xs uppercase tracking-wide text-muted-foreground">
-              {s}
-            </div>
-          </div>
-        ))}
-      </div>
-    )
+export const Disabled: Story = {
+  args: {
+    disabled: true,
   },
-}
-
-export const Controlled: Story = {
-  render: (args) => {
-    const [state, setState] = useState<MicrophoneState>("idle")
-
-    return (
-      <div className="space-y-4">
-        <Microphone {...args} state={state} onStateChange={setState} />
-        <div className="flex flex-wrap gap-2">
-          {(["idle", "recording", "transcribing", "success", "error"] as const).map(
-            (s) => (
-              <button
-                key={s}
-                className={`rounded border px-2 py-1 text-sm ${
-                  state === s ? "bg-muted" : ""
-                }`}
-                onClick={() => setState(s)}
-              >
-                {s}
-              </button>
-            )
-          )}
-        </div>
-      </div>
-    )
-  },
+  render: (args) => <VoiceDictationButton {...args} />,
 }
 


### PR DESCRIPTION
Summary
- Replaced the Shared/Microphone Storybook story with our ShadCN-based VoiceDictationButton that we use throughout the Next.js app.
- This aligns Storybook with our design system (ShadCN components) per the issue request.

Details
- Updated apps/storybook/src/stories/Microphone.stories.tsx to import VoiceDictationButton from the app ("@/components/common/VoiceDictationButton").
- Provided two stories: Default and Disabled.

Why
- We want Storybook to showcase and rely on the same ShadCN components our app uses, ensuring consistency and avoiding divergence between shared/demo components and the actual UI.

Notes
- No runtime logic changed outside of Storybook. The shared Microphone component remains in place for any other usage, but Storybook now showcases the ShadCN version.
- Ran repository checks; linting and type-checking are clean within the repository's configured checks.

Closes #1091