### PR TITLE
Fix layout shift and hide Load More button on issues page when empty

### DIFF
--- a/components/issues/IssueTable.tsx
+++ b/components/issues/IssueTable.tsx
@@ -14,7 +14,7 @@ interface Props {
 export default async function IssueTable({ repoFullName }: Props) {
   return (
     <div className="rounded-md border">
-      <Table className="table-fixed sm:table-auto">
+      <Table className="table-auto">
         <TableBody>
           {/* Render GitHub issues first */}
           <Suspense fallback={<RowsSkeleton rows={5} columns={3} />}>


### PR DESCRIPTION
Summary
- Fixes mobile layout shift on the repository issues page where content appeared squeezed to the left until the "Load more" button was clicked.
- Hides the "Load more" button when there are no issues, and respects initial pagination state.

Details
1) Address mobile layout shift
- Root cause: the table was using `table-fixed` for small screens and the first rendered row could be the colspanned "Load more" row. With a fixed table layout and a single colspanned row, browsers can miscompute column widths, causing the content to appear squeezed until more rows render.
- Change: switched the issues table to `table-auto` so column widths are determined by cell content immediately. This removes the width miscalculation and the subsequent layout shift.

File: components/issues/IssueTable.tsx
- Update `<Table className="table-auto">` (replacing `table-fixed sm:table-auto`).

2) Hide Load More button when there are no issues
- The button used to render even if the initial page had no issues, because the client-side component didn’t know that yet.
- Change: on mount, `LoadMoreIssues` makes a small request to `/api/issues/list` (page 1 with the same per page value) to determine:
  - whether there are any issues at all
  - whether additional pages exist (using the API’s `hasMore` field)
- The button is only shown when (a) there are any issues and (b) `hasMore !== false`. This prevents the button from showing for empty repositories.

File: components/issues/LoadMoreIssues.tsx
- Add an initial check with `useEffect` to set `hasAnyInitialIssues` and initialize `hasMore`.
- Gate button visibility with `const showButton = hasAnyInitialIssues === true && hasMore !== false`.

Why this approach
- Small, focused change that does not refactor the server-side fetching logic.
- Avoids brittle DOM inspection hacks.
- Keeps additional network overhead minimal (one lightweight API call on mount).

QA notes
- On mobile, navigate to a repo’s issues page where before the content appeared squeezed to the left — it should now render correctly without shifting on first interaction.
- If a repository has no issues, the table shows no rows and the "Load more" button does not appear.
- If there are issues but fewer than a page, the button will not appear.
- Clicking "Load more" continues to fetch next pages and hides itself once no further pages are available.

Checks
- Ran `pnpm run check:all` (ESLint, Prettier check, and TypeScript) successfully.

Closes: Fix layout shift and load more button on issues page

Closes #1159