### PR TITLE
Add simple pricing page and homepage section with Stripe link placeholder

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,19 +1,13 @@
 import { auth } from "@/auth"
 import IssueDashboard from "@/components/home/IssueDashboard"
-import AgentArchitecture from "@/components/landing-page/AgentArchitecture"
-import Benefits from "@/components/landing-page/Benefits"
-import ComparisonToIDEAgents from "@/components/landing-page/ComparisonToIDEAgents"
-import Features from "@/components/landing-page/Features"
 import Footer from "@/components/landing-page/Footer"
-import GetStarted from "@/components/landing-page/GetStarted"
 import Hero from "@/components/landing-page/Hero"
 import NonDeveloperBenefits from "@/components/landing-page/NonDeveloperBenefits"
-import PlanningFeature from "@/components/landing-page/PlanningFeature"
-import Pricing from "@/components/landing-page/Pricing"
-import Steps from "@/components/landing-page/Steps"
+import SimplePricing from "@/components/landing-page/SimplePricing"
 import GridBackground from "@/components/ui/grid-background"
 
 import OpenAIApiKeyCard from "./OpenAIApiKeyCard"
+import Benefits from "@/components/landing-page/Benefits"
 
 export default async function LandingPage() {
   const session = await auth()
@@ -37,8 +31,10 @@ export default async function LandingPage() {
           <Benefits />
           <NonDeveloperBenefits />
         </GridBackground>
+        <SimplePricing />
       </main>
       <Footer />
     </div>
   )
 }
+

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,0 +1,17 @@
+import SimplePricing from "@/components/landing-page/SimplePricing"
+
+export const metadata = {
+  title: "Pricing | Issue To PR",
+  description: "Simple, beautiful, and professional pricing with a single $10 plan.",
+}
+
+export default function PricingPage() {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <main>
+        <SimplePricing />
+      </main>
+    </div>
+  )
+}
+

--- a/components/landing-page/SimplePricing.tsx
+++ b/components/landing-page/SimplePricing.tsx
@@ -1,0 +1,100 @@
+"use client"
+
+import { motion } from "framer-motion"
+import { Check } from "lucide-react"
+import Link from "next/link"
+import React from "react"
+
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import MovingBorderCard from "@/components/ui/moving-border-card"
+import ShineButton from "@/components/ui/shine-button"
+import TextLg from "@/components/ui/text-lg"
+import TextMd from "@/components/ui/text-md"
+
+type SimplePricingProps = {
+  paymentLink?: string
+}
+
+const DEFAULT_PAYMENT_LINK =
+  process.env.NEXT_PUBLIC_STRIPE_PAYMENT_LINK || 
+  "#" // TODO: Replace with your Stripe payment link
+
+export default function SimplePricing({
+  paymentLink = DEFAULT_PAYMENT_LINK,
+}: SimplePricingProps) {
+  const features = [
+    "One straightforward plan — no tiers",
+    "Professional UI for your issues to PRs workflow",
+    "Cancel anytime",
+  ]
+
+  return (
+    <motion.section
+      id="pricing"
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.2 }}
+      transition={{ duration: 0.6 }}
+      className="relative py-16 sm:py-20 flex flex-col items-center justify-center overflow-hidden border-t-2 border-black"
+    >
+      <div className="text-center mb-10">
+        <TextLg className="max-w-2xl">
+          <span className="italic text-accent">Simple</span>, beautiful, and
+          professional pricing
+        </TextLg>
+        <TextMd className="mt-2 text-muted-foreground">
+          One plan that fits most builders
+        </TextMd>
+      </div>
+
+      <div className="w-full max-w-4xl px-4">
+        <MovingBorderCard wrapperClassName="rounded-3xl h-full">
+          <Card className="shadow-xl rounded-3xl overflow-hidden bg-white/95 backdrop-blur-sm border border-accent/20 h-full flex flex-col">
+            <CardHeader className="py-8 text-center bg-gradient-to-r from-accent to-accent/80">
+              <h2 className="text-4xl sm:text-5xl font-bold text-accent-foreground">
+                $10
+              </h2>
+              <p className="text-sm text-accent-foreground/90 mt-1">
+                Simple plan — pay once to get started
+              </p>
+            </CardHeader>
+
+            <div className="w-full flex items-center justify-center mt-6 px-6">
+              <Link href={paymentLink} className="w-full" target={paymentLink.startsWith("http") ? "_blank" : undefined}>
+                <ShineButton className="text-base w-full sm:text-lg py-3.5 bg-gradient-to-r from-accent to-accent/80 text-accent-foreground hover:from-accent/90 hover:to-accent/70 border-none font-medium">
+                  Buy now — $10
+                </ShineButton>
+              </Link>
+            </div>
+
+            <CardContent className="p-6 sm:p-8">
+              <div className="flex flex-col items-start justify-start space-y-3 max-w-xl mx-auto">
+                {features.map((feature, index) => (
+                  <motion.div
+                    key={feature}
+                    initial={{ opacity: 0, x: -5 }}
+                    whileInView={{ opacity: 1, x: 0 }}
+                    viewport={{ once: true }}
+                    transition={{ delay: 0.05 * index, duration: 0.25 }}
+                    className="flex items-start"
+                  >
+                    <div className="min-w-[24px] h-6 flex items-center justify-center bg-accent/20 rounded-full mr-3">
+                      <Check size={14} strokeWidth={3} className="text-accent" />
+                    </div>
+                    <p className="text-sm sm:text-base text-foreground">{feature}</p>
+                  </motion.div>
+                ))}
+              </div>
+              <div className="text-center mt-6">
+                <Link href="/pricing" className="underline underline-offset-4 text-muted-foreground hover:text-foreground">
+                  Learn more about pricing
+                </Link>
+              </div>
+            </CardContent>
+          </Card>
+        </MovingBorderCard>
+      </div>
+    </motion.section>
+  )
+}
+


### PR DESCRIPTION
Summary
- Implemented a new SimplePricing component with a single $10 plan
- Added a Buy Now button that links to a configurable Stripe payment URL
- Created a dedicated /pricing page
- Appended the SimplePricing section to the public homepage so pricing appears at the end

Stripe link configuration
- The button reads from NEXT_PUBLIC_STRIPE_PAYMENT_LINK
- If not set, it defaults to '#'
- To wire up Stripe, set NEXT_PUBLIC_STRIPE_PAYMENT_LINK in your environment, for example:

  NEXT_PUBLIC_STRIPE_PAYMENT_LINK=https://buy.stripe.com/your_payment_link

Design goals
- Simple, beautiful, and professional: one clear plan, minimal copy, smooth motion/animation
- Prominent CTA and a short feature list

Code quality
- Followed the existing component style (Tailwind + shadcn UI components)
- Ran repository checks (next lint, prettier --check, tsc --noEmit) — all passed with only warnings in unrelated files

Files changed
- components/landing-page/SimplePricing.tsx (new)
- app/pricing/page.tsx (new)
- app/page.tsx (append SimplePricing to the end for non-authenticated users)

Notes
- When you provide the Stripe Payment Link, just set the env var and the Buy Now buttons will link to it automatically.
- Added a subtle link to the /pricing page from the section as well.

Closes #1148