### PR TITLE
Redesign: shared autoresolve use case + streamlined event reporting

### DIFF
--- a/lib/adapters/WorkflowReporter.ts
+++ b/lib/adapters/WorkflowReporter.ts
@@ -1,0 +1,67 @@
+import type { WorkflowReporter } from "@shared/core/ports/events"
+
+import workflowEventEmitter from "@/lib/services/EventEmitter"
+import {
+  createErrorEvent,
+  createStatusEvent,
+  createWorkflowStateEvent,
+} from "@/lib/neo4j/services/event"
+
+/**
+ * Adapter that bridges the shared WorkflowReporter port to our Neo4j-backed
+ * event store and in-memory streaming bus.
+ */
+export class Neo4jWorkflowReporter implements WorkflowReporter {
+  constructor(private readonly workflowId: string, private readonly scope?: string) {}
+
+  private withScope(message?: string) {
+    if (!message) return undefined
+    return this.scope ? `[${this.scope}] ${message}` : message
+  }
+
+  async start(message?: string): Promise<void> {
+    await createWorkflowStateEvent({ workflowId: this.workflowId, state: "running" })
+    if (message) await this.status(message)
+  }
+
+  async status(message: string): Promise<void> {
+    const content = this.withScope(message)!
+    await createStatusEvent({ workflowId: this.workflowId, content })
+    workflowEventEmitter.emit(this.workflowId, {
+      type: "status",
+      data: { status: content },
+      timestamp: new Date(),
+    })
+  }
+
+  async info(message: string): Promise<void> {
+    // For now we map info to status to reduce event types in the UI
+    await this.status(message)
+  }
+
+  async warn(message: string): Promise<void> {
+    // Use a simple [WARNING] prefix to keep UI consistent
+    await this.status(`[WARNING]: ${message}`)
+  }
+
+  async complete(message?: string): Promise<void> {
+    await createWorkflowStateEvent({ workflowId: this.workflowId, state: "completed" })
+    if (message) await this.status(message)
+  }
+
+  async error(message: string): Promise<void> {
+    const content = this.withScope(message)!
+    await createErrorEvent({ workflowId: this.workflowId, content })
+    await createWorkflowStateEvent({ workflowId: this.workflowId, state: "error", content })
+    workflowEventEmitter.emit(this.workflowId, {
+      type: "error",
+      data: { error: content },
+      timestamp: new Date(),
+    })
+  }
+
+  child(scope: string): WorkflowReporter {
+    return new Neo4jWorkflowReporter(this.workflowId, scope)
+  }
+}
+

--- a/shared/src/core/ports/events.ts
+++ b/shared/src/core/ports/events.ts
@@ -1,0 +1,55 @@
+export type WorkflowState = "pending" | "running" | "completed" | "error"
+
+export interface WorkflowReporter {
+  /**
+   * Called once at the beginning of a workflow run. The implementation
+   * may persist a workflow state event and/or stream to clients.
+   */
+  start(message?: string): Promise<void>
+
+  /**
+   * General status update. Prefer short, human-readable messages.
+   */
+  status(message: string): Promise<void>
+
+  /**
+   * Informational message that doesn't represent a step transition.
+   */
+  info(message: string): Promise<void>
+
+  /**
+   * Warning message that doesn't fail the workflow but signals degraded path.
+   */
+  warn(message: string): Promise<void>
+
+  /**
+   * Finalize the workflow as successfully completed.
+   */
+  complete(message?: string): Promise<void>
+
+  /**
+   * Record an error and mark the workflow as failed.
+   */
+  error(message: string): Promise<void>
+
+  /**
+   * Create a scoped reporter that prefixes messages with the given scope.
+   * Useful to nest steps such as "branch-generation", "env-setup", etc.
+   */
+  child(scope: string): WorkflowReporter
+}
+
+/**
+ * No-op reporter for tests or CLI usage where event persistence/streaming
+ * is not required. This keeps the use case pure and easy to unit-test.
+ */
+export class NoopWorkflowReporter implements WorkflowReporter {
+  start = async () => {}
+  status = async () => {}
+  info = async () => {}
+  warn = async () => {}
+  complete = async () => {}
+  error = async () => {}
+  child = (_scope: string) => this
+}
+

--- a/shared/src/core/usecases/autoResolveIssue.ts
+++ b/shared/src/core/usecases/autoResolveIssue.ts
@@ -1,0 +1,242 @@
+import { generateNonConflictingBranchName } from "@shared/core/usecases/generateBranchName"
+import type { LLMPort } from "@shared/core/ports/llm"
+import type { GitHubRefsPort } from "@shared/core/ports/refs"
+import type { WorkflowReporter } from "@shared/core/ports/events"
+
+export interface IssueLite {
+  number: number
+  title: string
+  body?: string | null
+}
+
+export interface RepositoryLite {
+  full_name: string // e.g. "owner/repo"
+  default_branch: string
+}
+
+export type CommentLite = {
+  user?: { login?: string | null } | null
+  created_at: string | Date
+  body?: string | null
+}
+
+export interface RepoEnvironmentLite {
+  kind: string
+  name: string
+}
+
+export type CodeAgentInput = {
+  role: "user" | "assistant"
+  content: string
+  type: "message"
+}
+
+export interface CodeAgent {
+  addInput(input: CodeAgentInput): Promise<void>
+  runWithFunctions(): Promise<unknown>
+}
+
+export interface CodeAgentFactory {
+  create(params: {
+    apiKey: string
+    env: RepoEnvironmentLite
+    defaultBranch: string
+    issueNumber: number
+    repository: RepositoryLite
+    sessionToken: string
+    jobId: string
+  }): CodeAgent
+}
+
+export interface PermissionsPort {
+  checkRepoPermissions(repoFullName: string): Promise<{
+    canPush: boolean
+    canCreatePR: boolean
+  }>
+}
+
+export interface WorkflowRunPort {
+  initialize(params: {
+    id: string
+    type: "autoResolveIssue"
+    issueNumber: number
+    repoFullName: string
+    postToGithub: boolean
+  }): Promise<void>
+  setState(state: "running" | "completed" | "error", content?: string): Promise<void>
+}
+
+export interface LocalRepoPort {
+  setupLocalRepository(params: {
+    repoFullName: string
+    workingBranch: string
+  }): Promise<string> // hostRepoPath
+}
+
+export interface ContainerWorkspacePort {
+  createWorkspace(params: {
+    repoFullName: string
+    branch: string
+    workflowId: string
+    hostRepoPath: string
+  }): Promise<{ containerName: string }>
+  createDirectoryTree(containerName: string): Promise<string[]>
+}
+
+export interface GithubIssueCommentsPort {
+  getIssueComments(params: {
+    repoFullName: string
+    issueNumber: number
+  }): Promise<CommentLite[]>
+}
+
+export interface InstallationAuthPort {
+  getInstallationTokenFromRepo(params: { owner: string; repo: string }): Promise<string>
+}
+
+export type AutoResolvePorts = {
+  llm: LLMPort
+  refs: GitHubRefsPort
+  reporter: WorkflowReporter
+  permissions: PermissionsPort
+  workflowRun: WorkflowRunPort
+  localRepo: LocalRepoPort
+  workspace: ContainerWorkspacePort
+  ghComments: GithubIssueCommentsPort
+  installationAuth: InstallationAuthPort
+  agentFactory: CodeAgentFactory
+}
+
+export type AutoResolveParams = {
+  issue: IssueLite
+  repository: RepositoryLite
+  apiKey: string
+  jobId: string
+}
+
+export async function autoResolveIssueUseCase(
+  ports: AutoResolvePorts,
+  { issue, repository, apiKey, jobId }: AutoResolveParams
+): Promise<unknown> {
+  const { reporter } = ports
+
+  await ports.workflowRun.initialize({
+    id: jobId,
+    type: "autoResolveIssue",
+    issueNumber: issue.number,
+    repoFullName: repository.full_name,
+    postToGithub: true,
+  })
+
+  await ports.workflowRun.setState("running")
+  await reporter.start(`Starting auto resolve workflow for issue #${issue.number}`)
+
+  const { canPush, canCreatePR } = await ports.permissions.checkRepoPermissions(
+    repository.full_name
+  )
+
+  if (!canCreatePR || !canPush) {
+    await reporter.warn(
+      `Insufficient permissions to push code changes or create PR\nCan push?: ${canPush}\nCan create PR?: ${canCreatePR}`
+    )
+  }
+
+  // Decide working branch
+  const [owner, repo] = repository.full_name.split("/")
+  let workingBranch = repository.default_branch
+  try {
+    const context = `GitHub issue title: ${issue.title}\n\n${issue.body ?? ""}`
+    const generated = await generateNonConflictingBranchName(
+      { llm: ports.llm, refs: ports.refs },
+      { owner, repo, context, prefix: "feature" }
+    )
+    workingBranch = generated
+    await reporter.status(`Using working branch: ${generated}`)
+  } catch (e) {
+    await reporter.warn(
+      `Failed to generate non-conflicting branch name, falling back to default branch ${repository.default_branch}. Error: ${String(
+        e
+      )}`
+    )
+    workingBranch = repository.default_branch
+  }
+
+  const hostRepoPath = await ports.localRepo.setupLocalRepository({
+    repoFullName: repository.full_name,
+    workingBranch: repository.default_branch, // prepare default locally; branch will be created in container if needed
+  })
+
+  const { containerName } = await ports.workspace.createWorkspace({
+    repoFullName: repository.full_name,
+    branch: workingBranch,
+    workflowId: jobId,
+    hostRepoPath,
+  })
+
+  const env: RepoEnvironmentLite = { kind: "container", name: containerName }
+
+  const sessionToken = await ports.installationAuth.getInstallationTokenFromRepo({
+    owner,
+    repo,
+  })
+
+  const agent = ports.agentFactory.create({
+    apiKey,
+    env,
+    defaultBranch: repository.default_branch,
+    issueNumber: issue.number,
+    repository,
+    sessionToken,
+    jobId,
+  })
+
+  const tree = await ports.workspace.createDirectoryTree(containerName)
+  const comments = await ports.ghComments.getIssueComments({
+    repoFullName: repository.full_name,
+    issueNumber: issue.number,
+  })
+
+  await agent.addInput({
+    role: "user",
+    content: `Github issue title: ${issue.title}\nGithub issue description: ${issue.body}`,
+    type: "message",
+  })
+
+  if (comments && comments.length > 0) {
+    await agent.addInput({
+      role: "user",
+      content: `Github issue comments:\n${comments
+        .map(
+          (c) =>
+            `\n- **User**: ${c.user?.login ?? "unknown"}\n- **Created At**: ${new Date(
+              c.created_at
+            ).toLocaleString()}\n- **Comment**: ${c.body ?? ""}`
+        )
+        .join("\n")}`,
+      type: "message",
+    })
+  }
+
+  if (tree && tree.length > 0) {
+    await agent.addInput({
+      role: "user",
+      content: `Here is the codebase's tree directory:\n${tree.join("\n")}`,
+      type: "message",
+    })
+  }
+
+  await reporter.status("Running agent")
+
+  try {
+    const result = await agent.runWithFunctions()
+    await ports.workflowRun.setState("completed")
+    await reporter.complete("Workflow completed")
+    return result
+  } catch (error) {
+    const msg = String(error)
+    await reporter.error(msg)
+    await ports.workflowRun.setState("error", msg)
+    throw error
+  }
+}
+

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -7,7 +7,9 @@ export { makeOpenAIAdapter } from "@/shared/src/adapters/openai"
 export * from "@/shared/src/core/ports/github"
 export * from "@/shared/src/core/ports/llm"
 export * from "@/shared/src/core/ports/refs"
+export * from "@/shared/src/core/ports/events"
 export * from "@/shared/src/core/usecases/generateBranchName"
+export * from "@/shared/src/core/usecases/autoResolveIssue"
 export * from "@/shared/src/ui/IssueRow"
 export * from "@/shared/src/ui/Microphone"
 export * from "@/shared/src/ui/button"
@@ -18,3 +20,4 @@ export {
   logStart,
   withTiming,
 } from "@/shared/src/utils/telemetry"
+


### PR DESCRIPTION
Summary
- Added a new shared use case autoResolveIssueUseCase that encapsulates the existing auto-resolve workflow as pure orchestration with dependency-injected ports. This allows us to reuse the workflow across environments without coupling to app adapters.
- Introduced a WorkflowReporter port (and NoopWorkflowReporter) to standardize event emission and reduce create*Event clutter. Events can now be expressed as reporter.start/status/warn/error/complete and scoped via child().
- Implemented a Neo4jWorkflowReporter adapter that bridges the WorkflowReporter port to our existing Neo4j event services and in-memory EventEmitter for streaming.
- Exported the new ports and use case from shared.

Why
- The current workflow code has many scattered createEvent calls which impacts readability and makes testing difficult.
- Moving the core workflow into shared + ports lets us evolve implementations independently and simplifies unit testing.

What changed
- shared/src/core/ports/events.ts: New WorkflowReporter port with methods start/status/info/warn/complete/error and child(), plus a NoopWorkflowReporter for tests/CLI.
- shared/src/core/usecases/autoResolveIssue.ts: New use case that mirrors the current lib/workflows/autoResolveIssue.ts logic but expressed via ports and the new reporter.
- lib/adapters/WorkflowReporter.ts: New adapter that persists workflow state and status/error events to Neo4j and emits over the in-memory bus.
- shared/src/index.ts: Export new port and use case.

How to adopt
- In lib/workflows/autoResolveIssue.ts (or future workflows), instead of many createStatusEvent/createErrorEvent calls, construct a Neo4jWorkflowReporter with the workflowId and pass it into the shared use case (along with the other adapters for ports). Messages become reporter.status("…")/reporter.warn("…"), etc.
- You can also create scoped reporters for steps: const branchReporter = reporter.child("branch"); branchReporter.status("generated feature/foo-bar").

Notes
- This PR does not yet wire the shared use case into the app to keep changes small and focused. It provides the primitives and patterns to migrate incrementally.
- All repo-defined lint/type checks pass locally (next lint, prettier --check, tsc --noEmit).

Closes #1142