### PR TITLE
Fix layout shift on mobile and hide 'Load more' when no issues

### DIFF
--- a/components/issues/IssueRows.tsx
+++ b/components/issues/IssueRows.tsx
@@ -1,5 +1,6 @@
 import IssueRow from "@/components/issues/IssueRow"
 import PRStatusIndicator from "@/components/issues/PRStatusIndicator"
+import LoadMoreIssues from "@/components/issues/LoadMoreIssues"
 import {
   getIssueListWithStatus,
   getLinkedPRNumbersForIssues,
@@ -11,9 +12,10 @@ interface Props {
 }
 
 export default async function IssueRows({ repoFullName }: Props) {
+  const perPage = 25
   const issues = await getIssueListWithStatus({
     repoFullName: repoFullName.fullName,
-    per_page: 25,
+    per_page: perPage,
   })
 
   if (issues.length === 0) return null
@@ -39,6 +41,14 @@ export default async function IssueRows({ repoFullName }: Props) {
           }
         />
       ))}
+
+      {/* Load more button and dynamically loaded issues: only show if the first page was full */}
+      <LoadMoreIssues
+        repoFullName={repoFullName.fullName}
+        perPage={perPage}
+        initialHasMore={issues.length === perPage}
+      />
     </>
   )
 }
+

--- a/components/issues/IssueTable.tsx
+++ b/components/issues/IssueTable.tsx
@@ -1,7 +1,6 @@
 import { Suspense } from "react"
 
 import IssueRows from "@/components/issues/IssueRows"
-import LoadMoreIssues from "@/components/issues/LoadMoreIssues"
 import RowsSkeleton from "@/components/issues/RowsSkeleton"
 import TaskRows from "@/components/issues/TaskRows"
 import { Table, TableBody } from "@/components/ui/table"
@@ -14,15 +13,13 @@ interface Props {
 export default async function IssueTable({ repoFullName }: Props) {
   return (
     <div className="rounded-md border">
-      <Table className="table-fixed sm:table-auto">
+      {/* Use auto table layout on all viewports to avoid column squeeze on mobile */}
+      <Table className="table-auto">
         <TableBody>
           {/* Render GitHub issues first */}
           <Suspense fallback={<RowsSkeleton rows={5} columns={3} />}>
             <IssueRows repoFullName={repoFullName} />
           </Suspense>
-
-          {/* Load more button and dynamically loaded issues */}
-          <LoadMoreIssues repoFullName={repoFullName.fullName} />
 
           <Suspense fallback={<RowsSkeleton rows={2} columns={3} />}>
             <TaskRows repoFullName={repoFullName} />

--- a/components/issues/LoadMoreIssues.tsx
+++ b/components/issues/LoadMoreIssues.tsx
@@ -11,15 +11,24 @@ import type { IssueWithStatus } from "@/lib/github/issues"
 interface Props {
   repoFullName: string
   perPage?: number
+  // Whether the initial server-rendered page indicates more results exist.
+  // If false, we will not show the load more button initially.
+  initialHasMore?: boolean
 }
 
-export default function LoadMoreIssues({ repoFullName, perPage = 25 }: Props) {
+export default function LoadMoreIssues({
+  repoFullName,
+  perPage = 25,
+  initialHasMore,
+}: Props) {
   const [page, setPage] = useState(1) // initial server rendered page is 1; next fetch will be 2
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [issues, setIssues] = useState<IssueWithStatus[]>([])
   const [prMap, setPrMap] = useState<Record<number, number | null>>({})
-  const [hasMore, setHasMore] = useState<boolean | null>(null)
+  const [hasMore, setHasMore] = useState<boolean | null>(
+    typeof initialHasMore === "boolean" ? initialHasMore : null
+  )
 
   const loadMore = async () => {
     if (loading) return


### PR DESCRIPTION
Problem
- On mobile, the issues table content looked squeezed to the left until the first time the Load more button was clicked.
- The Load more button appeared even when there were no issues to show.

Root cause
- The table used the CSS class `table-fixed` on small screens, which can cause overly constrained column widths, especially with our responsive row styling.
- The Load more button was always rendered initially because it didn't know whether the first page had more results.

What I changed
1) Prevent mobile layout squeeze
- Switched the issues table layout from `table-fixed sm:table-auto` to `table-auto` in `components/issues/IssueTable.tsx`. This lets the browser size columns naturally and avoids the squeeze on small viewports.

2) Hide Load more when unnecessary
- Moved the `LoadMoreIssues` component render into `components/issues/IssueRows.tsx` so it can use the initial server-fetched page to decide visibility.
- Added a new optional prop `initialHasMore` to `components/issues/LoadMoreIssues.tsx` and initialized its state from this value.
- `IssueRows` now passes `initialHasMore={issues.length === perPage}` and only renders `LoadMoreIssues` when there’s at least one issue on the first page. This prevents showing the button when there are no issues (or when the initial page is already the last page).

Files changed
- components/issues/IssueTable.tsx
- components/issues/IssueRows.tsx
- components/issues/LoadMoreIssues.tsx

Notes
- No API changes.
- Type checks and Next.js lint run without errors locally (only warnings). Prettier check shows repository-wide formatting warnings unrelated to these changes.

Expected result
- Issues page no longer shifts/squeezes on mobile before interaction.
- Load more button is hidden when there are no additional issues to load (including the case of zero issues).

Closes #1159