### PR TITLE
Implement global and client error pages with server logging

### DIFF
--- a/app/api/log-error/route.ts
+++ b/app/api/log-error/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    // Log client-reported errors on the server
+    // Intentionally minimal for now per requirements
+    // eslint-disable-next-line no-console
+    console.error('[client-error-report]', body);
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error('[client-error-report] Failed to parse body', e);
+    return NextResponse.json({ ok: false, error: 'Invalid JSON' }, { status: 400 });
+  }
+}
+

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    const report = async () => {
+      try {
+        const payload = {
+          source: 'segment-error',
+          message: error?.message ?? 'Unknown error',
+          stack: error?.stack,
+          digest: error?.digest,
+          url: typeof window !== 'undefined' ? window.location.href : undefined,
+          userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : undefined,
+          timestamp: new Date().toISOString(),
+        };
+        await fetch('/api/log-error', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+      } catch (_err) {
+        // ignore
+      }
+    };
+    report();
+  }, [error]);
+
+  return (
+    <div style={{ padding: 24 }}>
+      <h2>Something went wrong</h2>
+      <p>Try again or go back.</p>
+      <pre style={{ whiteSpace: 'pre-wrap', overflowX: 'auto' }}>{error?.message}</pre>
+      <button
+        onClick={() => reset()}
+        style={{
+          marginTop: 16,
+          padding: '8px 12px',
+          border: '1px solid #ccc',
+          borderRadius: 6,
+          background: 'white',
+          cursor: 'pointer',
+        }}
+      >
+        Try again
+      </button>
+    </div>
+  );
+}
+

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    const report = async () => {
+      try {
+        const payload = {
+          source: 'global-error',
+          message: error?.message ?? 'Unknown error',
+          stack: error?.stack,
+          digest: error?.digest,
+          url: typeof window !== 'undefined' ? window.location.href : undefined,
+          userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : undefined,
+          timestamp: new Date().toISOString(),
+        };
+        await fetch('/api/log-error', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+      } catch (_err) {
+        // no-op
+      }
+    };
+    report();
+  }, [error]);
+
+  return (
+    <html>
+      <body>
+        <div style={{ padding: 24 }}>
+          <h2>Something went wrong</h2>
+          <p>We encountered an unexpected error. You can try reloading the app.</p>
+          <pre style={{ whiteSpace: 'pre-wrap', overflowX: 'auto' }}>{error?.message}</pre>
+          <button
+            onClick={() => reset()}
+            style={{
+              marginTop: 16,
+              padding: '8px 12px',
+              border: '1px solid #ccc',
+              borderRadius: 6,
+              background: 'white',
+              cursor: 'pointer',
+            }}
+          >
+            Try again
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}
+


### PR DESCRIPTION
Summary
- Added a root-level global error page to handle failures that affect the main layout and any root-level errors.
- Added a standard segment error page for client-side/runtime errors within route segments.
- Implemented a simple server endpoint to receive error telemetry from the client and log it to the server console.

What changed
1) app/global-error.tsx
   - A Client Component that captures and displays errors at the root boundary.
   - Sends a POST to /api/log-error with error details (message, stack, digest, url, userAgent, timestamp).
   - Provides a Try again button wired to the reset() function.

2) app/error.tsx
   - A Client Component error boundary for segment-level/client runtime errors.
   - Also reports errors via /api/log-error and shows a minimal recovery UI with a Try again button.

3) app/api/log-error/route.ts
   - Adds a POST handler that receives error payloads and console.error logs them on the server as requested. Returns { ok: true } on success.

Why this approach
- Next.js app router supports a global root error boundary via app/global-error.tsx specifically for failures in the root layout or the entire app shell.
- app/error.tsx provides a local boundary for typical client/runtime errors within route segments.
- A small, dedicated API route centralizes the error logging behavior and can be expanded later (e.g., integrate with an APM/observability platform) without changing UI components.

Quality checks
- Installed dependencies with pnpm and ran repository checks (lint + tsc). No TypeScript or ESLint errors; some non-blocking warnings remain consistent with existing code.

Testing notes
- To simulate an error in any component under app/, throw an error to see the new error UIs.
- Verify server logging by checking your server console while triggering the error; a log line prefixed with [client-error-report] should appear.

No breaking changes expected. The error pages only render when an unhandled error occurs.

Closes #1102