### PR TITLE
Display message and disable input when issues are disabled

### DIFF
--- a/app/[username]/[repo]/issues/page.tsx
+++ b/app/[username]/[repo]/issues/page.tsx
@@ -1,5 +1,6 @@
 import IssueTable from "@/components/issues/IssueTable"
 import NewTaskInput from "@/components/issues/NewTaskInput"
+import { getRepoFromString } from "@/lib/github/content"
 import { repoFullNameSchema } from "@/lib/types/github"
 
 interface Props {
@@ -13,6 +14,8 @@ export default async function RepoPage({ params }: Props) {
   const { username, repo } = params
 
   const repoFullName = repoFullNameSchema.parse(`${username}/${repo}`)
+  const repoData = await getRepoFromString(repoFullName.fullName)
+  const issuesEnabled = !!repoData.has_issues
 
   return (
     <main className="container mx-auto p-4">
@@ -21,8 +24,32 @@ export default async function RepoPage({ params }: Props) {
           {username} / {repo} - Issues
         </h1>
       </div>
-      <NewTaskInput repoFullName={repoFullName} />
-      <IssueTable repoFullName={repoFullName} />
+
+      {!issuesEnabled ? (
+        <div className="mb-6 rounded-md border border-yellow-300 bg-yellow-50 p-4 text-yellow-800">
+          <p className="mb-1 font-medium">GitHub Issues are disabled for this repository.</p>
+          <p>
+            To enable issues, visit the repository settings on GitHub and turn on the
+            Issues feature. {" "}
+            <a
+              href={`https://github.com/${username}/${repo}/settings#features`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              Open GitHub settings
+            </a>
+            .
+          </p>
+        </div>
+      ) : null}
+
+      <NewTaskInput repoFullName={repoFullName} issuesEnabled={issuesEnabled} />
+
+      {issuesEnabled ? (
+        <IssueTable repoFullName={repoFullName} />
+      ) : null}
     </main>
   )
 }
+

--- a/components/issues/NewTaskContainer.tsx
+++ b/components/issues/NewTaskContainer.tsx
@@ -1,6 +1,7 @@
 import RepoSelector from "@/components/common/RepoSelector"
 import IssueTable from "@/components/issues/IssueTable"
 import NewTaskInput from "@/components/issues/NewTaskInput"
+import { getRepoFromString } from "@/lib/github/content"
 import { AuthenticatedUserRepository, RepoFullName } from "@/lib/types/github"
 
 interface Props {
@@ -17,6 +18,9 @@ export default async function NewTaskContainer({
   repoFullName,
   repositories,
 }: Props) {
+  const repo = await getRepoFromString(repoFullName.fullName)
+  const issuesEnabled = !!repo.has_issues
+
   return (
     <main className="mx-auto max-w-4xl w-full py-10 px-4 sm:px-6">
       <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
@@ -28,10 +32,32 @@ export default async function NewTaskContainer({
           />
         </div>
       </div>
+
+      {!issuesEnabled ? (
+        <div className="mb-6 rounded-md border border-yellow-300 bg-yellow-50 p-4 text-yellow-800">
+          <p className="mb-1 font-medium">GitHub Issues are disabled for this repository.</p>
+          <p>
+            To enable issues, visit the repository settings on GitHub and turn on the
+            Issues feature. {" "}
+            <a
+              href={`https://github.com/${repoFullName.owner}/${repoFullName.repo}/settings#features`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              Open GitHub settings
+            </a>
+            .
+          </p>
+        </div>
+      ) : null}
+
       <div className="mb-6">
-        <NewTaskInput repoFullName={repoFullName} />
+        <NewTaskInput repoFullName={repoFullName} issuesEnabled={issuesEnabled} />
       </div>
-      <IssueTable repoFullName={repoFullName} />
+
+      {issuesEnabled ? <IssueTable repoFullName={repoFullName} /> : null}
     </main>
   )
 }
+


### PR DESCRIPTION
Summary
- When a repository has GitHub Issues disabled, the Issues page now:
  - Displays a clear banner indicating that Issues are disabled, with a direct link to the repository’s GitHub settings to enable Issues.
  - Disables the new task input (textarea, submit button, and voice dictation) and shows a helpful tooltip message on hover explaining why.
  - Skips rendering the IssueTable to avoid server errors from calling the GitHub Issues API on repos without issues.

What changed
- app/[username]/[repo]/issues/page.tsx
  - Fetch repo metadata via getRepoFromString, detect has_issues, show banner, pass issuesEnabled to NewTaskInput, and conditionally render IssueTable.
- components/issues/NewTaskContainer.tsx
  - Same behavior for the generic Issues page flow with repo selector.
- components/issues/NewTaskInput.tsx
  - Added issuesEnabled prop (default true).
  - Disabled UI when issues are disabled and added tooltips plus toast message on attempted submit.
  - Linked to GitHub settings (…/settings#features) for convenience.

Why
- Improves UX by clearly communicating that Issues are disabled for the repo and preventing confusing errors on create or fetch.
- Provides a direct path for users to enable Issues.

Notes
- The link goes to https://github.com/{owner}/{repo}/settings#features which brings users to the right place to toggle the Issues feature.
- No API or schema changes.

QA
- Navigate to any repo with Issues disabled:
  - You should see a yellow banner message with a link to GitHub settings.
  - The textarea, Create GitHub Issue button, and microphone button are disabled.
  - Hovering over the disabled inputs shows a tooltip explaining that Issues are disabled.
  - The issue list does not render and no errors should be thrown from GitHub API calls.
- Navigate to a repo with Issues enabled to see the normal behavior.

Closes #1105