### PR TITLE
Add live transcription side pane to OpenAI Realtime app

### DIFF
--- a/apps/openai-realtime-agents/src/app/App.tsx
+++ b/apps/openai-realtime-agents/src/app/App.tsx
@@ -9,6 +9,7 @@ import Image from "next/image"
 import Transcript from "./components/Transcript"
 import Events from "./components/Events"
 import BottomToolbar from "./components/BottomToolbar"
+import LiveTranscription from "./components/LiveTranscription"
 
 // Types
 import { SessionStatus } from "@realtime/app/types"
@@ -97,6 +98,8 @@ function App() {
     useState<SessionStatus>("DISCONNECTED")
 
   const [isEventsPaneExpanded, setIsEventsPaneExpanded] =
+    useState<boolean>(true)
+  const [isLiveTranscriptionPaneExpanded, setIsLiveTranscriptionPaneExpanded] =
     useState<boolean>(true)
   const [userText, setUserText] = useState<string>("")
   const [isPTTActive, setIsPTTActive] = useState<boolean>(false)
@@ -355,6 +358,10 @@ function App() {
     if (storedLogsExpanded) {
       setIsEventsPaneExpanded(storedLogsExpanded === "true")
     }
+    const storedLiveExpanded = localStorage.getItem("liveTransExpanded")
+    if (storedLiveExpanded) {
+      setIsLiveTranscriptionPaneExpanded(storedLiveExpanded === "true")
+    }
     const storedAudioPlaybackEnabled = localStorage.getItem(
       "audioPlaybackEnabled"
     )
@@ -370,6 +377,13 @@ function App() {
   useEffect(() => {
     localStorage.setItem("logsExpanded", isEventsPaneExpanded.toString())
   }, [isEventsPaneExpanded])
+
+  useEffect(() => {
+    localStorage.setItem(
+      "liveTransExpanded",
+      isLiveTranscriptionPaneExpanded.toString()
+    )
+  }, [isLiveTranscriptionPaneExpanded])
 
   useEffect(() => {
     localStorage.setItem(
@@ -520,6 +534,7 @@ function App() {
           canSend={sessionStatus === "CONNECTED"}
         />
 
+        <LiveTranscription isExpanded={isLiveTranscriptionPaneExpanded} />
         <Events isExpanded={isEventsPaneExpanded} />
       </div>
 
@@ -533,6 +548,8 @@ function App() {
         handleTalkButtonUp={handleTalkButtonUp}
         isEventsPaneExpanded={isEventsPaneExpanded}
         setIsEventsPaneExpanded={setIsEventsPaneExpanded}
+        isLiveTranscriptionPaneExpanded={isLiveTranscriptionPaneExpanded}
+        setIsLiveTranscriptionPaneExpanded={setIsLiveTranscriptionPaneExpanded}
         isAudioPlaybackEnabled={isAudioPlaybackEnabled}
         setIsAudioPlaybackEnabled={setIsAudioPlaybackEnabled}
         codec={urlCodec}
@@ -543,3 +560,4 @@ function App() {
 }
 
 export default App
+

--- a/apps/openai-realtime-agents/src/app/components/BottomToolbar.tsx
+++ b/apps/openai-realtime-agents/src/app/components/BottomToolbar.tsx
@@ -11,6 +11,8 @@ interface BottomToolbarProps {
   handleTalkButtonUp: () => void;
   isEventsPaneExpanded: boolean;
   setIsEventsPaneExpanded: (val: boolean) => void;
+  isLiveTranscriptionPaneExpanded: boolean;
+  setIsLiveTranscriptionPaneExpanded: (val: boolean) => void;
   isAudioPlaybackEnabled: boolean;
   setIsAudioPlaybackEnabled: (val: boolean) => void;
   codec: string;
@@ -27,6 +29,8 @@ function BottomToolbar({
   handleTalkButtonUp,
   isEventsPaneExpanded,
   setIsEventsPaneExpanded,
+  isLiveTranscriptionPaneExpanded,
+  setIsLiveTranscriptionPaneExpanded,
   isAudioPlaybackEnabled,
   setIsAudioPlaybackEnabled,
   codec,
@@ -130,6 +134,19 @@ function BottomToolbar({
       </div>
 
       <div className="flex flex-row items-center gap-2">
+        <input
+          id="live-transcription"
+          type="checkbox"
+          checked={isLiveTranscriptionPaneExpanded}
+          onChange={(e) => setIsLiveTranscriptionPaneExpanded(e.target.checked)}
+          className="w-4 h-4"
+        />
+        <label htmlFor="live-transcription" className="flex items-center cursor-pointer">
+          Live transcript
+        </label>
+      </div>
+
+      <div className="flex flex-row items-center gap-2">
         <div>Codec:</div>
         {/*
           Codec selector – Lets you force the WebRTC track to use 8 kHz 
@@ -155,3 +172,4 @@ function BottomToolbar({
 }
 
 export default BottomToolbar;
+

--- a/apps/openai-realtime-agents/src/app/components/LiveTranscription.tsx
+++ b/apps/openai-realtime-agents/src/app/components/LiveTranscription.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import React, { useEffect, useMemo, useRef } from "react";
+import { useTranscript } from "@/app/contexts/TranscriptContext";
+
+export interface LiveTranscriptionProps {
+  isExpanded: boolean;
+}
+
+function LiveTranscription({ isExpanded }: LiveTranscriptionProps) {
+  const { transcriptItems } = useTranscript();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const liveItems = useMemo(
+    () =>
+      transcriptItems
+        .filter(
+          (t) =>
+            t.type === "MESSAGE" &&
+            t.status === "IN_PROGRESS" &&
+            !t.isHidden &&
+            (t.title ?? "").trim().length > 0,
+        )
+        .sort((a, b) => a.createdAtMs - b.createdAtMs),
+    [transcriptItems],
+  );
+
+  useEffect(() => {
+    if (isExpanded && containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
+    }
+  }, [isExpanded, liveItems]);
+
+  return (
+    <div
+      className={
+        (isExpanded ? "w-1/3 overflow-auto" : "w-0 overflow-hidden opacity-0") +
+        " transition-all rounded-xl duration-200 ease-in-out flex flex-col bg-white"
+      }
+      ref={containerRef}
+    >
+      {isExpanded && (
+        <div className="flex flex-col h-full min-h-0">
+          <div className="flex items-center justify-between px-6 py-3.5 sticky top-0 z-10 text-base border-b bg-white rounded-t-xl">
+            <span className="font-semibold">Live Transcription</span>
+          </div>
+
+          <div className="p-4 flex flex-col gap-y-3">
+            {liveItems.length === 0 && (
+              <div className="text-sm text-gray-500 italic">
+                Waiting for speech...
+              </div>
+            )}
+            {liveItems.map((item) => (
+              <div key={item.itemId} className="flex flex-col">
+                <div className="text-xs text-gray-500 font-mono mb-1">
+                  {item.timestamp} · {item.role === "user" ? "User" : "Assistant"}
+                </div>
+                <div className="bg-gray-50 border border-gray-200 rounded-md p-2 whitespace-pre-wrap">
+                  {item.title}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default LiveTranscription;
+


### PR DESCRIPTION
Summary
- Adds a Live Transcription component to the OpenAI Realtime app that displays ongoing transcriptions in real-time.
- Transcription is already enabled in the session (inputAudioTranscription using gpt-4o-mini-transcribe). This PR surfaces those deltas in a dedicated UI window.
- Includes a new toggle in the bottom toolbar to show/hide the Live Transcription pane (state is persisted to localStorage).

Key changes
- apps/openai-realtime-agents/src/app/components/LiveTranscription.tsx: New component rendering in-progress transcript items, auto-scrolling as deltas arrive.
- apps/openai-realtime-agents/src/app/components/BottomToolbar.tsx: Adds a "Live transcript" checkbox next to the existing Logs toggle.
- apps/openai-realtime-agents/src/app/App.tsx: Wires the new component and manages persisted UI state.

Implementation notes
- The app already handles these events via useHandleSessionHistory (response.audio_transcript.delta/response.audio_transcript.done and conversation.item.input_audio_transcription.completed). The new pane simply filters transcriptItems by status === "IN_PROGRESS" and displays them with timestamps and roles.
- Styling matches existing panes (Events) and uses Tailwind classes.

QA steps
1) Open the Realtime app and connect to a scenario.
2) Ensure "Live transcript" toggle is on in the bottom toolbar.
3) Speak or type; you should see the pane update in real-time while transcription is in progress.
4) Once finalized, the entry will disappear from the live pane (it remains visible in the main Transcript panel).

Lint/Checks
- Ran "pnpm install" and "pnpm run check:all" (includes Next lint, Prettier check, and tsc). No blocking errors.

This is a UI-only enhancement that should be safe and backwards-compatible.

Closes #1094