### PR TITLE
Add use case for generating non-conflicting branch names

### DIFF
--- a/shared/src/core/entities/refs.ts
+++ b/shared/src/core/entities/refs.ts
@@ -1,0 +1,22 @@
+import { z } from "zod"
+
+export const branchPrefixSchema = z
+  .string()
+  .optional()
+  .transform((str) => str?.trim()?.replace(/\/$/, ""))
+
+export const baseBranchSlugSchema = z
+  .string()
+  .min(1, "Ref slug cannot be empty")
+  .toLowerCase()
+  .transform((input) =>
+    input
+      .replace(/[\s_/|]+/g, "-")
+      // Remove invalid git ref characters
+      .replace(/[~^:\\?*\[\]@{}]+/g, "")
+      // Collapse multiple hyphens
+      .replace(/-+/g, "-")
+      // Trim hyphens and dots
+      .replace(/^[.-]+|[.-]+$/g, "")
+  )
+  .default("new-branch")

--- a/shared/src/core/ports/refs.ts
+++ b/shared/src/core/ports/refs.ts
@@ -5,4 +5,3 @@ export interface GitHubRefsPort {
    */
   listBranches(params: { owner: string; repo: string }): Promise<string[]>
 }
-

--- a/shared/src/core/ports/refs.ts
+++ b/shared/src/core/ports/refs.ts
@@ -1,0 +1,8 @@
+export interface GitHubRefsPort {
+  /**
+   * List branch names for a GitHub repository (remote refs/heads).
+   * Implementations may use REST or GraphQL but must return just the branch names, e.g. "main", "feature/foo".
+   */
+  listBranches(params: { owner: string; repo: string }): Promise<string[]>
+}
+

--- a/shared/src/core/usecases/generateBranchName.ts
+++ b/shared/src/core/usecases/generateBranchName.ts
@@ -34,8 +34,13 @@ export async function generateNonConflictingBranchName(
 
   // 1) Load existing branches
   const existing = new Set(
-    (params.existingBranches ??
-      (await ports.refs.listBranches({ owner: params.owner, repo: params.repo })))
+    (
+      params.existingBranches ??
+      (await ports.refs.listBranches({
+        owner: params.owner,
+        repo: params.repo,
+      }))
+    )
       .map((b) => b.trim())
       .filter(Boolean)
   )
@@ -49,9 +54,12 @@ export async function generateNonConflictingBranchName(
 
   const user = `Context:\n${trimToMax(params.context, 2000)}\n\nRespond with only a short kebab-case slug suitable for a branch name. Example: add-dismiss-button-to-toasts`
 
-  const raw = (await ports.llm.createCompletion({ system, messages: [
-    { role: "user", content: user },
-  ] })).trim()
+  const raw = (
+    await ports.llm.createCompletion({
+      system,
+      messages: [{ role: "user", content: user }],
+    })
+  ).trim()
 
   // 3) Sanitize and format candidate
   const baseSlug = sanitizeToSlug(raw) || "new-branch"
@@ -73,7 +81,10 @@ export async function generateNonConflictingBranchName(
   if (!existing.has(fallback)) return fallback
 
   // Extremely unlikely path: random suffix
-  return trimToMax(`${candidate}-${Math.random().toString(36).slice(2, 8)}`, 200)
+  return trimToMax(
+    `${candidate}-${Math.random().toString(36).slice(2, 8)}`,
+    200
+  )
 }
 
 function sanitizeToSlug(input: string): string {
@@ -95,4 +106,3 @@ function trimToMax(input: string, max: number): string {
   if (input.length <= max) return input
   return input.slice(0, max)
 }
-

--- a/shared/src/core/usecases/generateBranchName.ts
+++ b/shared/src/core/usecases/generateBranchName.ts
@@ -1,0 +1,98 @@
+import type { LLMPort } from "@shared/core/ports/llm"
+import type { GitHubRefsPort } from "@shared/core/ports/refs"
+
+export type GenerateBranchNameParams = {
+  owner: string
+  repo: string
+  /**
+   * Stringified context that describes why this branch is being created.
+   * Keep it concise; the LLM will use this to propose a descriptive slug.
+   */
+  context: string
+  /** Optional prefix segment like "feature", "fix", "chore". Default: "feature" */
+  prefix?: string
+  /**
+   * If provided, bypasses the refsPort and uses this set of branches for conflict checks.
+   */
+  existingBranches?: string[]
+  /** Max attempts to find a unique suffix if conflicts occur. Default: 20 */
+  maxAttempts?: number
+}
+
+/**
+ * Use case: propose a clean branch name from context and ensure it does not
+ * conflict with existing remote branches.
+ *
+ * Ports are injected for pure, testable logic with no adapters coupled here.
+ */
+export async function generateNonConflictingBranchName(
+  ports: { llm: LLMPort; refs: GitHubRefsPort },
+  params: GenerateBranchNameParams
+): Promise<string> {
+  const prefix = (params.prefix ?? "feature").trim().replace(/\/$/, "")
+  const maxAttempts = Math.max(1, params.maxAttempts ?? 20)
+
+  // 1) Load existing branches
+  const existing = new Set(
+    (params.existingBranches ??
+      (await ports.refs.listBranches({ owner: params.owner, repo: params.repo })))
+      .map((b) => b.trim())
+      .filter(Boolean)
+  )
+
+  // 2) Ask LLM for a candidate slug from the context
+  const system = [
+    "You generate short, descriptive Git branch names in kebab-case.",
+    "Prefer 3-6 words max. Avoid issue numbers unless present in context.",
+    "Return ONLY the branch path (no code blocks, no quotes).",
+  ].join(" ")
+
+  const user = `Context:\n${trimToMax(params.context, 2000)}\n\nRespond with only a short kebab-case slug suitable for a branch name. Example: add-dismiss-button-to-toasts`
+
+  const raw = (await ports.llm.createCompletion({ system, messages: [
+    { role: "user", content: user },
+  ] })).trim()
+
+  // 3) Sanitize and format candidate
+  const baseSlug = sanitizeToSlug(raw) || "new-branch"
+  let candidate = `${prefix}/${baseSlug}`
+  candidate = trimToMax(candidate, 200)
+
+  // 4) Ensure uniqueness by appending numeric suffixes
+  if (!existing.has(candidate)) return candidate
+
+  let attempt = 2
+  while (attempt <= maxAttempts) {
+    const next = trimToMax(`${candidate}-${attempt}`, 200)
+    if (!existing.has(next)) return next
+    attempt++
+  }
+
+  // 5) As a last resort, include a timestamp suffix
+  const fallback = trimToMax(`${candidate}-${Date.now()}`, 200)
+  if (!existing.has(fallback)) return fallback
+
+  // Extremely unlikely path: random suffix
+  return trimToMax(`${candidate}-${Math.random().toString(36).slice(2, 8)}`, 200)
+}
+
+function sanitizeToSlug(input: string): string {
+  const s = input
+    .toLowerCase()
+    // Replace separators and whitespace with hyphen
+    .replace(/[\s_/|]+/g, "-")
+    // Remove invalid git ref characters
+    .replace(/[~^:\\?*\[\]@{}]+/g, "")
+    // Collapse multiple hyphens
+    .replace(/-+/g, "-")
+    // Trim hyphens and dots
+    .replace(/^[.-]+|[.-]+$/g, "")
+  // Disallow sequences that end a path segment with .lock or .
+  return s
+}
+
+function trimToMax(input: string, max: number): string {
+  if (input.length <= max) return input
+  return input.slice(0, max)
+}
+

--- a/shared/src/core/usecases/generateBranchName.ts
+++ b/shared/src/core/usecases/generateBranchName.ts
@@ -1,21 +1,29 @@
+import {
+  baseBranchSlugSchema,
+  branchPrefixSchema,
+} from "@shared/core/entities/refs"
 import type { LLMPort } from "@shared/core/ports/llm"
 import type { GitHubRefsPort } from "@shared/core/ports/refs"
+
+const MAX_CONTEXT_LENGTH = 100000
+const MAX_BRANCH_NAME_LENGTH = 200
+const MAX_ATTEMPTS = 10
 
 export type GenerateBranchNameParams = {
   owner: string
   repo: string
   /**
    * Stringified context that describes why this branch is being created.
-   * Keep it concise; the LLM will use this to propose a descriptive slug.
+   * The LLM will use this to propose a descriptive slug.
    */
   context: string
-  /** Optional prefix segment like "feature", "fix", "chore". Default: "feature" */
+  /** Optional prefix segment like "feature", "fix", "chore". */
   prefix?: string
   /**
    * If provided, bypasses the refsPort and uses this set of branches for conflict checks.
    */
   existingBranches?: string[]
-  /** Max attempts to find a unique suffix if conflicts occur. Default: 20 */
+  /** Max attempts to find a unique suffix if conflicts occur. Default: MAX_ATTEMPTS */
   maxAttempts?: number
 }
 
@@ -29,8 +37,13 @@ export async function generateNonConflictingBranchName(
   ports: { llm: LLMPort; refs: GitHubRefsPort },
   params: GenerateBranchNameParams
 ): Promise<string> {
-  const prefix = (params.prefix ?? "feature").trim().replace(/\/$/, "")
-  const maxAttempts = Math.max(1, params.maxAttempts ?? 20)
+  const parsedPrefix = branchPrefixSchema.safeParse(params.prefix)
+  if (!parsedPrefix.success) {
+    throw new Error("Invalid prefix")
+  }
+  const prefix = parsedPrefix.data
+
+  const maxAttempts = Math.max(1, params.maxAttempts ?? MAX_ATTEMPTS)
 
   // 1) Load existing branches
   const existing = new Set(
@@ -48,58 +61,48 @@ export async function generateNonConflictingBranchName(
   // 2) Ask LLM for a candidate slug from the context
   const system = [
     "You generate short, descriptive Git branch names in kebab-case.",
-    "Prefer 3-6 words max. Avoid issue numbers unless present in context.",
+    "Prefer 3-6 words max.",
     "Return ONLY the branch path (no code blocks, no quotes).",
+    `${prefix ? `Do NOT provide a prefix in the branch path, we will add this manually.` : ""}`,
   ].join(" ")
 
-  const user = `Context:\n${trimToMax(params.context, 2000)}\n\nRespond with only a short kebab-case slug suitable for a branch name. Example: add-dismiss-button-to-toasts`
+  const user = `Context:\n${trimToMax(params.context, MAX_CONTEXT_LENGTH)}\n\nRespond with only a short kebab-case slug suitable for a branch name.`
 
   const raw = (
     await ports.llm.createCompletion({
       system,
+      model: "gpt-4.1",
       messages: [{ role: "user", content: user }],
     })
   ).trim()
 
-  // 3) Sanitize and format candidate
-  const baseSlug = sanitizeToSlug(raw) || "new-branch"
-  let candidate = `${prefix}/${baseSlug}`
-  candidate = trimToMax(candidate, 200)
+  // 3) Parse and format candidate
+  const baseSlug = baseBranchSlugSchema.parse(raw)
+  let candidate = prefix ? `${prefix}/${baseSlug}` : baseSlug
+  candidate = trimToMax(candidate, MAX_BRANCH_NAME_LENGTH)
 
   // 4) Ensure uniqueness by appending numeric suffixes
   if (!existing.has(candidate)) return candidate
 
   let attempt = 2
   while (attempt <= maxAttempts) {
-    const next = trimToMax(`${candidate}-${attempt}`, 200)
+    const next = trimToMax(`${candidate}-${attempt}`, MAX_BRANCH_NAME_LENGTH)
     if (!existing.has(next)) return next
     attempt++
   }
 
   // 5) As a last resort, include a timestamp suffix
-  const fallback = trimToMax(`${candidate}-${Date.now()}`, 200)
+  const fallback = trimToMax(
+    `${candidate}-${Date.now()}`,
+    MAX_BRANCH_NAME_LENGTH
+  )
   if (!existing.has(fallback)) return fallback
 
   // Extremely unlikely path: random suffix
   return trimToMax(
     `${candidate}-${Math.random().toString(36).slice(2, 8)}`,
-    200
+    MAX_BRANCH_NAME_LENGTH
   )
-}
-
-function sanitizeToSlug(input: string): string {
-  const s = input
-    .toLowerCase()
-    // Replace separators and whitespace with hyphen
-    .replace(/[\s_/|]+/g, "-")
-    // Remove invalid git ref characters
-    .replace(/[~^:\\?*\[\]@{}]+/g, "")
-    // Collapse multiple hyphens
-    .replace(/-+/g, "-")
-    // Trim hyphens and dots
-    .replace(/^[.-]+|[.-]+$/g, "")
-  // Disallow sequences that end a path segment with .lock or .
-  return s
 }
 
 function trimToMax(input: string, max: number): string {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -7,6 +7,8 @@ export * from "@/shared/src/core/ports/github"
 export * from "@/shared/src/core/ports/llm"
 export * from "@/shared/src/core/ports/refs"
 export * from "@/shared/src/core/usecases/generateBranchName"
+export * from "@/shared/src/ui/IssueRow"
+export * from "@/shared/src/ui/Microphone"
 export type { LogMeta } from "@/shared/src/utils/telemetry"
 export {
   logEnd,
@@ -14,6 +16,3 @@ export {
   logStart,
   withTiming,
 } from "@/shared/src/utils/telemetry"
-export * from "@/shared/src/ui/IssueRow"
-export * from "@/shared/src/ui/Microphone"
-

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -5,6 +5,8 @@ export {
 } from "@/shared/src/adapters/decorators/timing"
 export * from "@/shared/src/core/ports/github"
 export * from "@/shared/src/core/ports/llm"
+export * from "@/shared/src/core/ports/refs"
+export * from "@/shared/src/core/usecases/generateBranchName"
 export type { LogMeta } from "@/shared/src/utils/telemetry"
 export {
   logEnd,


### PR DESCRIPTION
Summary
- Added a clean-architecture use case to generate a non-conflicting branch name using an injected LLM and a new GitHub refs port.
- Introduced a new port (GitHubRefsPort) for listing remote branches of a repository.
- Exported the new port and use case from the shared package for easy consumption by apps/adapters later.

Details
- New port: shared/src/core/ports/refs.ts
  - interface GitHubRefsPort { listBranches({ owner, repo }): Promise<string[]> }
- New use case: shared/src/core/usecases/generateBranchName.ts
  - generateNonConflictingBranchName(ports, params):
    - Uses LLMPort to propose a short kebab-case slug from the provided context.
    - Sanitizes the suggestion into a valid branch path with a configurable prefix (default: "feature").
    - Ensures uniqueness by checking against existing remote branches (from GitHubRefsPort or an explicit list) and appending numeric/timestamp suffixes if needed.

Why this approach
- Keeps domain logic pure: only depends on ports (LLM and GitHub refs) and returns a deterministic branch name.
- Branch conflict avoidance is handled in the use case instead of pushing the entire branch list into the LLM context.
- Matches our target code structure direction (domain code in shared core). No adapters were added as requested.

Usage example (pseudo-code)
const name = await generateNonConflictingBranchName(
  { llm, refs },
  {
    owner: "octocat",
    repo: "Hello-World",
    context: JSON.stringify({ issue: 123, summary: "Add dismiss button to toasts" }),
    prefix: "feature",
  }
)
// => e.g. "feature/add-dismiss-button-to-toasts" or with a suffix if already taken

Checks
- next lint passes (with existing warnings unrelated to this change)
- TypeScript strict build via "pnpm run lint:tsc" passes

Closes #1120