### PR TITLE
Run auto-resolve issue workflow from worker using GitHub App tokens

### DIFF
--- a/__tests__/lib/usecases/generateBranchName.test.ts
+++ b/__tests__/lib/usecases/generateBranchName.test.ts
@@ -75,7 +75,7 @@ describe("generateNonConflictingBranchName", () => {
     expect(result).toBe(`${candidate}-5`)
   })
 
-  it("falls back to timestamp when maxAttempts is exhausted (and trims to max length)", async () => {
+  it("falls back to timestamp when maxAttempts is exhausted (no hard trimming)", async () => {
     const fixedNow = 1_725_000_000_000
     jest.spyOn(Date, "now").mockReturnValue(fixedNow)
 
@@ -97,8 +97,7 @@ describe("generateNonConflictingBranchName", () => {
       }
     )
 
-    expect(result.startsWith(`${candidate}-`)).toBe(true)
-    expect(result.length).toBeLessThanOrEqual(30)
+    expect(result).toBe(`${candidate}-${fixedNow}`)
   })
 
   it("cleans noisy LLM output and returns a kebab-case slug without prefix when not provided", async () => {
@@ -154,7 +153,7 @@ describe("generateNonConflictingBranchName", () => {
     expect(result).toBe("chore/refactor-components")
   })
 
-  it("trims the final branch name to the max length", async () => {
+  it("does not trim the final branch name to a hard limit", async () => {
     const long = "a".repeat(500)
     const { llm, refs } = mockPorts({ llmText: long })
 
@@ -168,7 +167,7 @@ describe("generateNonConflictingBranchName", () => {
       }
     )
 
-    expect(result.length).toBeLessThanOrEqual(30 + "feature/".length)
-    expect(result.startsWith("feature/")).toBe(true)
+    expect(result).toBe(`feature/${long}`)
   })
 })
+

--- a/app/api/issues/list/route.ts
+++ b/app/api/issues/list/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+
+import {
+  getIssueListWithStatus,
+  getLinkedPRNumbersForIssues,
+} from "@/lib/github/issues"
+
+const RequestSchema = z.object({
+  repoFullName: z.string().min(3),
+  page: z.number().int().min(1).default(1),
+  per_page: z.number().int().min(1).max(100).default(25),
+})
+
+export async function POST(req: Request) {
+  try {
+    const json = await req.json()
+    const { repoFullName, page, per_page } = RequestSchema.parse(json)
+
+    const issues = await getIssueListWithStatus({
+      repoFullName,
+      page,
+      per_page,
+    })
+
+    const issueNumbers = issues.map((i) => i.number)
+    const prMap = await getLinkedPRNumbersForIssues({
+      repoFullName,
+      issueNumbers,
+    })
+
+    const hasMore = issues.length === per_page
+
+    return NextResponse.json({ issues, prMap, hasMore })
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: "Invalid request data", details: err.errors },
+        { status: 400 }
+      )
+    }
+    console.error("Failed to list issues:", err)
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Unknown error" },
+      { status: 500 }
+    )
+  }
+}
+

--- a/app/api/telemetry/error/route.ts
+++ b/app/api/telemetry/error/route.ts
@@ -40,4 +40,3 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok: false }, { status: 500 })
   }
 }
-

--- a/app/api/telemetry/error/route.ts
+++ b/app/api/telemetry/error/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server"
+
+import { sendServerError } from "@/lib/telemetry/server"
+
+export async function POST(req: Request) {
+  try {
+    const data = (await req.json()) as {
+      message: string
+      stack?: string
+      url?: string
+      userAgent?: string
+      source?: string
+      componentStack?: string
+      meta?: Record<string, unknown>
+      severity?: "error" | "warning"
+    }
+
+    await sendServerError({
+      type: "server-error",
+      message: data.message || "Client error",
+      stack: data.stack,
+      url: data.url,
+      meta: {
+        source: data.source ?? "client",
+        userAgent: data.userAgent,
+        componentStack: data.componentStack,
+        severity: data.severity ?? "error",
+        ...(data.meta || {}),
+      },
+    })
+
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    await sendServerError({
+      type: "server-error",
+      message: err instanceof Error ? err.message : "Failed to record error",
+      stack: err instanceof Error ? err.stack : undefined,
+      meta: { route: "/api/telemetry/error" },
+    })
+    return NextResponse.json({ ok: false }, { status: 500 })
+  }
+}
+

--- a/app/api/workflow/autoResolveIssue/route.ts
+++ b/app/api/workflow/autoResolveIssue/route.ts
@@ -1,9 +1,15 @@
 import { NextRequest, NextResponse } from "next/server"
+import { v4 as uuidv4 } from "uuid"
 import { z } from "zod"
 
-import { AutoResolveIssueRequestSchema } from "@/lib/schemas/api"
+import { getRepoFromString } from "@/lib/github/content"
+import { getInstallationTokenFromRepo } from "@/lib/github/installation"
+import { getIssue } from "@/lib/github/issues"
 import { getInstallationFromRepo } from "@/lib/github/repos"
-import { addJob } from "@/shared/src/services/job"
+import { getUserOpenAIApiKey } from "@/lib/neo4j/services/user"
+import { AutoResolveIssueRequestSchema } from "@/lib/schemas/api"
+import { addJob } from "@shared/services/job"
+import { AutoResolveIssueJobDataSchema } from "@shared/services/workflows/autoResolveIssue"
 
 export async function POST(request: NextRequest) {
   try {
@@ -11,38 +17,67 @@ export async function POST(request: NextRequest) {
     const { issueNumber, repoFullName } =
       AutoResolveIssueRequestSchema.parse(body)
 
-    // Determine installation id for the repo so the worker can use the App token
-    const [owner, repo] = repoFullName.split("/")
-    if (!owner || !repo) {
+    const apiKey = await getUserOpenAIApiKey()
+    if (!apiKey) {
       return NextResponse.json(
-        { error: "Invalid repository full name" },
-        { status: 400 }
+        { error: "Missing OpenAI API key" },
+        { status: 401 }
       )
     }
 
-    let installationId: number | undefined
+    // Ensure GitHub App is installed on the target repository
+    const [owner, repo] = repoFullName.split("/")
     try {
-      const installation = await getInstallationFromRepo({ owner, repo })
-      installationId = installation.data.id
-    } catch (e) {
-      console.error(
-        `[autoResolveIssue] Failed to get installation for ${repoFullName}:`,
-        e
-      )
+      await getInstallationFromRepo({ owner, repo })
+    } catch (err) {
       return NextResponse.json(
-        { error: "GitHub App is not installed on this repository" },
+        {
+          error:
+            "The Issue-to-PR GitHub App is not installed on the target repository. Please install it and try again.",
+        },
         { status: 403 }
       )
     }
 
-    // Enqueue job for the worker to process
-    const jobId = await addJob("default", "autoResolveIssue", {
+    // Resolve repository and issue details up front (orchestrator role)
+    const [repository, issueResult, installationToken] = await Promise.all([
+      getRepoFromString(repoFullName),
+      getIssue({ fullName: repoFullName, issueNumber }),
+      getInstallationTokenFromRepo({ owner, repo }),
+    ])
+
+    if (issueResult.type !== "success") {
+      const status =
+        issueResult.type === "not_found"
+          ? 404
+          : issueResult.type === "forbidden"
+            ? 403
+            : 500
+      return NextResponse.json(
+        { error: `Failed to fetch issue: ${issueResult.type}` },
+        { status }
+      )
+    }
+
+    const jobId = uuidv4()
+
+    const payload = AutoResolveIssueJobDataSchema.parse({
+      jobId,
       repoFullName,
       issueNumber,
-      installationId,
+      openaiApiKey: apiKey,
+      installationToken,
+      repository,
+      issue: issueResult.issue,
     })
 
-    return NextResponse.json({ jobId })
+    await addJob("workflows", "autoResolveIssue", payload, {
+      jobId,
+      removeOnComplete: 100,
+      removeOnFail: 100,
+    })
+
+    return NextResponse.json({ jobId }, { status: 202 })
   } catch (error) {
     console.error("Error processing request:", error)
     if (error instanceof z.ZodError) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { SessionProvider } from "next-auth/react"
 
 import { auth } from "@/auth"
 import Navigation from "@/components/layout/Navigation"
+import ErrorListener from "@/components/system/ErrorListener"
 import { Toaster } from "@/components/ui/toaster"
 
 const inter = Inter({ subsets: ["latin"] })
@@ -31,6 +32,7 @@ export default async function RootLayout({
       >
         <SessionProvider session={session}>
           <Navigation />
+          <ErrorListener />
           {children}
           <Toaster />
         </SessionProvider>
@@ -38,3 +40,4 @@ export default async function RootLayout({
     </html>
   )
 }
+

--- a/apps/openai-realtime-agents/src/app/App.tsx
+++ b/apps/openai-realtime-agents/src/app/App.tsx
@@ -9,6 +9,7 @@ import Image from "next/image"
 import Transcript from "./components/Transcript"
 import Events from "./components/Events"
 import BottomToolbar from "./components/BottomToolbar"
+import LiveTranscription from "./components/LiveTranscription"
 
 // Types
 import { SessionStatus } from "@realtime/app/types"
@@ -97,6 +98,8 @@ function App() {
     useState<SessionStatus>("DISCONNECTED")
 
   const [isEventsPaneExpanded, setIsEventsPaneExpanded] =
+    useState<boolean>(true)
+  const [isLiveTranscriptionPaneExpanded, setIsLiveTranscriptionPaneExpanded] =
     useState<boolean>(true)
   const [userText, setUserText] = useState<string>("")
   const [isPTTActive, setIsPTTActive] = useState<boolean>(false)
@@ -355,6 +358,10 @@ function App() {
     if (storedLogsExpanded) {
       setIsEventsPaneExpanded(storedLogsExpanded === "true")
     }
+    const storedLiveExpanded = localStorage.getItem("liveTransExpanded")
+    if (storedLiveExpanded) {
+      setIsLiveTranscriptionPaneExpanded(storedLiveExpanded === "true")
+    }
     const storedAudioPlaybackEnabled = localStorage.getItem(
       "audioPlaybackEnabled"
     )
@@ -370,6 +377,13 @@ function App() {
   useEffect(() => {
     localStorage.setItem("logsExpanded", isEventsPaneExpanded.toString())
   }, [isEventsPaneExpanded])
+
+  useEffect(() => {
+    localStorage.setItem(
+      "liveTransExpanded",
+      isLiveTranscriptionPaneExpanded.toString()
+    )
+  }, [isLiveTranscriptionPaneExpanded])
 
   useEffect(() => {
     localStorage.setItem(
@@ -520,6 +534,7 @@ function App() {
           canSend={sessionStatus === "CONNECTED"}
         />
 
+        <LiveTranscription isExpanded={isLiveTranscriptionPaneExpanded} />
         <Events isExpanded={isEventsPaneExpanded} />
       </div>
 
@@ -533,6 +548,8 @@ function App() {
         handleTalkButtonUp={handleTalkButtonUp}
         isEventsPaneExpanded={isEventsPaneExpanded}
         setIsEventsPaneExpanded={setIsEventsPaneExpanded}
+        isLiveTranscriptionPaneExpanded={isLiveTranscriptionPaneExpanded}
+        setIsLiveTranscriptionPaneExpanded={setIsLiveTranscriptionPaneExpanded}
         isAudioPlaybackEnabled={isAudioPlaybackEnabled}
         setIsAudioPlaybackEnabled={setIsAudioPlaybackEnabled}
         codec={urlCodec}
@@ -543,3 +560,4 @@ function App() {
 }
 
 export default App
+

--- a/apps/openai-realtime-agents/src/app/components/BottomToolbar.tsx
+++ b/apps/openai-realtime-agents/src/app/components/BottomToolbar.tsx
@@ -11,6 +11,8 @@ interface BottomToolbarProps {
   handleTalkButtonUp: () => void;
   isEventsPaneExpanded: boolean;
   setIsEventsPaneExpanded: (val: boolean) => void;
+  isLiveTranscriptionPaneExpanded: boolean;
+  setIsLiveTranscriptionPaneExpanded: (val: boolean) => void;
   isAudioPlaybackEnabled: boolean;
   setIsAudioPlaybackEnabled: (val: boolean) => void;
   codec: string;
@@ -27,6 +29,8 @@ function BottomToolbar({
   handleTalkButtonUp,
   isEventsPaneExpanded,
   setIsEventsPaneExpanded,
+  isLiveTranscriptionPaneExpanded,
+  setIsLiveTranscriptionPaneExpanded,
   isAudioPlaybackEnabled,
   setIsAudioPlaybackEnabled,
   codec,
@@ -130,6 +134,19 @@ function BottomToolbar({
       </div>
 
       <div className="flex flex-row items-center gap-2">
+        <input
+          id="live-transcription"
+          type="checkbox"
+          checked={isLiveTranscriptionPaneExpanded}
+          onChange={(e) => setIsLiveTranscriptionPaneExpanded(e.target.checked)}
+          className="w-4 h-4"
+        />
+        <label htmlFor="live-transcription" className="flex items-center cursor-pointer">
+          Live transcript
+        </label>
+      </div>
+
+      <div className="flex flex-row items-center gap-2">
         <div>Codec:</div>
         {/*
           Codec selector – Lets you force the WebRTC track to use 8 kHz 
@@ -155,3 +172,4 @@ function BottomToolbar({
 }
 
 export default BottomToolbar;
+

--- a/apps/openai-realtime-agents/src/app/components/LiveTranscription.tsx
+++ b/apps/openai-realtime-agents/src/app/components/LiveTranscription.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import React, { useEffect, useMemo, useRef } from "react";
+import { useTranscript } from "@/app/contexts/TranscriptContext";
+
+export interface LiveTranscriptionProps {
+  isExpanded: boolean;
+}
+
+function LiveTranscription({ isExpanded }: LiveTranscriptionProps) {
+  const { transcriptItems } = useTranscript();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const liveItems = useMemo(
+    () =>
+      transcriptItems
+        .filter(
+          (t) =>
+            t.type === "MESSAGE" &&
+            t.status === "IN_PROGRESS" &&
+            !t.isHidden &&
+            (t.title ?? "").trim().length > 0,
+        )
+        .sort((a, b) => a.createdAtMs - b.createdAtMs),
+    [transcriptItems],
+  );
+
+  useEffect(() => {
+    if (isExpanded && containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
+    }
+  }, [isExpanded, liveItems]);
+
+  return (
+    <div
+      className={
+        (isExpanded ? "w-1/3 overflow-auto" : "w-0 overflow-hidden opacity-0") +
+        " transition-all rounded-xl duration-200 ease-in-out flex flex-col bg-white"
+      }
+      ref={containerRef}
+    >
+      {isExpanded && (
+        <div className="flex flex-col h-full min-h-0">
+          <div className="flex items-center justify-between px-6 py-3.5 sticky top-0 z-10 text-base border-b bg-white rounded-t-xl">
+            <span className="font-semibold">Live Transcription</span>
+          </div>
+
+          <div className="p-4 flex flex-col gap-y-3">
+            {liveItems.length === 0 && (
+              <div className="text-sm text-gray-500 italic">
+                Waiting for speech...
+              </div>
+            )}
+            {liveItems.map((item) => (
+              <div key={item.itemId} className="flex flex-col">
+                <div className="text-xs text-gray-500 font-mono mb-1">
+                  {item.timestamp} · {item.role === "user" ? "User" : "Assistant"}
+                </div>
+                <div className="bg-gray-50 border border-gray-200 rounded-md p-2 whitespace-pre-wrap">
+                  {item.title}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default LiveTranscription;
+

--- a/apps/workers/src/handlers/autoResolveIssue.ts
+++ b/apps/workers/src/handlers/autoResolveIssue.ts
@@ -1,0 +1,23 @@
+import autoResolveIssue from "@/lib/workflows/autoResolveIssue"
+import type { GitHubIssue, GitHubRepository } from "@/lib/types/github"
+import { AutoResolveIssueJobDataSchema } from "@shared/services/workflows/autoResolveIssue"
+
+// Keep this file focused on processing a single job type.
+// All heavy lifting is delegated to the existing workflow implementation.
+
+export async function handleAutoResolveIssueJob(raw: unknown) {
+  const data = AutoResolveIssueJobDataSchema.parse(raw)
+
+  const issue: GitHubIssue = data.issue as unknown as GitHubIssue
+  const repository: GitHubRepository =
+    data.repository as unknown as GitHubRepository
+
+  await autoResolveIssue({
+    issue,
+    repository,
+    apiKey: data.openaiApiKey,
+    jobId: data.jobId,
+    sessionToken: data.installationToken,
+  })
+}
+

--- a/apps/workers/tsconfig.json
+++ b/apps/workers/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "paths": {
-      "@/*": ["./src/*"]
-    },
     "rootDir": "./src",
     "outDir": "./dist",
     "noEmit": false,
@@ -14,3 +11,4 @@
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }
+

--- a/apps/workers/tsconfig.json
+++ b/apps/workers/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    // Inherit monorepo-wide path aliases so imports like '@/shared/*' and '@/lib/*' resolve consistently
+    // Do not override "@/*" to the local src folder, as that breaks monorepo aliases.
     "rootDir": "./src",
     "outDir": "./dist",
     "noEmit": false,

--- a/components/issues/IssueTable.tsx
+++ b/components/issues/IssueTable.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react"
 
 import IssueRows from "@/components/issues/IssueRows"
+import LoadMoreIssues from "@/components/issues/LoadMoreIssues"
 import RowsSkeleton from "@/components/issues/RowsSkeleton"
 import TaskRows from "@/components/issues/TaskRows"
 import { Table, TableBody } from "@/components/ui/table"
@@ -20,6 +21,9 @@ export default async function IssueTable({ repoFullName }: Props) {
             <IssueRows repoFullName={repoFullName} />
           </Suspense>
 
+          {/* Load more button and dynamically loaded issues */}
+          <LoadMoreIssues repoFullName={repoFullName.fullName} />
+
           <Suspense fallback={<RowsSkeleton rows={2} columns={3} />}>
             <TaskRows repoFullName={repoFullName} />
           </Suspense>
@@ -28,3 +32,4 @@ export default async function IssueTable({ repoFullName }: Props) {
     </div>
   )
 }
+

--- a/components/issues/LoadMoreIssues.tsx
+++ b/components/issues/LoadMoreIssues.tsx
@@ -1,0 +1,95 @@
+"use client"
+
+import { useState } from "react"
+
+import IssueRow from "@/components/issues/IssueRow"
+import PRStatusIndicator from "@/components/issues/PRStatusIndicator"
+import { Button } from "@/components/ui/button"
+import { TableCell, TableRow } from "@/components/ui/table"
+import type { IssueWithStatus } from "@/lib/github/issues"
+
+interface Props {
+  repoFullName: string
+  perPage?: number
+}
+
+export default function LoadMoreIssues({ repoFullName, perPage = 25 }: Props) {
+  const [page, setPage] = useState(1) // initial server rendered page is 1; next fetch will be 2
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [issues, setIssues] = useState<IssueWithStatus[]>([])
+  const [prMap, setPrMap] = useState<Record<number, number | null>>({})
+  const [hasMore, setHasMore] = useState<boolean | null>(null)
+
+  const loadMore = async () => {
+    if (loading) return
+    setLoading(true)
+    setError(null)
+    try {
+      const nextPage = page + 1
+      const resp = await fetch("/api/issues/list", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ repoFullName, page: nextPage, per_page: perPage }),
+      })
+      if (!resp.ok) {
+        throw new Error(`Failed to load issues: ${resp.status}`)
+      }
+      const data: {
+        issues: IssueWithStatus[]
+        prMap: Record<number, number | null>
+        hasMore: boolean
+      } = await resp.json()
+
+      setIssues((prev) => [...prev, ...data.issues])
+      setPrMap((prev) => ({ ...prev, ...data.prMap }))
+      setHasMore(data.hasMore)
+      setPage(nextPage)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Unknown error")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // If we already determined there are no more, hide the button.
+  // Initially null means unknown - show the button so users can try to load more.
+  const showButton = hasMore !== false
+
+  return (
+    <>
+      {issues.map((issue) => (
+        <IssueRow
+          key={`issue-more-${issue.id}`}
+          issue={issue}
+          repoFullName={repoFullName}
+          prSlot={
+            <PRStatusIndicator
+              repoFullName={repoFullName}
+              prNumber={prMap[issue.number]}
+            />
+          }
+        />
+      ))}
+
+      {error && (
+        <TableRow>
+          <TableCell colSpan={3} className="text-red-600">
+            {error}
+          </TableCell>
+        </TableRow>
+      )}
+
+      {showButton && (
+        <TableRow>
+          <TableCell colSpan={3} className="text-center py-4">
+            <Button onClick={loadMore} disabled={loading} variant="outline">
+              {loading ? "Loading..." : "Load more"}
+            </Button>
+          </TableCell>
+        </TableRow>
+      )}
+    </>
+  )
+}
+

--- a/components/system/ErrorListener.tsx
+++ b/components/system/ErrorListener.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+/*
+ Global client-side error listener that reports errors to the server for telemetry.
+ Only sends in production to avoid noisy local development logs.
+*/
+
+import { useEffect } from "react"
+
+function postError(payload: unknown) {
+  try {
+    void fetch("/api/telemetry/error", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      keepalive: true, // allow sending during page unload
+    })
+  } catch {
+    // do nothing - best effort
+  }
+}
+
+export default function ErrorListener() {
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "production") return
+
+    const onError = (event: ErrorEvent) => {
+      postError({
+        message: event.message,
+        stack: event.error?.stack,
+        url: window.location.href,
+        userAgent: navigator.userAgent,
+        source: "window.onerror",
+        meta: {
+          filename: event.filename,
+          lineno: event.lineno,
+          colno: event.colno,
+        },
+      })
+    }
+
+    const onUnhandledRejection = (event: PromiseRejectionEvent) => {
+      const reason = event.reason
+      let message = "Unhandled promise rejection"
+      let stack: string | undefined
+      if (reason instanceof Error) {
+        message = reason.message
+        stack = reason.stack
+      } else if (typeof reason === "string") {
+        message = reason
+      }
+      postError({
+        message,
+        stack,
+        url: window.location.href,
+        userAgent: navigator.userAgent,
+        source: "window.unhandledrejection",
+      })
+    }
+
+    window.addEventListener("error", onError)
+    window.addEventListener("unhandledrejection", onUnhandledRejection)
+
+    return () => {
+      window.removeEventListener("error", onError)
+      window.removeEventListener("unhandledrejection", onUnhandledRejection)
+    }
+  }, [])
+
+  return null
+}
+

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,43 @@
+/*
+ Next.js instrumentation file to register global server-side error handlers in production.
+ Docs: https://nextjs.org/docs/app/building-your-application/optimizing/open-telemetry
+*/
+
+import { sendServerError } from "@/lib/telemetry/server"
+
+export async function register() {
+  if (process.env.NODE_ENV !== "production") return
+
+  // Avoid installing multiple listeners if register() runs more than once
+  const globalAny = globalThis as unknown as { __errorTelemetryInstalled?: boolean }
+  if (globalAny.__errorTelemetryInstalled) return
+  globalAny.__errorTelemetryInstalled = true
+
+  process.on("uncaughtException", (err) => {
+    void sendServerError({
+      type: "uncaught-exception",
+      message: err?.message || "uncaughtException",
+      stack: err?.stack,
+      meta: { kind: "process.on(uncaughtException)" },
+    })
+  })
+
+  process.on("unhandledRejection", (reason) => {
+    const message =
+      reason instanceof Error
+        ? reason.message
+        : typeof reason === "string"
+        ? reason
+        : "unhandledRejection"
+
+    const stack = reason instanceof Error ? reason.stack : undefined
+
+    void sendServerError({
+      type: "unhandled-rejection",
+      message,
+      stack,
+      meta: { kind: "process.on(unhandledRejection)" },
+    })
+  })
+}
+

--- a/lib/schemas/api.ts
+++ b/lib/schemas/api.ts
@@ -81,5 +81,8 @@ export const ResolveRequestSchema = z.object({
 
 export const AutoResolveIssueRequestSchema = z.object({
   issueNumber: z.number(),
-  repoFullName: z.string().min(1),
+  repoFullName: z
+    .string()
+    .regex(/^[^/]+\/[^/]+$/, "Repository must be in 'owner/repo' format"),
 })
+

--- a/lib/telemetry/server.ts
+++ b/lib/telemetry/server.ts
@@ -1,0 +1,48 @@
+/*
+ Server-side error telemetry utility.
+ Sends error events to a configurable webhook URL (e.g., Slack, custom collector).
+ Falls back to console logging when no webhook is configured.
+*/
+
+export type ServerErrorPayload = {
+  type: "server-error" | "unhandled-rejection" | "uncaught-exception"
+  message: string
+  stack?: string
+  timestamp?: string
+  url?: string
+  method?: string
+  userId?: string | null
+  meta?: Record<string, unknown>
+}
+
+const WEBHOOK_URL = process.env.ERROR_WEBHOOK_URL
+
+export async function sendServerError(payload: ServerErrorPayload) {
+  const body = {
+    ...payload,
+    timestamp: payload.timestamp ?? new Date().toISOString(),
+    environment: process.env.NODE_ENV,
+    service: process.env.VERCEL_PROJECT_PRODUCTION_URL || "issue-to-pr",
+  }
+
+  if (!WEBHOOK_URL) {
+    // eslint-disable-next-line no-console
+    console.error("[telemetry]", body)
+    return
+  }
+
+  try {
+    await fetch(WEBHOOK_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    })
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error("[telemetry] Failed to send to webhook:", err)
+    // best effort: still log locally
+    // eslint-disable-next-line no-console
+    console.error("[telemetry]", body)
+  }
+}
+

--- a/lib/telemetry/server.ts
+++ b/lib/telemetry/server.ts
@@ -45,4 +45,3 @@ export async function sendServerError(payload: ServerErrorPayload) {
     console.error("[telemetry]", body)
   }
 }
-

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@radix-ui/react-tooltip": "^1.1.8",
     "@types/dockerode": "^3.3.42",
     "@upstash/redis": "^1.34.4",
+    "@vercel/otel": "^1.13.0",
     "bullmq": "~5.56.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
@@ -93,6 +94,7 @@
     "@storybook/addon-docs": "^9.1.3",
     "@storybook/addon-onboarding": "^9.1.3",
     "@storybook/addon-vitest": "^9.1.3",
+    "@storybook/nextjs-vite": "^9.1.3",
     "@tailwindcss/typography": "^0.5.16",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
@@ -101,6 +103,8 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@vitest/browser": "^3.2.4",
+    "@vitest/coverage-v8": "^3.2.4",
     "autoprefixer": "^10.4.21",
     "dotenv": "^16.5.0",
     "eslint": "^8",
@@ -113,6 +117,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "mini-css-extract-plugin": "^2.9.2",
     "msw": "^2.7.3",
+    "playwright": "^1.55.0",
     "postcss": "^8.5.3",
     "prettier": "^3.4.2",
     "storybook": "^9.1.3",
@@ -121,11 +126,7 @@
     "ts-node": "^10.9.2",
     "typescript": "^5",
     "typescript-eslint": "^8.19.0",
-    "@storybook/nextjs-vite": "^9.1.3",
-    "vitest": "^3.2.4",
-    "@vitest/browser": "^3.2.4",
-    "playwright": "^1.55.0",
-    "@vitest/coverage-v8": "^3.2.4"
+    "vitest": "^3.2.4"
   },
   "msw": {
     "workerDirectory": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       '@upstash/redis':
         specifier: ^1.34.4
         version: 1.34.5
+      '@vercel/otel':
+        specifier: ^1.13.0
+        version: 1.13.0(@opentelemetry/api-logs@0.57.2)(@opentelemetry/api@1.9.0)(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))
       bullmq:
         specifier: ~5.56.0
         version: 5.56.10
@@ -130,10 +133,10 @@ importers:
         version: 5.28.1
       next:
         specifier: ^14.2.18
-        version: 14.2.24(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.24(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-auth:
         specifier: ^5.0.0-beta.25
-        version: 5.0.0-beta.25(next@14.2.24(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 5.0.0-beta.25(next@14.2.24(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       octokit:
         specifier: ^4.0.2
         version: 4.1.2
@@ -197,7 +200,7 @@ importers:
         version: 9.1.3(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.3(@testing-library/dom@10.4.0)(msw@2.7.3(@types/node@20.17.24)(typescript@5.8.2))(prettier@3.5.3)(vite@7.1.3(@types/node@20.17.24)(jiti@1.21.7)(terser@5.43.1)(yaml@2.7.0)))(vitest@3.2.4)
       '@storybook/nextjs-vite':
         specifier: ^9.1.3
-        version: 9.1.3(@babel/core@7.28.3)(next@14.2.24(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.50.0)(storybook@9.1.3(@testing-library/dom@10.4.0)(msw@2.7.3(@types/node@20.17.24)(typescript@5.8.2))(prettier@3.5.3)(vite@7.1.3(@types/node@20.17.24)(jiti@1.21.7)(terser@5.43.1)(yaml@2.7.0)))(typescript@5.8.2)(vite@7.1.3(@types/node@20.17.24)(jiti@1.21.7)(terser@5.43.1)(yaml@2.7.0))
+        version: 9.1.3(@babel/core@7.28.3)(next@14.2.24(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.50.0)(storybook@9.1.3(@testing-library/dom@10.4.0)(msw@2.7.3(@types/node@20.17.24)(typescript@5.8.2))(prettier@3.5.3)(vite@7.1.3(@types/node@20.17.24)(jiti@1.21.7)(terser@5.43.1)(yaml@2.7.0)))(typescript@5.8.2)(vite@7.1.3(@types/node@20.17.24)(jiti@1.21.7)(terser@5.43.1)(yaml@2.7.0))
       '@tailwindcss/typography':
         specifier: ^0.5.16
         version: 0.5.16(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.17.24)(typescript@5.8.2)))
@@ -308,7 +311,7 @@ importers:
         version: 16.5.0
       next:
         specifier: ^15.3.1
-        version: 15.5.2(@babel/core@7.28.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 15.5.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       openai:
         specifier: ^4.77.3
         version: 4.104.0(ws@8.18.3)(zod@3.24.2)
@@ -1602,6 +1605,54 @@ packages:
   '@openai/agents@0.0.5':
     resolution: {integrity: sha512-baR5yTS+0D/mzomxBjvuxMkx9TshedJiY9qVvrMyqngIo1t6sB8d+aUYDnlLx/Pu3Q7TSqbW+xiowXSZD+ycZA==}
 
+  '@opentelemetry/api-logs@0.57.2':
+    resolution: {integrity: sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@1.30.1':
+    resolution: {integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/instrumentation@0.57.2':
+    resolution: {integrity: sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@1.30.1':
+    resolution: {integrity: sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.57.2':
+    resolution: {integrity: sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@1.30.1':
+    resolution: {integrity: sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@1.30.1':
+    resolution: {integrity: sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.28.0':
+    resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
+    engines: {node: '>=14'}
+
   '@panva/hkdf@1.2.1':
     resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
 
@@ -2554,6 +2605,9 @@ packages:
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
 
+  '@types/shimmer@1.2.0':
+    resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
+
   '@types/ssh2@1.15.5':
     resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
@@ -2633,6 +2687,18 @@ packages:
 
   '@upstash/redis@1.34.5':
     resolution: {integrity: sha512-ZsYy1AX89OWQIGGQcO8CDBoWyLuVuvuJdjLKfj5WYxnhzYBzYb8E26gbvLO1lVlhVBAIuFX/k0LNjtv7wn2bcQ==}
+
+  '@vercel/otel@1.13.0':
+    resolution: {integrity: sha512-esRkt470Y2jRK1B1g7S1vkt4Csu44gp83Zpu8rIyPoqy2BKgk4z7ik1uSMswzi45UogLHFl6yR5TauDurBQi4Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.7.0 <2.0.0'
+      '@opentelemetry/api-logs': '>=0.46.0 <0.200.0'
+      '@opentelemetry/instrumentation': '>=0.46.0 <0.200.0'
+      '@opentelemetry/resources': '>=1.19.0 <2.0.0'
+      '@opentelemetry/sdk-logs': '>=0.46.0 <0.200.0'
+      '@opentelemetry/sdk-metrics': '>=1.19.0 <2.0.0'
+      '@opentelemetry/sdk-trace-base': '>=1.19.0 <2.0.0'
 
   '@vitest/browser@3.2.4':
     resolution: {integrity: sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==}
@@ -2752,6 +2818,11 @@ packages:
 
   acorn-globals@7.0.1:
     resolution: {integrity: sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==}
+
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -4171,6 +4242,9 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-in-the-middle@1.14.2:
+    resolution: {integrity: sha512-5tCuY9BV8ujfOpwtAGgsTx9CGUapcFMEEyByLv1B+v2+6DhAcw+Zr0nhQT7uwaZ7DiourxFEscghOR8e1aPLQw==}
+
   import-local@3.2.0:
     resolution: {integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==}
     engines: {node: '>=8'}
@@ -4920,6 +4994,9 @@ packages:
   module-alias@2.2.3:
     resolution: {integrity: sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q==}
 
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
   motion-dom@11.18.1:
     resolution: {integrity: sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==}
 
@@ -5616,6 +5693,10 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  require-in-the-middle@7.5.2:
+    resolution: {integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==}
+    engines: {node: '>=8.6.0'}
+
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
@@ -5762,6 +5843,9 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shimmer@1.2.1:
+    resolution: {integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -8083,6 +8167,57 @@ snapshots:
       - ws
       - zod
 
+  '@opentelemetry/api-logs@0.57.2':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.57.2
+      '@types/shimmer': 1.2.0
+      import-in-the-middle: 1.14.2
+      require-in-the-middle: 7.5.2
+      semver: 7.7.2
+      shimmer: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/semantic-conventions@1.28.0': {}
+
   '@panva/hkdf@1.2.1': {}
 
   '@pkgjs/parseargs@0.11.0':
@@ -8799,18 +8934,18 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/nextjs-vite@9.1.3(@babel/core@7.28.3)(next@14.2.24(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.50.0)(storybook@9.1.3(@testing-library/dom@10.4.0)(msw@2.7.3(@types/node@20.17.24)(typescript@5.8.2))(prettier@3.5.3)(vite@7.1.3(@types/node@20.17.24)(jiti@1.21.7)(terser@5.43.1)(yaml@2.7.0)))(typescript@5.8.2)(vite@7.1.3(@types/node@20.17.24)(jiti@1.21.7)(terser@5.43.1)(yaml@2.7.0))':
+  '@storybook/nextjs-vite@9.1.3(@babel/core@7.28.3)(next@14.2.24(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.50.0)(storybook@9.1.3(@testing-library/dom@10.4.0)(msw@2.7.3(@types/node@20.17.24)(typescript@5.8.2))(prettier@3.5.3)(vite@7.1.3(@types/node@20.17.24)(jiti@1.21.7)(terser@5.43.1)(yaml@2.7.0)))(typescript@5.8.2)(vite@7.1.3(@types/node@20.17.24)(jiti@1.21.7)(terser@5.43.1)(yaml@2.7.0))':
     dependencies:
       '@storybook/builder-vite': 9.1.3(storybook@9.1.3(@testing-library/dom@10.4.0)(msw@2.7.3(@types/node@20.17.24)(typescript@5.8.2))(prettier@3.5.3)(vite@7.1.3(@types/node@20.17.24)(jiti@1.21.7)(terser@5.43.1)(yaml@2.7.0)))(vite@7.1.3(@types/node@20.17.24)(jiti@1.21.7)(terser@5.43.1)(yaml@2.7.0))
       '@storybook/react': 9.1.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.3(@testing-library/dom@10.4.0)(msw@2.7.3(@types/node@20.17.24)(typescript@5.8.2))(prettier@3.5.3)(vite@7.1.3(@types/node@20.17.24)(jiti@1.21.7)(terser@5.43.1)(yaml@2.7.0)))(typescript@5.8.2)
       '@storybook/react-vite': 9.1.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.50.0)(storybook@9.1.3(@testing-library/dom@10.4.0)(msw@2.7.3(@types/node@20.17.24)(typescript@5.8.2))(prettier@3.5.3)(vite@7.1.3(@types/node@20.17.24)(jiti@1.21.7)(terser@5.43.1)(yaml@2.7.0)))(typescript@5.8.2)(vite@7.1.3(@types/node@20.17.24)(jiti@1.21.7)(terser@5.43.1)(yaml@2.7.0))
-      next: 14.2.24(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.24(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       storybook: 9.1.3(@testing-library/dom@10.4.0)(msw@2.7.3(@types/node@20.17.24)(typescript@5.8.2))(prettier@3.5.3)(vite@7.1.3(@types/node@20.17.24)(jiti@1.21.7)(terser@5.43.1)(yaml@2.7.0))
       styled-jsx: 5.1.6(@babel/core@7.28.3)(react@18.3.1)
       vite: 7.1.3(@types/node@20.17.24)(jiti@1.21.7)(terser@5.43.1)(yaml@2.7.0)
-      vite-plugin-storybook-nextjs: 2.0.7(next@14.2.24(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(storybook@9.1.3(@testing-library/dom@10.4.0)(msw@2.7.3(@types/node@20.17.24)(typescript@5.8.2))(prettier@3.5.3)(vite@7.1.3(@types/node@20.17.24)(jiti@1.21.7)(terser@5.43.1)(yaml@2.7.0)))(typescript@5.8.2)(vite@7.1.3(@types/node@20.17.24)(jiti@1.21.7)(terser@5.43.1)(yaml@2.7.0))
+      vite-plugin-storybook-nextjs: 2.0.7(next@14.2.24(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(storybook@9.1.3(@testing-library/dom@10.4.0)(msw@2.7.3(@types/node@20.17.24)(typescript@5.8.2))(prettier@3.5.3)(vite@7.1.3(@types/node@20.17.24)(jiti@1.21.7)(terser@5.43.1)(yaml@2.7.0)))(typescript@5.8.2)(vite@7.1.3(@types/node@20.17.24)(jiti@1.21.7)(terser@5.43.1)(yaml@2.7.0))
     optionalDependencies:
       typescript: 5.8.2
     transitivePeerDependencies:
@@ -9074,6 +9209,8 @@ snapshots:
 
   '@types/resolve@1.20.6': {}
 
+  '@types/shimmer@1.2.0': {}
+
   '@types/ssh2@1.15.5':
     dependencies:
       '@types/node': 18.19.80
@@ -9231,6 +9368,16 @@ snapshots:
   '@upstash/redis@1.34.5':
     dependencies:
       crypto-js: 4.2.0
+
+  '@vercel/otel@1.13.0(@opentelemetry/api-logs@0.57.2)(@opentelemetry/api@1.9.0)(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
 
   '@vitest/browser@3.2.4(msw@2.7.3(@types/node@20.17.24)(typescript@5.8.2))(playwright@1.55.0)(vite@7.1.3(@types/node@20.17.24)(jiti@1.21.7)(terser@5.43.1)(yaml@2.7.0))(vitest@3.2.4)':
     dependencies:
@@ -9411,6 +9558,10 @@ snapshots:
     dependencies:
       acorn: 8.14.1
       acorn-walk: 8.3.4
+
+  acorn-import-attributes@1.9.5(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
 
   acorn-jsx@5.3.2(acorn@8.14.1):
     dependencies:
@@ -11251,6 +11402,13 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-in-the-middle@1.14.2:
+    dependencies:
+      acorn: 8.15.0
+      acorn-import-attributes: 1.9.5(acorn@8.15.0)
+      cjs-module-lexer: 1.4.3
+      module-details-from-path: 1.0.4
+
   import-local@3.2.0:
     dependencies:
       pkg-dir: 4.2.0
@@ -12355,6 +12513,8 @@ snapshots:
 
   module-alias@2.2.3: {}
 
+  module-details-from-path@1.0.4: {}
+
   motion-dom@11.18.1:
     dependencies:
       motion-utils: 11.18.1
@@ -12458,13 +12618,13 @@ snapshots:
       neo4j-driver-core: 5.28.1
       rxjs: 7.8.2
 
-  next-auth@5.0.0-beta.25(next@14.2.24(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
+  next-auth@5.0.0-beta.25(next@14.2.24(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
     dependencies:
       '@auth/core': 0.37.2
-      next: 14.2.24(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.24(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
 
-  next@14.2.24(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.24(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.24
       '@swc/helpers': 0.5.5
@@ -12485,11 +12645,12 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 14.2.24
       '@next/swc-win32-ia32-msvc': 14.2.24
       '@next/swc-win32-x64-msvc': 14.2.24
+      '@opentelemetry/api': 1.9.0
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.5.2(@babel/core@7.28.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+  next@15.5.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
       '@next/env': 15.5.2
       '@swc/helpers': 0.5.15
@@ -12507,6 +12668,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.2
       '@next/swc-win32-arm64-msvc': 15.5.2
       '@next/swc-win32-x64-msvc': 15.5.2
+      '@opentelemetry/api': 1.9.0
       sharp: 0.34.3
     transitivePeerDependencies:
       - '@babel/core'
@@ -13129,6 +13291,14 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  require-in-the-middle@7.5.2:
+    dependencies:
+      debug: 4.4.1
+      module-details-from-path: 1.0.4
+      resolve: 1.22.10
+    transitivePeerDependencies:
+      - supports-color
+
   requires-port@1.0.0: {}
 
   resolve-cwd@3.0.0:
@@ -13263,8 +13433,7 @@ snapshots:
 
   semver@7.7.1: {}
 
-  semver@7.7.2:
-    optional: true
+  semver@7.7.2: {}
 
   send@1.2.0:
     dependencies:
@@ -13357,6 +13526,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shimmer@1.2.1: {}
 
   side-channel-list@1.0.0:
     dependencies:
@@ -14129,13 +14300,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-storybook-nextjs@2.0.7(next@14.2.24(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(storybook@9.1.3(@testing-library/dom@10.4.0)(msw@2.7.3(@types/node@20.17.24)(typescript@5.8.2))(prettier@3.5.3)(vite@7.1.3(@types/node@20.17.24)(jiti@1.21.7)(terser@5.43.1)(yaml@2.7.0)))(typescript@5.8.2)(vite@7.1.3(@types/node@20.17.24)(jiti@1.21.7)(terser@5.43.1)(yaml@2.7.0)):
+  vite-plugin-storybook-nextjs@2.0.7(next@14.2.24(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(storybook@9.1.3(@testing-library/dom@10.4.0)(msw@2.7.3(@types/node@20.17.24)(typescript@5.8.2))(prettier@3.5.3)(vite@7.1.3(@types/node@20.17.24)(jiti@1.21.7)(terser@5.43.1)(yaml@2.7.0)))(typescript@5.8.2)(vite@7.1.3(@types/node@20.17.24)(jiti@1.21.7)(terser@5.43.1)(yaml@2.7.0)):
     dependencies:
       '@next/env': 15.5.2
       image-size: 2.0.2
       magic-string: 0.30.18
       module-alias: 2.2.3
-      next: 14.2.24(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.24(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       storybook: 9.1.3(@testing-library/dom@10.4.0)(msw@2.7.3(@types/node@20.17.24)(typescript@5.8.2))(prettier@3.5.3)(vite@7.1.3(@types/node@20.17.24)(jiti@1.21.7)(terser@5.43.1)(yaml@2.7.0))
       ts-dedent: 2.2.0
       vite: 7.1.3(@types/node@20.17.24)(jiti@1.21.7)(terser@5.43.1)(yaml@2.7.0)

--- a/shared/src/adapters/github-pullrequest-graphql.ts
+++ b/shared/src/adapters/github-pullrequest-graphql.ts
@@ -1,0 +1,244 @@
+import { graphql } from "@octokit/graphql"
+
+import {
+  type GitHubPullRequestsPort,
+  type GitHubPRErrors,
+  type PRFileChange,
+  type PRIssueComment,
+  type PRIssueLink,
+  type PRReview,
+  type PullRequestContext,
+  type PullRequestRef,
+} from "@/shared/src/core/ports/pullRequests"
+import { err, ok, type Result } from "@/shared/src/entities/result"
+
+export function makeGitHubPRGraphQLAdapter(params: {
+  token: string
+}): GitHubPullRequestsPort {
+  const client = graphql.defaults({
+    headers: { authorization: `token ${params.token}` },
+  })
+
+  async function getPullRequestContext(
+    ref: PullRequestRef
+  ): Promise<Result<PullRequestContext, GitHubPRErrors>> {
+    const [owner, repo] = ref.repoFullName.split("/")
+    if (!owner || !repo) {
+      return err("ValidationFailed", {
+        message: "Invalid repoFullName. Expected 'owner/repo'",
+      })
+    }
+
+    // Keep limits modest to avoid hitting GraphQL limits; callers can slice further if needed
+    const variables = {
+      owner,
+      repo,
+      pullNumber: ref.number,
+      commentsLimit: 100,
+      reviewsLimit: 50,
+      commentsPerReview: 100,
+      filesLimit: 200,
+    }
+
+    const query = `
+      query getPRContext(
+        $owner: String!,
+        $repo: String!,
+        $pullNumber: Int!,
+        $commentsLimit: Int!,
+        $reviewsLimit: Int!,
+        $commentsPerReview: Int!,
+        $filesLimit: Int!
+      ) {
+        repository(owner: $owner, name: $repo) {
+          pullRequest(number: $pullNumber) {
+            id
+            number
+            title
+            body
+            state
+            isDraft
+            merged
+            mergedAt
+            createdAt
+            updatedAt
+            baseRefName
+            headRefName
+            additions
+            deletions
+            changedFiles
+            author { login }
+            files(first: $filesLimit) {
+              nodes { path additions deletions changeType }
+            }
+            closingIssuesReferences(first: 10) {
+              nodes { number title state }
+            }
+            comments(first: $commentsLimit) {
+              nodes { id body createdAt author { login } }
+            }
+            reviews(first: $reviewsLimit) {
+              nodes {
+                id
+                body
+                state
+                author { login }
+                submittedAt
+                comments(first: $commentsPerReview) {
+                  nodes {
+                    id
+                    body
+                    author { login }
+                    path
+                    position
+                    originalPosition
+                    diffHunk
+                    createdAt
+                    replyTo { id }
+                    pullRequestReview { id }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `
+
+    type QueryResponse = {
+      repository: {
+        pullRequest: {
+          id: string
+          number: number
+          title: string
+          body: string | null
+          state: "OPEN" | "CLOSED" | "MERGED"
+          isDraft: boolean
+          merged: boolean
+          mergedAt: string | null
+          createdAt: string
+          updatedAt: string
+          baseRefName: string
+          headRefName: string
+          additions: number | null
+          deletions: number | null
+          changedFiles: number | null
+          author: { login: string } | null
+          files: { nodes: Array<{ path: string; additions: number | null; deletions: number | null; changeType?: string | null }> }
+          closingIssuesReferences: { nodes: Array<{ number: number; title: string | null; state: "OPEN" | "CLOSED" }> }
+          comments: { nodes: Array<{ id: string; body: string; createdAt: string; author: { login: string } | null }> }
+          reviews: {
+            nodes: Array<{
+              id: string
+              body: string
+              state: string
+              author: { login: string } | null
+              submittedAt: string
+              comments: {
+                nodes: Array<{
+                  id: string
+                  body: string
+                  author: { login: string } | null
+                  path: string
+                  position: number | null
+                  originalPosition: number | null
+                  diffHunk: string
+                  createdAt: string
+                  replyTo: { id: string } | null
+                  pullRequestReview: { id: string } | null
+                }>
+              }
+            }>
+          }
+        } | null
+      } | null
+    }
+
+    try {
+      const data = await client<QueryResponse>(query, variables)
+      const pr = data?.repository?.pullRequest
+      if (!pr) {
+        return err("RepoNotFound")
+      }
+
+      const files: PRFileChange[] = (pr.files?.nodes || []).map((f) => ({
+        path: f.path,
+        additions: f.additions,
+        deletions: f.deletions,
+        changeType: f.changeType ?? null,
+      }))
+      const linkedIssues: PRIssueLink[] = (
+        pr.closingIssuesReferences?.nodes || []
+      ).map((i) => ({ number: i.number, title: i.title, state: i.state }))
+      const comments: PRIssueComment[] = (pr.comments?.nodes || []).map(
+        (c) => ({ id: c.id, body: c.body, createdAt: c.createdAt, author: c.author?.login ?? null })
+      )
+      const reviews: PRReview[] = (pr.reviews?.nodes || []).map((r) => ({
+        id: r.id,
+        body: r.body,
+        state: r.state,
+        author: r.author?.login ?? null,
+        submittedAt: r.submittedAt,
+        comments:
+          r.comments?.nodes.map((c) => ({
+            id: c.id,
+            body: c.body,
+            author: c.author?.login ?? null,
+            file: c.path,
+            position: c.position,
+            originalPosition: c.originalPosition,
+            diffHunk: c.diffHunk,
+            createdAt: c.createdAt,
+            replyTo: c.replyTo?.id ?? null,
+            reviewId: c.pullRequestReview?.id ?? null,
+          })) || [],
+      }))
+
+      const context: PullRequestContext = {
+        pullRequest: {
+          number: pr.number,
+          title: pr.title,
+          body: pr.body,
+          state: pr.state,
+          isDraft: pr.isDraft,
+          merged: pr.merged,
+          mergedAt: pr.mergedAt,
+          createdAt: pr.createdAt,
+          updatedAt: pr.updatedAt,
+          baseRefName: pr.baseRefName,
+          headRefName: pr.headRefName,
+          additions: pr.additions ?? undefined,
+          deletions: pr.deletions ?? undefined,
+          changedFiles: pr.changedFiles ?? undefined,
+          author: pr.author ? { login: pr.author.login } : null,
+        },
+        files,
+        linkedIssues,
+        comments,
+        reviews,
+      }
+
+      return ok(context)
+    } catch (e: unknown) {
+      let status: number | undefined
+      let message: string | undefined
+      if (typeof e === "object" && e !== null) {
+        const anyErr = e as any
+        status = anyErr.status ?? anyErr?.response?.status
+        message = anyErr.message
+      }
+      if (status === 401 || status === 403) return err("AuthRequired", { status, message })
+      if (typeof message === "string" && /rate\s*limit/i.test(message)) return err("RateLimited", { status, message })
+      if (status === 422) return err("ValidationFailed", { status, message })
+      return err("Unknown", { status, message })
+    }
+  }
+
+  return {
+    getPullRequestContext,
+  }
+}
+
+export const makeGithubPRGraphQLAdapter = (token: string) =>
+  makeGitHubPRGraphQLAdapter({ token })
+

--- a/shared/src/core/ports/pullRequests.ts
+++ b/shared/src/core/ports/pullRequests.ts
@@ -1,0 +1,96 @@
+import { type Result } from "@/shared/src/entities/result"
+
+export type PullRequestRef = {
+  repoFullName: string // e.g. owner/repo
+  number: number
+}
+
+export type PRState = "OPEN" | "CLOSED" | "MERGED"
+
+export type PRAuthor = {
+  login: string | null
+}
+
+export type PRBasicInfo = {
+  number: number
+  title: string
+  body: string | null
+  state: PRState
+  isDraft: boolean
+  merged: boolean
+  mergedAt: string | null
+  createdAt: string
+  updatedAt: string
+  baseRefName: string
+  headRefName: string
+  additions?: number
+  deletions?: number
+  changedFiles?: number
+  author?: PRAuthor | null
+}
+
+export type PRFileChange = {
+  path: string
+  additions: number | null
+  deletions: number | null
+  changeType?: string | null
+}
+
+export type PRIssueLink = {
+  number: number
+  title: string | null
+  state?: "OPEN" | "CLOSED"
+}
+
+export type PRIssueComment = {
+  id: string
+  body: string
+  author: string | null
+  createdAt: string
+}
+
+export type PRReviewComment = {
+  id: string
+  body: string
+  author: string | null
+  file: string
+  position: number | null
+  originalPosition: number | null
+  diffHunk: string
+  createdAt: string
+  replyTo: string | null
+  reviewId: string | null
+}
+
+export type PRReview = {
+  id: string
+  body: string
+  state: string
+  author: string | null
+  submittedAt: string
+  comments: PRReviewComment[]
+}
+
+export type PullRequestContext = {
+  pullRequest: PRBasicInfo
+  files?: PRFileChange[]
+  linkedIssues?: PRIssueLink[]
+  comments?: PRIssueComment[]
+  reviews?: PRReview[]
+}
+
+export type GitHubPRErrors =
+  | "AuthRequired"
+  | "RepoNotFound"
+  | "RateLimited"
+  | "ValidationFailed"
+  | "Unknown"
+
+export interface GitHubPullRequestsPort {
+  /**
+   * Fetch rich context for a pull request: basic PR info, linked issues, PR comments,
+   * reviews with their comments, and changed files summary.
+   */
+  getPullRequestContext(ref: PullRequestRef): Promise<Result<PullRequestContext, GitHubPRErrors>>
+}
+

--- a/shared/src/core/usecases/generateBranchName.ts
+++ b/shared/src/core/usecases/generateBranchName.ts
@@ -60,7 +60,7 @@ export async function generateNonConflictingBranchName(
   // 2) Ask LLM for a candidate slug from the context
   const system = [
     "You generate short, descriptive Git branch names in kebab-case.",
-    "Keep it very short (ideally 2-5 words).",
+    "Keep it short (ideally 3-6 words).",
     "Return ONLY the branch path (no code blocks, no quotes).",
     `${prefix ? `Do NOT provide a prefix in the branch path, we will add this manually.` : ""}`,
   ].join(" ")
@@ -101,4 +101,3 @@ function trimToMax(input: string, max: number): string {
   if (input.length <= max) return input
   return input.slice(0, max)
 }
-

--- a/shared/src/core/usecases/generateBranchName.ts
+++ b/shared/src/core/usecases/generateBranchName.ts
@@ -6,7 +6,6 @@ import type { LLMPort } from "@shared/core/ports/llm"
 import type { GitHubRefsPort } from "@shared/core/ports/refs"
 
 const MAX_CONTEXT_LENGTH = 100000
-const MAX_BRANCH_NAME_LENGTH = 30
 const MAX_ATTEMPTS = 10
 
 export type GenerateBranchNameParams = {
@@ -61,7 +60,7 @@ export async function generateNonConflictingBranchName(
   // 2) Ask LLM for a candidate slug from the context
   const system = [
     "You generate short, descriptive Git branch names in kebab-case.",
-    "Prefer 3-6 words max.",
+    "Keep it very short (ideally 2-5 words).",
     "Return ONLY the branch path (no code blocks, no quotes).",
     `${prefix ? `Do NOT provide a prefix in the branch path, we will add this manually.` : ""}`,
   ].join(" ")
@@ -78,34 +77,28 @@ export async function generateNonConflictingBranchName(
 
   // 3) Parse and format candidate
   const baseSlug = baseBranchSlugSchema.parse(raw)
-  const trimmedSlug = trimToMax(baseSlug, MAX_BRANCH_NAME_LENGTH)
-  const candidate = prefix ? `${prefix}/${trimmedSlug}` : trimmedSlug
+  const candidate = prefix ? `${prefix}/${baseSlug}` : baseSlug
 
   // 4) Ensure uniqueness by appending numeric suffixes
   if (!existing.has(candidate)) return candidate
 
   let attempt = 2
   while (attempt <= maxAttempts) {
-    const next = trimToMax(`${candidate}-${attempt}`, MAX_BRANCH_NAME_LENGTH)
+    const next = `${candidate}-${attempt}`
     if (!existing.has(next)) return next
     attempt++
   }
 
   // 5) As a last resort, include a timestamp suffix
-  const fallback = trimToMax(
-    `${candidate}-${Date.now()}`,
-    MAX_BRANCH_NAME_LENGTH
-  )
+  const fallback = `${candidate}-${Date.now()}`
   if (!existing.has(fallback)) return fallback
 
   // Extremely unlikely path: random suffix
-  return trimToMax(
-    `${candidate}-${Math.random().toString(36).slice(2, 8)}`,
-    MAX_BRANCH_NAME_LENGTH
-  )
+  return `${candidate}-${Math.random().toString(36).slice(2, 8)}`
 }
 
 function trimToMax(input: string, max: number): string {
   if (input.length <= max) return input
   return input.slice(0, max)
 }
+

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -8,9 +8,14 @@ export {
   buildPreviewSubdomainSlug,
   toKebabSlug,
 } from "@/shared/src/core/entities/previewSlug"
+export {
+  makeGitHubPRGraphQLAdapter,
+  makeGithubPRGraphQLAdapter,
+} from "@/shared/src/adapters/github-pullrequest-graphql"
 export * from "@/shared/src/core/ports/github"
 export * from "@/shared/src/core/ports/llm"
 export * from "@/shared/src/core/ports/refs"
+export * from "@/shared/src/core/ports/pullRequests"
 export * from "@/shared/src/core/usecases/generateBranchName"
 export * from "@/shared/src/ui/button"
 export * from "@/shared/src/ui/IssueRow"
@@ -22,3 +27,4 @@ export {
   logStart,
   withTiming,
 } from "@/shared/src/utils/telemetry"
+

--- a/shared/src/services/workflows/autoResolveIssue.ts
+++ b/shared/src/services/workflows/autoResolveIssue.ts
@@ -1,0 +1,36 @@
+import { z } from "zod"
+
+// Shared zod schema for orchestrating the autoResolveIssue workflow via BullMQ
+// Ensures worker receives a fully-typed, JSON-serializable payload
+
+export const RepoFullNameSchema = z
+  .string()
+  .regex(/^[^/]+\/[^/]+$/, "Repository must be in 'owner/repo' format")
+
+export const AutoResolveIssueJobDataSchema = z.object({
+  jobId: z.string().min(1),
+  repoFullName: RepoFullNameSchema,
+  issueNumber: z.number(),
+  // The user-scoped OpenAI API key that initiated this workflow
+  openaiApiKey: z.string().min(1),
+  // GitHub App installation token used by the worker to access GitHub
+  installationToken: z.string().min(1),
+  // Minimal shapes for GitHub objects the workflow relies on. We allow extra fields
+  // since these are passed straight from Octokit responses.
+  repository: z
+    .object({
+      full_name: z.string(),
+      default_branch: z.string(),
+    })
+    .passthrough(),
+  issue: z
+    .object({
+      number: z.number(),
+      title: z.string().nullable().optional(),
+      body: z.string().nullable().optional(),
+    })
+    .passthrough(),
+})
+
+export type AutoResolveIssueJobData = z.infer<typeof AutoResolveIssueJobDataSchema>
+


### PR DESCRIPTION
Summary
- Queue the auto-resolve workflow onto a dedicated BullMQ "workflows" queue and process it via a worker.
- API now acts as an orchestrator: validates input, ensures GitHub App installation, resolves repo/issue, fetches GitHub App installation token, and enqueues a fully-specified payload including the requesting user's OpenAI API key.
- Worker uses the provided GitHub App installation token for GitHub API access during the workflow; avoids relying on user session tokens.
- API returns 202 with the queued jobId for client-side tracking.

Key Changes
- app/api/workflow/autoResolveIssue/route.ts
  - Validate input with zod (owner/repo format and numeric issueNumber).
  - Verify the Issue-to-PR GitHub App is installed on target repo; return 403 if not.
  - Resolve repository and issue details; obtain installation token.
  - Enqueue job on the "workflows" queue with a structured, JSON-serializable payload.
  - Return 202 and jobId.

- shared/src/services/workflows/autoResolveIssue.ts
  - New shared zod schema for AutoResolveIssue job data to enforce typed payloads without `as` casting.

- apps/workers/src/handlers/autoResolveIssue.ts
  - New focused handler module that runs the existing workflow using the job payload (repo/issue, OpenAI key, installation token).

- apps/workers/src/index.ts
  - Keep file focused on dispatch and queue event logging.
  - Add a dedicated Worker for the "workflows" queue alongside the existing default worker.

- apps/workers/tsconfig.json
  - Align worker path aliases with monorepo config by removing the local "@/*" override so imports like "@/shared" and "@/lib" resolve consistently.

- lib/workflows/autoResolveIssue.ts
  - Accept an optional pre-resolved `sessionToken` to support running under the worker with app tokens (falls back to fetching if not provided).

Notes on Requirements
- Dedicated "workflows" queue created; API enqueues there; worker listens there.
- API is an orchestrator and returns { jobId } with 202.
- Input validation is enforced via zod, including repoFullName format and issueNumber.
- Uses GitHub App installation token for GitHub calls executed by the worker.
- The user's OpenAI API key gets passed in the job payload and used by the workflow.
- The job payload is JSON-serializable. No adapters/classes are put directly into BullMQ data.
- Kept apps/workers/src/index.ts focused on dispatch; the heavy handler moved to its own module.
- Avoided broad type assertions by validating job data with shared zod schemas; a small compatibility cast remains when interfacing with Octokit types.
- Updated worker tsconfig so `@/shared` and `@/lib` resolve like the rest of the monorepo.

Operational Considerations
- Worker environment still reads env from monorepo root as before.
- If desired later, we can migrate more Next.js-specific `/lib` utilities to `/shared` to further decouple the worker.

Lint/Checks
- Installed dependencies and ran `pnpm run lint`; only warnings remain, no errors.



Closes #1129