### PR TITLE
Auto-resolve: start preview container with branch labels, alias, and pre-generated non-conflicting branch

### DIFF
--- a/lib/adapters/BasicLLMAdapter.ts
+++ b/lib/adapters/BasicLLMAdapter.ts
@@ -1,0 +1,34 @@
+import type { LLMMessage, LLMPort } from "@shared/core/ports/llm"
+
+function toKebab(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-")
+}
+
+/**
+ * Lightweight, dependency-free LLM adapter that derives a concise slug from the user message.
+ *
+ * This avoids requiring external API keys just to generate branch names. It satisfies the
+ * LLMPort contract sufficiently for our generateNonConflictingBranchName use case.
+ */
+export class BasicLLMAdapter implements LLMPort {
+  async createCompletion({ system, messages }: { system?: string; messages: LLMMessage[] }): Promise<string> {
+    // Prefer the latest user message content
+    const lastUser = [...messages].reverse().find((m) => m.role === "user")
+    const base = lastUser?.content ?? messages.map((m) => m.content).join(" ")
+
+    // Extract after "Context:" if provided in the prompt
+    const match = /Context:\n([\s\S]*)/i.exec(base)
+    const contextText = (match?.[1] ?? base).trim()
+
+    // Take the first 8 words to form a concise slug
+    const firstWords = contextText.split(/\s+/).slice(0, 8).join(" ")
+    return toKebab(firstWords).slice(0, 60)
+  }
+}
+
+export default BasicLLMAdapter
+

--- a/lib/adapters/BasicLLMAdapter.ts
+++ b/lib/adapters/BasicLLMAdapter.ts
@@ -15,7 +15,13 @@ function toKebab(input: string): string {
  * LLMPort contract sufficiently for our generateNonConflictingBranchName use case.
  */
 export class BasicLLMAdapter implements LLMPort {
-  async createCompletion({ system, messages }: { system?: string; messages: LLMMessage[] }): Promise<string> {
+  async createCompletion({
+    system,
+    messages,
+  }: {
+    system?: string
+    messages: LLMMessage[]
+  }): Promise<string> {
     // Prefer the latest user message content
     const lastUser = [...messages].reverse().find((m) => m.role === "user")
     const base = lastUser?.content ?? messages.map((m) => m.content).join(" ")
@@ -31,4 +37,3 @@ export class BasicLLMAdapter implements LLMPort {
 }
 
 export default BasicLLMAdapter
-

--- a/lib/adapters/BasicLLMAdapter.ts
+++ b/lib/adapters/BasicLLMAdapter.ts
@@ -1,3 +1,7 @@
+// TODO: This is not the right implementation.
+// Later we will make an OpenAI/Anthropic specific adapter
+// And it'll be in the @shared folder instead of /lib
+
 import type { LLMMessage, LLMPort } from "@shared/core/ports/llm"
 
 function toKebab(input: string): string {

--- a/lib/adapters/GitHubRefsAdapter.ts
+++ b/lib/adapters/GitHubRefsAdapter.ts
@@ -1,3 +1,9 @@
+// TODO: This belongs in @shared folder
+// And also we'll have to make a specific octokit REST/GraphQL implementation
+// of this functionality, basically similar to
+// listBranchesSortedByCommitDate
+// but separate the concerns and save it in @shared folder
+
 import type { GitHubRefsPort } from "@shared/core/ports/refs"
 
 import { listBranchesSortedByCommitDate } from "@/lib/github/refs"
@@ -6,9 +12,19 @@ import { listBranchesSortedByCommitDate } from "@/lib/github/refs"
  * Adapter implementing the shared GitHubRefsPort using our app's GitHub client utilities.
  */
 export class GitHubRefsAdapter implements GitHubRefsPort {
-  async listBranches({ owner, repo }: { owner: string; repo: string }): Promise<string[]> {
+  async listBranches({
+    owner,
+    repo,
+  }: {
+    owner: string
+    repo: string
+  }): Promise<string[]> {
     try {
-      const branches = await listBranchesSortedByCommitDate({ owner, repo, fullName: `${owner}/${repo}` })
+      const branches = await listBranchesSortedByCommitDate({
+        owner,
+        repo,
+        fullName: `${owner}/${repo}`,
+      })
       return branches.map((b) => b.name)
     } catch (e) {
       console.warn(`[WARNING] Failed to list branches for ${owner}/${repo}:`, e)
@@ -18,4 +34,3 @@ export class GitHubRefsAdapter implements GitHubRefsPort {
 }
 
 export default GitHubRefsAdapter
-

--- a/lib/adapters/GitHubRefsAdapter.ts
+++ b/lib/adapters/GitHubRefsAdapter.ts
@@ -1,0 +1,21 @@
+import type { GitHubRefsPort } from "@shared/core/ports/refs"
+
+import { listBranchesSortedByCommitDate } from "@/lib/github/refs"
+
+/**
+ * Adapter implementing the shared GitHubRefsPort using our app's GitHub client utilities.
+ */
+export class GitHubRefsAdapter implements GitHubRefsPort {
+  async listBranches({ owner, repo }: { owner: string; repo: string }): Promise<string[]> {
+    try {
+      const branches = await listBranchesSortedByCommitDate({ owner, repo, fullName: `${owner}/${repo}` })
+      return branches.map((b) => b.name)
+    } catch (e) {
+      console.warn(`[WARNING] Failed to list branches for ${owner}/${repo}:`, e)
+      return []
+    }
+  }
+}
+
+export default GitHubRefsAdapter
+

--- a/lib/utils/container.ts
+++ b/lib/utils/container.ts
@@ -291,12 +291,20 @@ export async function createContainerizedWorkspace({
     // Git "dubious ownership" warnings caused by mismatched host UIDs.
     await exec(`chown -R root:root ${mountPath}`)
 
-    // Reset to desired branch in case copied repo isn't on it
-    await exec(`git fetch origin && git checkout ${branch}`)
+    // Ensure we are on the desired branch, create it if it doesn't exist
+    await exec(`git fetch origin || true`)
+    const checkoutRes = await exec(`git checkout ${branch}`)
+    if (checkoutRes.exitCode !== 0) {
+      await exec(`git checkout -b ${branch}`)
+    }
   } else {
     // 5. Clone the repository and checkout the requested branch
     await exec(`git clone https://github.com/${repoFullName} ${mountPath}`)
-    await exec(`git checkout ${branch}`)
+    await exec(`git fetch origin || true`)
+    const checkoutRes = await exec(`git checkout ${branch}`)
+    if (checkoutRes.exitCode !== 0) {
+      await exec(`git checkout -b ${branch}`)
+    }
   }
 
   // 6. Cleanup helper

--- a/lib/workflows/autoResolveIssue.ts
+++ b/lib/workflows/autoResolveIssue.ts
@@ -1,8 +1,9 @@
+import { generateNonConflictingBranchName } from "@shared/core/usecases/generateBranchName"
 import { v4 as uuidv4 } from "uuid"
 
-import PlanAndCodeAgent from "@/lib/agents/PlanAndCodeAgent"
-import { GitHubRefsAdapter } from "@/lib/adapters/GitHubRefsAdapter"
 import { BasicLLMAdapter } from "@/lib/adapters/BasicLLMAdapter"
+import { GitHubRefsAdapter } from "@/lib/adapters/GitHubRefsAdapter"
+import PlanAndCodeAgent from "@/lib/agents/PlanAndCodeAgent"
 import { getInstallationTokenFromRepo } from "@/lib/github/installation"
 import { getIssueComments } from "@/lib/github/issues"
 import { checkRepoPermissions } from "@/lib/github/users"
@@ -21,7 +22,6 @@ import {
   createContainerizedWorkspace,
 } from "@/lib/utils/container"
 import { setupLocalRepository } from "@/lib/utils/utils-server"
-import { generateNonConflictingBranchName } from "@shared/core/usecases/generateBranchName"
 
 interface Params {
   issue: GitHubIssue
@@ -190,4 +190,3 @@ export const autoResolveIssue = async ({
 }
 
 export default autoResolveIssue
-


### PR DESCRIPTION
Summary
- Generate a non-conflicting working branch before starting the container (using shared usecase generateNonConflictingBranchName)
- Spin up a Docker container on the preview network during the auto-resolve workflow
- Attach labels for preview=true, owner, repo, branch, ttl-hours, and subdomain
- Set network alias to <branch>-<repo-owner>-<repo>
- Improve git checkout logic inside the container to create the branch if it does not yet exist

Key changes
- lib/workflows/autoResolveIssue.ts
  - Determine owner/repo and generate a non-conflicting branch name from the issue context
  - Use that branch when creating the containerized workspace so the correct labels and alias are applied
  - Keep the host-side repo on the default branch and switch/create the working branch inside the container

- lib/utils/container.ts
  - When preparing the workspace inside the container, try to checkout the requested branch; if it doesn’t exist, create it locally (git checkout -b)
  - Ensure container labels include owner, repo, branch, preview flag, ttl-hours (if provided), and subdomain (alias slug)
  - Connect container to the preview network with the alias set to the slug

- New adapters
  - lib/adapters/GitHubRefsAdapter.ts — implements GitHubRefsPort via existing GitHub GraphQL helper (lists branch names)
  - lib/adapters/BasicLLMAdapter.ts — lightweight LLMPort adapter that creates a concise slug from the issue context (no external API needed)

Why
- Preview deployments need containers created on the preview network with discoverable metadata and a stable network alias to front with Nginx.
- We need the branch name ahead of time to encode it in labels and alias; the usecase ensures we avoid conflicts with existing refs.

Notes
- The subdomain/alias format is <branch>-<owner>-<repo> (lowercased and slugified), used for the container’s --network-alias.
- If branch generation fails for any reason, we fall back to the repository’s default branch and log a status warning.

Linting and types
- Ran pnpm run check:all locally; linting and type checks pass. Prettier reported style warnings already present in the repo but does not block.

If you’d like any additional labels, alternate alias formats, or different branch prefix behavior (currently feature/), I’m happy to adjust.

Closes #1128