### PR TITLE
Add shadCN-style shared Button and Storybook stories; include Microphone states

### DIFF
--- a/apps/storybook/src/stories/SharedButton.stories.tsx
+++ b/apps/storybook/src/stories/SharedButton.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import React from "react"
+import { Button } from "@shared/ui/button"
+import { Loader2, Mail, Plus } from "lucide-react"
+
+const meta: Meta<typeof Button> = {
+  title: "Shared/Button",
+  component: Button,
+  parameters: {
+    layout: "padded",
+  },
+  args: {
+    children: "Button",
+  },
+}
+export default meta
+
+type Story = StoryObj<typeof Button>
+
+export const Variants: Story = {
+  render: (args) => (
+    <div className="flex flex-wrap gap-3">
+      <Button {...args} variant="default">Default</Button>
+      <Button {...args} variant="secondary">Secondary</Button>
+      <Button {...args} variant="destructive">Destructive</Button>
+      <Button {...args} variant="outline">Outline</Button>
+      <Button {...args} variant="ghost">Ghost</Button>
+      <Button {...args} variant="link">Link</Button>
+    </div>
+  ),
+}
+
+export const Sizes: Story = {
+  render: (args) => (
+    <div className="flex items-center gap-3">
+      <Button {...args} size="sm">Small</Button>
+      <Button {...args} size="default">Default</Button>
+      <Button {...args} size="lg">Large</Button>
+      <Button {...args} size="icon" aria-label="Add">
+        <Plus />
+      </Button>
+    </div>
+  ),
+}
+
+export const Disabled: Story = {
+  args: { disabled: true },
+  render: (args) => (
+    <div className="flex flex-wrap gap-3">
+      <Button {...args} variant="default">Default</Button>
+      <Button {...args} variant="secondary">Secondary</Button>
+      <Button {...args} variant="destructive">Destructive</Button>
+      <Button {...args} variant="outline">Outline</Button>
+      <Button {...args} variant="ghost">Ghost</Button>
+      <Button {...args} variant="link">Link</Button>
+    </div>
+  ),
+}
+
+export const WithIcon: Story = {
+  render: (args) => (
+    <div className="flex flex-wrap items-center gap-3">
+      <Button {...args}>
+        <Mail />
+        Email
+      </Button>
+      <Button {...args} variant="secondary">
+        <Loader2 className="animate-spin" />
+        Loading
+      </Button>
+    </div>
+  ),
+}
+

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -14,4 +14,5 @@ export {
 } from "@/shared/src/utils/telemetry"
 export * from "@/shared/src/ui/IssueRow"
 export * from "@/shared/src/ui/Microphone"
+export * from "@/shared/src/ui/button"
 

--- a/shared/src/ui/button.tsx
+++ b/shared/src/ui/button.tsx
@@ -1,0 +1,58 @@
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react"
+
+import { cn } from "@shared/ui/cn"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-10 rounded-md px-8",
+        icon: "h-9 w-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }
+

--- a/shared/src/ui/cn.ts
+++ b/shared/src/ui/cn.ts
@@ -1,0 +1,7 @@
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+


### PR DESCRIPTION
Summary
- Added a shadCN-style Button component under shared/src/ui/button.tsx so it can be consumed across apps.
- Implemented a small cn utility (shared/src/ui/cn.ts) to avoid cross-package imports and keep shared package standalone.
- Exported the Button from shared/src/index.ts so it can be imported via @shared/ui/button.
- Added Storybook coverage for shared Button (apps/storybook/src/stories/SharedButton.stories.tsx) demonstrating:
  - All variants (default, secondary, destructive, outline, ghost, link)
  - Sizes (sm, default, lg, icon)
  - Disabled state and buttons with icons/loading indicator.
- Microphone component already existed in shared UI and is showcased in existing story (AllStates and Interactive in Microphone.stories.tsx).

Why
This addresses the request to bring shadcn components (specifically buttons) into the shared UI folder and showcase their states in Storybook, along with the Microphone button that was already implemented.

Notes
- The Button implementation mirrors our existing shadcn button from components/ui/button.tsx but uses a local cn helper to avoid app-specific imports.
- No breaking changes to existing apps.
- Lint and type checks pass locally with pnpm run check:all.

How to test
1) pnpm --filter @issue-to-pr/storybook dev
2) Open http://localhost:6006
3) See "Shared/Button" for variants and states.
4) See "Shared/Microphone" for interactive and state demos.

Closes #1100