### PR TITLE
Allow auto-resolve workflow to run on any branch

### DIFF
--- a/app/api/workflow/autoResolveIssue/route.ts
+++ b/app/api/workflow/autoResolveIssue/route.ts
@@ -11,7 +11,7 @@ import autoResolveIssue from "@/lib/workflows/autoResolveIssue"
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
-    const { issueNumber, repoFullName } =
+    const { issueNumber, repoFullName, branch } =
       AutoResolveIssueRequestSchema.parse(body)
 
     const apiKey = await getUserOpenAIApiKey()
@@ -41,6 +41,7 @@ export async function POST(request: NextRequest) {
           repository: repo,
           apiKey,
           jobId,
+          branch,
         })
       } catch (error) {
         console.error(error)
@@ -62,3 +63,4 @@ export async function POST(request: NextRequest) {
     )
   }
 }
+

--- a/components/issues/IssueActions.tsx
+++ b/components/issues/IssueActions.tsx
@@ -33,6 +33,7 @@ export default function IssueActions({
   const { execute: executeAutoResolve } = AutoResolveIssueController({
     issueNumber: issue.number,
     repoFullName,
+    branch: selectedRef,
     onStart: () => {
       onWorkflowStart("Auto Resolving...")
     },
@@ -125,3 +126,4 @@ export default function IssueActions({
     </div>
   )
 }
+

--- a/components/issues/controllers/AutoResolveIssueController.tsx
+++ b/components/issues/controllers/AutoResolveIssueController.tsx
@@ -5,6 +5,7 @@ import { toast } from "@/lib/hooks/use-toast"
 interface Props {
   issueNumber: number
   repoFullName: string
+  branch?: string
   onStart: () => void
   onComplete: () => void
   onError: () => void
@@ -13,6 +14,7 @@ interface Props {
 export default function AutoResolveIssueController({
   issueNumber,
   repoFullName,
+  branch,
   onStart,
   onComplete,
   onError,
@@ -23,7 +25,7 @@ export default function AutoResolveIssueController({
       const response = await fetch("/api/workflow/autoResolveIssue", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ issueNumber, repoFullName }),
+        body: JSON.stringify({ issueNumber, repoFullName, branch }),
       })
 
       if (!response.ok) {
@@ -53,3 +55,4 @@ export default function AutoResolveIssueController({
 
   return { execute }
 }
+

--- a/lib/schemas/api.ts
+++ b/lib/schemas/api.ts
@@ -82,4 +82,6 @@ export const ResolveRequestSchema = z.object({
 export const AutoResolveIssueRequestSchema = z.object({
   issueNumber: z.number(),
   repoFullName: z.string().min(1),
+  branch: z.string().min(1).optional(),
 })
+

--- a/lib/workflows/autoResolveIssue.ts
+++ b/lib/workflows/autoResolveIssue.ts
@@ -25,6 +25,7 @@ interface Params {
   repository: GitHubRepository
   apiKey?: string
   jobId?: string
+  branch?: string
 }
 
 export const autoResolveIssue = async ({
@@ -32,6 +33,7 @@ export const autoResolveIssue = async ({
   repository,
   apiKey,
   jobId,
+  branch,
 }: Params) => {
   if (!apiKey) {
     const apiKeyFromSettings = await getUserOpenAIApiKey()
@@ -72,14 +74,16 @@ export const autoResolveIssue = async ({
       })
     }
 
+    const selectedBranch = branch && branch.length > 0 ? branch : repository.default_branch
+
     const hostRepoPath = await setupLocalRepository({
       repoFullName: repository.full_name,
-      workingBranch: repository.default_branch,
+      workingBranch: selectedBranch,
     })
 
     const { containerName } = await createContainerizedWorkspace({
       repoFullName: repository.full_name,
-      branch: repository.default_branch,
+      branch: selectedBranch,
       workflowId,
       hostRepoPath,
     })
@@ -160,3 +164,4 @@ export const autoResolveIssue = async ({
 }
 
 export default autoResolveIssue
+


### PR DESCRIPTION
Summary
- Add optional branch parameter to autoResolveIssue API and workflow
- Pass selected branch from UI (IssueActions -> AutoResolveIssueController)
- Workflow checks out and runs against the provided branch in both local setup and container workspace
- Default behavior remains unchanged (falls back to repository.default_branch when branch not provided)

Implementation details
- Extended AutoResolveIssueRequestSchema with optional branch
- app/api/workflow/autoResolveIssue/route.ts accepts and forwards branch
- lib/workflows/autoResolveIssue.ts uses selectedBranch for setupLocalRepository and createContainerizedWorkspace
- components/issues/IssueActions.ts integrates existing BranchSelector and passes selected value into the auto-resolve controller
- components/issues/controllers/AutoResolveIssueController.tsx includes branch in the request body

Why
Previously the auto-resolve workflow always ran from the default branch. This change allows running it on any branch selected in the UI, ensuring the code pulled, the agent’s context, and the directory tree are all based on that branch.

Notes
- No breaking changes: if branch is omitted, behavior is unchanged.
- Lint, type-check and formatting check pass via `pnpm run check:all` (Prettier reports are informational in check mode).

Closes #1097