### PR TITLE
Redesign LandingPage IssueDashboard and add client IssuesList with server action

### DIFF
--- a/components/home/IssueDashboard.tsx
+++ b/components/home/IssueDashboard.tsx
@@ -1,5 +1,6 @@
 import NoRepoCTA from "@/components/common/NoRepoCTA"
-import NewTaskContainer from "@/components/issues/NewTaskContainer"
+import IssueDashboardClient from "@/components/home/IssueDashboardClient"
+import { getRepoFromString } from "@/lib/github/content"
 import { listUserAppRepositories } from "@/lib/github/repos"
 import { repoFullNameSchema } from "@/lib/types/github"
 
@@ -13,5 +14,15 @@ export default async function IssueDashboard() {
   }
 
   const repoFullName = repoFullNameSchema.parse(firstRepo.full_name)
-  return <NewTaskContainer repoFullName={repoFullName} repositories={repos} />
+  const repo = await getRepoFromString(repoFullName.fullName)
+  const issuesEnabled = !!repo.has_issues
+
+  return (
+    <IssueDashboardClient
+      repoFullName={repoFullName}
+      repositories={repos}
+      issuesEnabled={issuesEnabled}
+    />
+  )
 }
+

--- a/components/home/IssueDashboardClient.tsx
+++ b/components/home/IssueDashboardClient.tsx
@@ -1,0 +1,148 @@
+"use client"
+
+import { Suspense, useEffect, useState } from "react"
+
+import RepoSelector from "@/components/common/RepoSelector"
+import IssuesList from "@/components/issues/IssuesList"
+import NewTaskInput from "@/components/issues/NewTaskInput"
+import RowsSkeleton from "@/components/issues/RowsSkeleton"
+import { Table, TableBody } from "@/components/ui/table"
+import { listIssues } from "@/lib/actions/issues"
+import type { IssueWithStatus } from "@/lib/github/issues"
+import type {
+  AuthenticatedUserRepository,
+  RepoFullName,
+} from "@/lib/types/github"
+
+interface Props {
+  repoFullName: RepoFullName
+  repositories: AuthenticatedUserRepository[]
+  issuesEnabled: boolean
+}
+
+export default function IssueDashboardClient({
+  repoFullName,
+  repositories,
+  issuesEnabled,
+}: Props) {
+  const [issues, setIssues] = useState<IssueWithStatus[]>([])
+  const [prMap, setPrMap] = useState<Record<number, number | null>>({})
+  const [page, setPage] = useState(1)
+  const [hasMore, setHasMore] = useState<boolean>(true)
+  const [loading, setLoading] = useState(false)
+  const [initialLoading, setInitialLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    async function loadInitial() {
+      setInitialLoading(true)
+      setError(null)
+      try {
+        const data = await listIssues({
+          repoFullName: repoFullName.fullName,
+          page: 1,
+          per_page: 25,
+        })
+        if (cancelled) return
+        setIssues(data.issues)
+        setPrMap(data.prMap)
+        setHasMore(data.hasMore)
+        setPage(1)
+      } catch (e) {
+        if (cancelled) return
+        setError(e instanceof Error ? e.message : "Failed to load issues")
+      } finally {
+        if (!cancelled) setInitialLoading(false)
+      }
+    }
+    loadInitial()
+    return () => {
+      cancelled = true
+    }
+  }, [repoFullName.fullName])
+
+  const onLoadMore = async () => {
+    if (loading || !hasMore) return
+    setLoading(true)
+    setError(null)
+    try {
+      const nextPage = page + 1
+      const data = await listIssues({
+        repoFullName: repoFullName.fullName,
+        page: nextPage,
+        per_page: 25,
+      })
+      setIssues((prev) => [...prev, ...data.issues])
+      setPrMap((prev) => ({ ...prev, ...data.prMap }))
+      setHasMore(data.hasMore)
+      setPage(nextPage)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load more issues")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <main className="mx-auto max-w-4xl w-full py-10 px-4 sm:px-6">
+      <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <h1 className="text-2xl font-bold">Your Issues &amp; Workflows</h1>
+        <div className="flex items-center gap-3">
+          <RepoSelector
+            selectedRepo={repoFullName.fullName}
+            repositories={repositories}
+          />
+        </div>
+      </div>
+
+      {!issuesEnabled ? (
+        <div className="mb-6 rounded-md border border-yellow-300 bg-yellow-50 p-4 text-yellow-800">
+          <p className="mb-1 font-medium">GitHub Issues are disabled for this repository.</p>
+          <p>
+            To enable issues, visit the repository settings on GitHub and turn on the
+            Issues feature. {" "}
+            <a
+              href={`https://github.com/${repoFullName.owner}/${repoFullName.repo}/settings#features`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              Open GitHub settings
+            </a>
+            .
+          </p>
+        </div>
+      ) : null}
+
+      <div className="mb-6">
+        <NewTaskInput repoFullName={repoFullName} issuesEnabled={issuesEnabled} />
+      </div>
+
+      {issuesEnabled ? (
+        <div className="rounded-md border">
+          <Table className="table-fixed sm:table-auto">
+            <TableBody>
+              <Suspense fallback={<RowsSkeleton rows={5} columns={3} />}>
+                {initialLoading ? (
+                  <RowsSkeleton rows={5} columns={3} />
+                ) : (
+                  <IssuesList
+                    repoFullName={repoFullName.fullName}
+                    issues={issues}
+                    prMap={prMap}
+                    loading={loading}
+                    error={error}
+                    hasMore={hasMore}
+                    onLoadMore={onLoadMore}
+                  />
+                )}
+              </Suspense>
+            </TableBody>
+          </Table>
+        </div>
+      ) : null}
+    </main>
+  )
+}
+

--- a/components/issues/IssuesList.tsx
+++ b/components/issues/IssuesList.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import IssueRow from "@/components/issues/IssueRow"
+import PRStatusIndicator from "@/components/issues/PRStatusIndicator"
+import { Button } from "@/components/ui/button"
+import { TableCell, TableRow } from "@/components/ui/table"
+import type { IssueWithStatus } from "@/lib/github/issues"
+
+interface Props {
+  repoFullName: string
+  issues: IssueWithStatus[]
+  prMap: Record<number, number | null>
+  loading: boolean
+  error: string | null
+  hasMore: boolean
+  onLoadMore: () => void
+}
+
+export default function IssuesList({
+  repoFullName,
+  issues,
+  prMap,
+  loading,
+  error,
+  hasMore,
+  onLoadMore,
+}: Props) {
+  return (
+    <>
+      {issues.map((issue) => (
+        <IssueRow
+          key={`issue-${issue.id}`}
+          issue={issue}
+          repoFullName={repoFullName}
+          prSlot={
+            <PRStatusIndicator
+              repoFullName={repoFullName}
+              prNumber={prMap[issue.number]}
+            />
+          }
+        />
+      ))}
+
+      {error && (
+        <TableRow>
+          <TableCell colSpan={3} className="text-red-600">
+            {error}
+          </TableCell>
+        </TableRow>
+      )}
+
+      {hasMore && (
+        <TableRow>
+          <TableCell colSpan={3} className="text-center py-4">
+            <Button onClick={onLoadMore} disabled={loading} variant="outline">
+              {loading ? "Loading..." : "Load more"}
+            </Button>
+          </TableCell>
+        </TableRow>
+      )}
+    </>
+  )
+}
+

--- a/lib/actions/issues.ts
+++ b/lib/actions/issues.ts
@@ -1,0 +1,50 @@
+"use server"
+
+import { z } from "zod"
+
+import {
+  getIssueListWithStatus,
+  getLinkedPRNumbersForIssues,
+} from "@/lib/github/issues"
+
+// Input schema for listIssues server action. Accept unknown and validate with Zod.
+export const listIssuesInputSchema = z.object({
+  repoFullName: z.string().min(3),
+  page: z.number().int().min(1).default(1).optional(),
+  per_page: z.number().int().min(1).max(100).default(25).optional(),
+})
+export type ListIssuesInput = z.infer<typeof listIssuesInputSchema>
+
+const listIssuesResultSchema = z.object({
+  issues: z.array(z.any()),
+  prMap: z.record(z.number(), z.number().nullable()),
+  hasMore: z.boolean(),
+})
+export type ListIssuesResult = z.infer<typeof listIssuesResultSchema>
+
+// Overload for typed usage
+export async function listIssues(input: ListIssuesInput): Promise<ListIssuesResult>
+// Accept unknown at boundary and validate
+export async function listIssues(input: unknown): Promise<ListIssuesResult>
+export async function listIssues(input: unknown): Promise<ListIssuesResult> {
+  const { repoFullName, page = 1, per_page = 25 } = listIssuesInputSchema.parse(
+    input
+  )
+
+  const issues = await getIssueListWithStatus({
+    repoFullName,
+    page,
+    per_page,
+  })
+
+  const issueNumbers = issues.map((i) => i.number)
+  const prMap = await getLinkedPRNumbersForIssues({
+    repoFullName,
+    issueNumbers,
+  })
+
+  const hasMore = issues.length === per_page
+
+  return { issues, prMap, hasMore }
+}
+


### PR DESCRIPTION
Summary
- Show IssueDashboard for logged-in users (existing) and redesign its internal layout to use three client components: RepoSelector, NewTaskInput, and IssuesList.
- Add IssueDashboardClient wrapper that co-locates client state and orchestrates data flow under the RSC IssueDashboard.
- Implement new IssuesList client component with a Load More button; wrapped in Suspense and using a server action instead of API route.
- Introduce listIssues server action (with Zod schema + typed overload) that validates input and orchestrates the underlying use cases/adapters to fetch issues and PR mappings.

Details
- components/home/IssueDashboard.tsx now computes issuesEnabled and renders IssueDashboardClient.
- components/home/IssueDashboardClient.tsx (client) renders the layout, RepoSelector, NewTaskInput, and a table containing IssuesList within a Suspense. It manages issues state, page cursor, PR map, and error/loading flags.
- components/issues/IssuesList.tsx (client) displays issue rows with a single batched PR-lookup per page, plus Load More.
- lib/actions/issues.ts adds a listIssues server action:
  - Validates unknown boundary input via Zod and infers types (ListIssuesInput, ListIssuesResult).
  - Delegates to existing getIssueListWithStatus and getLinkedPRNumbersForIssues so the server action is an orchestrator.

Notes on data loading and Neo4j
- getIssueListWithStatus already batches Neo4j queries per-page (no per-row calls). When loading more, only the new page is fetched, aligning with the "new rows only" goal.
- PR references are fetched with a single GraphQL call per page using field aliases.

Non-breaking
- Existing NewTaskContainer/IssueTable/IssueRows/LoadMoreIssues remain in the codebase for other potential usages; IssueDashboard has been refactored to use the new client-driven flow.

Quality
- Installed deps via pnpm, ran next lint and tsc (no errors), and kept changes focused on IssueDashboard, issues loading, and the new server action.

If you’d like me to also remove the old IssueTable/LoadMoreIssues wiring and replace those usages elsewhere, I can follow up in a separate PR to keep this change focused.

Closes #1172