### PR TITLE
feat(shared): add getIssue port and Octokit GraphQL adapter\n\n- Define IssueDetails and GetIssueErrors types\n- Add getIssue method to GitHubIssuesPort\n- Implement getIssue in GraphQL and REST adapters\n- Add minimal Octokit GraphQL issues adapter at shared/src/adapters/github/octokit/graphql/issues.ts\n- Extend timing decorator to instrument getIssue\n\nThese fields cover auto-resolve workflow needs (title, body, state, labels, assignees, URLs and timestamps).

### DIFF
--- a/shared/src/adapters/decorators/timing.ts
+++ b/shared/src/adapters/decorators/timing.ts
@@ -1,8 +1,10 @@
 import type {
   CreateIssueInput,
+  GetIssueErrors,
   GithubIssueErrors,
   GitHubIssuesPort,
   Issue,
+  IssueDetails,
   IssueRef,
   IssueTitleResult,
 } from "@shared/core/ports/github"
@@ -19,6 +21,13 @@ export class TimedGitHubIssuesPort implements GitHubIssuesPort {
     private labelPrefix = "GitHub",
     private enabled = process.env.ENABLE_TIMING === "1"
   ) {}
+
+  async getIssue(ref: IssueRef): Promise<Result<IssueDetails, GetIssueErrors>> {
+    if (!this.enabled) return this.inner.getIssue(ref)
+    return withTiming(`${this.labelPrefix}: getIssue`, () =>
+      this.inner.getIssue(ref)
+    )
+  }
 
   async getIssueTitles(refs: IssueRef[]): Promise<IssueTitleResult[]> {
     if (!this.enabled) {
@@ -68,3 +77,4 @@ export function decorateWithTiming<T extends object>(
     },
   })
 }
+

--- a/shared/src/adapters/github-graphql.ts
+++ b/shared/src/adapters/github-graphql.ts
@@ -2,9 +2,11 @@ import { graphql } from "@octokit/graphql"
 
 import type {
   CreateIssueInput,
+  GetIssueErrors,
   GithubIssueErrors,
   GitHubIssuesPort,
   Issue,
+  IssueDetails,
   IssueRef,
   IssueTitleResult,
 } from "@/shared/src/core/ports/github"
@@ -20,6 +22,109 @@ export function makeGitHubGraphQLAdapter(params: {
   const client = graphql.defaults({
     headers: { authorization: `token ${token}` },
   })
+
+  async function getIssue(ref: IssueRef): Promise<Result<IssueDetails, GetIssueErrors>> {
+    const [owner, name] = ref.repoFullName.split("/")
+    if (!owner || !name) return err("RepoNotFound")
+
+    const query = `
+      query($owner: String!, $name: String!, $number: Int!) {
+        repository(owner: $owner, name: $name) {
+          issue(number: $number) {
+            number
+            title
+            body
+            state
+            url
+            createdAt
+            updatedAt
+            closedAt
+            author { login }
+            labels(first: 50) { nodes { name } }
+            assignees(first: 50) { nodes { login } }
+          }
+        }
+      }
+    `
+
+    type Resp = {
+      repository: {
+        issue: {
+          number: number
+          title: string | null
+          body: string | null
+          state: "OPEN" | "CLOSED"
+          url: string
+          createdAt: string
+          updatedAt: string
+          closedAt?: string | null
+          author: { login: string } | null
+          labels: { nodes: { name: string }[] }
+          assignees: { nodes: { login: string }[] }
+        } | null
+      } | null
+    }
+
+    try {
+      const data = await client<Resp>(query, {
+        owner,
+        name,
+        number: ref.number,
+      })
+
+      if (!data.repository) return err("RepoNotFound")
+      const issue = data.repository.issue
+      if (!issue) return err("NotFound")
+
+      const details: IssueDetails = {
+        repoFullName: ref.repoFullName,
+        number: issue.number,
+        title: issue.title ?? null,
+        body: issue.body ?? null,
+        state: issue.state,
+        url: issue.url,
+        authorLogin: issue.author?.login ?? null,
+        labels: (issue.labels?.nodes || []).map((n) => n.name).filter(Boolean),
+        assignees: (issue.assignees?.nodes || [])
+          .map((n) => n.login)
+          .filter(Boolean),
+        createdAt: issue.createdAt,
+        updatedAt: issue.updatedAt,
+        closedAt: issue.closedAt ?? null,
+      }
+
+      return ok(details)
+    } catch (e: unknown) {
+      let message: string | undefined
+      let status: number | undefined
+
+      const errObj = e as Record<string, unknown> | null
+      if (errObj && typeof errObj === "object") {
+        if (typeof errObj.message === "string") {
+          message = errObj.message
+        }
+        if (typeof errObj.status === "number") {
+          status = errObj.status
+        } else if (
+          errObj.response &&
+          typeof (errObj.response as Record<string, unknown>).status ===
+            "number"
+        ) {
+          status = (errObj.response as Record<string, unknown>).status as number
+        }
+      }
+
+      if (status === 401 || status === 403) {
+        return err("AuthRequired", { message, status })
+      }
+
+      if (typeof message === "string" && /rate\s*limit/i.test(message)) {
+        return err("RateLimited", { message })
+      }
+
+      return err("Unknown", { message, status })
+    }
+  }
 
   async function getIssueTitles(refs: IssueRef[]): Promise<IssueTitleResult[]> {
     if (refs.length === 0) return []
@@ -124,9 +229,10 @@ export function makeGitHubGraphQLAdapter(params: {
     }
   }
 
-  return { getIssueTitles, createIssue }
+  return { getIssue, getIssueTitles, createIssue }
 }
 
 // Backwards-compatible alias used elsewhere in the app
 export const makeGithubGraphQLAdapter = (token: string): GitHubIssuesPort =>
   makeGitHubGraphQLAdapter({ token })
+

--- a/shared/src/adapters/github-rest.ts
+++ b/shared/src/adapters/github-rest.ts
@@ -2,9 +2,11 @@ import { Octokit } from "@octokit/rest"
 
 import type {
   CreateIssueInput,
+  GetIssueErrors,
   GithubIssueErrors,
   GitHubIssuesPort,
   Issue,
+  IssueDetails,
   IssueRef,
   IssueTitleResult,
 } from "@/shared/src/core/ports/github"
@@ -18,6 +20,47 @@ export function makeGitHubRESTAdapter(params: {
 }): GitHubIssuesPort {
   const token = params.token
   const octokit = new Octokit({ auth: token })
+
+  async function getIssue(
+    ref: IssueRef
+  ): Promise<Result<IssueDetails, GetIssueErrors>> {
+    const [owner, repo] = ref.repoFullName.split("/")
+    if (!owner || !repo) return err("RepoNotFound")
+    try {
+      const { data } = await octokit.issues.get({
+        owner,
+        repo,
+        issue_number: ref.number,
+      })
+      const details: IssueDetails = {
+        repoFullName: ref.repoFullName,
+        number: data.number ?? ref.number,
+        title: data.title ?? null,
+        body: data.body ?? null,
+        state: (data.state?.toUpperCase() as "OPEN" | "CLOSED") || "OPEN",
+        url: data.html_url ?? "",
+        authorLogin: data.user?.login ?? null,
+        labels: (Array.isArray(data.labels) ? data.labels : [])
+          .map((l: any) => (typeof l === "string" ? l : l?.name))
+          .filter(Boolean) as string[],
+        assignees: (Array.isArray(data.assignees) ? data.assignees : [])
+          .map((a: any) => a?.login)
+          .filter(Boolean) as string[],
+        createdAt: data.created_at ?? new Date().toISOString(),
+        updatedAt: data.updated_at ?? new Date().toISOString(),
+        closedAt: data.closed_at ?? null,
+      }
+      return ok(details)
+    } catch (e: unknown) {
+      if (typeof e !== "object" || e === null) return err("Unknown")
+      const anyErr = e as { status?: number; message?: string }
+      if (anyErr.status === 404) return err("NotFound", { message: anyErr.message })
+      if (anyErr.status === 403) return err("Forbidden", { message: anyErr.message })
+      if (anyErr.status === 401) return err("AuthRequired", { message: anyErr.message })
+      if (anyErr.status === 429) return err("RateLimited", { message: anyErr.message })
+      return err("Unknown", { message: anyErr.message })
+    }
+  }
 
   // TODO: Seems it will make a network call for each issue.
   // Might consider calling listIssues with pagination for each repo, reducing number of requests.
@@ -72,11 +115,11 @@ export function makeGitHubRESTAdapter(params: {
 
       let status: number | undefined
       let message: string | undefined
-      if ("status" in e && typeof e.status === "number") {
-        status = e.status
+      if ("status" in e && typeof (e as any).status === "number") {
+        status = (e as any).status
       }
-      if ("message" in e && typeof e.message === "string") {
-        message = e.message
+      if ("message" in e && typeof (e as any).message === "string") {
+        message = (e as any).message
       }
 
       if (status === 401 || status === 403) {
@@ -99,9 +142,11 @@ export function makeGitHubRESTAdapter(params: {
   }
 
   return {
+    getIssue,
     getIssueTitles,
     createIssue,
   }
 }
 
 export default makeGitHubRESTAdapter
+

--- a/shared/src/adapters/github/octokit/graphql/issues.ts
+++ b/shared/src/adapters/github/octokit/graphql/issues.ts
@@ -1,0 +1,125 @@
+import { graphql } from "@octokit/graphql"
+
+import {
+  err,
+  ok,
+  type Result,
+} from "@/shared/src/entities/result"
+import type {
+  GetIssueErrors,
+  GitHubIssuesPort,
+  IssueDetails,
+  IssueRef,
+} from "@/shared/src/core/ports/github"
+
+/**
+ * Minimal Octokit GraphQL adapter focused on GitHub issues.
+ * It implements only the getIssue method from GitHubIssuesPort.
+ */
+export function makeOctokitGraphQLIssuesAdapter(params: {
+  token: string
+}): Pick<GitHubIssuesPort, "getIssue"> {
+  const client = graphql.defaults({
+    headers: { authorization: `token ${params.token}` },
+  })
+
+  const getIssue: GitHubIssuesPort["getIssue"] = async (
+    ref: IssueRef
+  ): Promise<Result<IssueDetails, GetIssueErrors>> => {
+    const [owner, name] = ref.repoFullName.split("/")
+    if (!owner || !name) return err("RepoNotFound")
+
+    const query = `
+      query($owner: String!, $name: String!, $number: Int!) {
+        repository(owner: $owner, name: $name) {
+          issue(number: $number) {
+            number
+            title
+            body
+            state
+            url
+            createdAt
+            updatedAt
+            closedAt
+            author { login }
+            labels(first: 50) { nodes { name } }
+            assignees(first: 50) { nodes { login } }
+          }
+        }
+      }
+    `
+
+    type Resp = {
+      repository: {
+        issue: {
+          number: number
+          title: string | null
+          body: string | null
+          state: "OPEN" | "CLOSED"
+          url: string
+          createdAt: string
+          updatedAt: string
+          closedAt?: string | null
+          author: { login: string } | null
+          labels: { nodes: { name: string }[] }
+          assignees: { nodes: { login: string }[] }
+        } | null
+      } | null
+    }
+
+    try {
+      const data = await client<Resp>(query, {
+        owner,
+        name,
+        number: ref.number,
+      })
+
+      const issue = data.repository?.issue
+      if (!data.repository) return err("RepoNotFound")
+      if (!issue) return err("NotFound")
+
+      const details: IssueDetails = {
+        repoFullName: ref.repoFullName,
+        number: issue.number,
+        title: issue.title ?? null,
+        body: issue.body ?? null,
+        state: issue.state,
+        url: issue.url,
+        authorLogin: issue.author?.login ?? null,
+        labels: (issue.labels?.nodes || []).map((n) => n.name).filter(Boolean),
+        assignees: (issue.assignees?.nodes || [])
+          .map((n) => n.login)
+          .filter(Boolean),
+        createdAt: issue.createdAt,
+        updatedAt: issue.updatedAt,
+        closedAt: issue.closedAt ?? null,
+      }
+
+      return ok(details)
+    } catch (e: unknown) {
+      let message: string | undefined
+      let status: number | undefined
+      const errObj = e as Record<string, unknown> | null
+      if (errObj && typeof errObj === "object") {
+        if (typeof errObj.message === "string") message = errObj.message
+        if (typeof errObj.status === "number") status = errObj.status
+        else if (
+          errObj.response &&
+          typeof (errObj.response as Record<string, unknown>).status ===
+            "number"
+        ) {
+          status = (errObj.response as Record<string, unknown>)
+            .status as number
+        }
+      }
+
+      if (status === 401 || status === 403) return err("AuthRequired", { status, message })
+      if (typeof message === "string" && /rate\s*limit/i.test(message)) return err("RateLimited", { message })
+
+      return err("Unknown", { status, message })
+    }
+  }
+
+  return { getIssue }
+}
+

--- a/shared/src/core/ports/github.ts
+++ b/shared/src/core/ports/github.ts
@@ -27,11 +27,40 @@ export type GithubIssueErrors =
   | "ValidationFailed"
   | "Unknown"
 
+// Key properties needed by auto-resolve and planning workflows
+// Keep this minimal and provider-agnostic
+export interface IssueDetails extends IssueRef {
+  title: string | null
+  body: string | null
+  state: "OPEN" | "CLOSED"
+  url: string
+  authorLogin: string | null
+  labels: string[] // label names only
+  assignees: string[] // assignee logins only
+  createdAt: string // ISO timestamp
+  updatedAt: string // ISO timestamp
+  closedAt?: string | null // ISO timestamp or null when open
+}
+
+export type GetIssueErrors =
+  | "AuthRequired"
+  | "RepoNotFound"
+  | "NotFound"
+  | "Forbidden"
+  | "IssuesDisabled"
+  | "RateLimited"
+  | "Unknown"
+
 /**
  * Abstraction over GitHub for reading issue metadata.
  * Implementations can use REST or GraphQL.
  */
 export interface GitHubIssuesPort {
+  /**
+   * Fetch a single issue with key properties used across workflows.
+   */
+  getIssue(ref: IssueRef): Promise<Result<IssueDetails, GetIssueErrors>>
+
   /**
    * Batch fetch issue titles for a set of (repo, number) pairs.
    * Implementations should be resilient to partial failures and return null titles when not found.
@@ -46,3 +75,4 @@ export interface GitHubIssuesPort {
     input: CreateIssueInput
   ): Promise<Result<Issue, GithubIssueErrors>>
 }
+


### PR DESCRIPTION
Summary
- Added a new getIssue method to the GitHubIssuesPort in shared to standardize fetching a single issue with the key fields needed by our workflows.
- Introduced IssueDetails and GetIssueErrors types to clarify the data contract and error handling.
- Implemented getIssue in both GraphQL and REST adapters for completeness.
- Added a focused Octokit GraphQL issues adapter under shared/src/adapters/github/octokit/graphql/issues.ts that provides a getIssue implementation.
- Updated the timing decorator to instrument the new getIssue method.

Why
The auto resolve workflow needs more than just titles. It relies on title, body, state and basic metadata to generate a working branch name and guide the planning/coding agents. Defining getIssue as a port keeps our clean architecture intact and enables both REST and GraphQL implementations.

Key properties returned by getIssue
- title: string | null
- body: string | null
- state: "OPEN" | "CLOSED"
- url: string
- authorLogin: string | null
- labels: string[] (label names)
- assignees: string[] (assignee logins)
- createdAt: ISO string
- updatedAt: ISO string
- closedAt: ISO string | null
- repoFullName, number (echoed from input)

Implementation details
- GraphQL adapter queries repository -> issue(number) with author, labels and assignees.
- REST adapter maps the REST response to IssueDetails and returns typed errors.
- Added a minimal Octokit GraphQL issues adapter (makeOctokitGraphQLIssuesAdapter) that implements getIssue and can be composed where needed.

Quality
- Ran pnpm i to set up the repo.
- Lint (next lint) passes (only benign warnings).
- Type-check (tsc --noEmit) passes.

Notes
This PR is intentionally small and focused on the port definition and adapter implementations. Future work can wire the new getIssue port into places where we currently fetch issues directly, such as the auto resolve workflow, to fully leverage the shared abstraction.

Closes #1141