### PR TITLE
Add settings link to error when issues are disabled

### DIFF
--- a/components/issues/NewTaskInput.tsx
+++ b/components/issues/NewTaskInput.tsx
@@ -104,9 +104,27 @@ export default function NewTaskInput({ repoFullName }: Props) {
         })
       } else {
         const message = mapGithubErrorToCopy(result)
+        const descriptionNode =
+          result.code === "IssuesDisabled" ? (
+            <span>
+              {message} {" "}
+              <a
+                href={`https://github.com/${owner}/${repo}/settings`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+              >
+                Open repository settings
+              </a>
+              .
+            </span>
+          ) : (
+            message
+          )
+
         toast({
           title: "Error creating task",
-          description: message,
+          description: descriptionNode,
           variant: "destructive",
         })
       }
@@ -167,3 +185,4 @@ export default function NewTaskInput({ repoFullName }: Props) {
     </form>
   )
 }
+


### PR DESCRIPTION
Summary
- When a user tries to create an issue in a repository where Issues are disabled, the error toast now includes a direct link to the repository’s Settings page so they can enable Issues quickly.

What changed
- components/issues/NewTaskInput.tsx
  - If createIssueAction returns an `IssuesDisabled` error, the toast description renders a link to `https://github.com/{owner}/{repo}/settings`.
  - Keeps existing friendly copy from mapGithubErrorToCopy and appends a clear call-to-action link ("Open repository settings").

Rationale
- The error message already advised enabling Issues in Settings → General, but lacked a direct link. This change minimizes friction by taking the user straight to the correct page.

Notes
- No changes to the error mapping utility were required; the check and link are localized to the NewTaskInput component where `owner` and `repo` are readily available.
- Lint/format/type checks: `pnpm run check:all` passes in this workspace (ESLint warnings remain unchanged from baseline).

Closes #1093