### PR TITLE
Hide shortcut commands on mobile devices

### DIFF
--- a/components/issues/NewTaskInput.tsx
+++ b/components/issues/NewTaskInput.tsx
@@ -259,12 +259,13 @@ export default function NewTaskInput({
                     </>
                   ) : (
                     <>
-                      Create Github Issue
-                      {hasKeyboard ? (
-                        <span className="ml-2 text-xs text-primary-foreground">
-                          {shortcutHint}
-                        </span>
-                      ) : null}
+                      Create GitHub Issue
+                      <span
+                        className={`ml-2 text-xs text-primary-foreground ${hasKeyboard ? "" : "invisible"}`}
+                        aria-hidden={!hasKeyboard}
+                      >
+                        {shortcutHint}
+                      </span>
                     </>
                   )}
                 </Button>
@@ -288,4 +289,3 @@ export default function NewTaskInput({
     </TooltipProvider>
   )
 }
-

--- a/components/issues/NewTaskInput.tsx
+++ b/components/issues/NewTaskInput.tsx
@@ -15,6 +15,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { createIssueAction } from "@/lib/actions/createIssue"
+import { useHasKeyboard } from "@/lib/hooks/use-has-keyboard"
 import { toast } from "@/lib/hooks/use-toast"
 import { IssueTitleResponseSchema } from "@/lib/types/api/schemas"
 import type { RepoFullName } from "@/lib/types/github"
@@ -42,6 +43,7 @@ export default function NewTaskInput({
   const router = useRouter()
   const formRef = useRef<HTMLFormElement>(null)
   const [isMac, setIsMac] = useState(false)
+  const hasKeyboard = useHasKeyboard()
 
   // Detect OS to adjust keyboard shortcut hint and behavior
   useEffect(() => {
@@ -258,9 +260,11 @@ export default function NewTaskInput({
                   ) : (
                     <>
                       Create Github Issue
-                      <span className="ml-2 text-xs text-primary-foreground">
-                        {shortcutHint}
-                      </span>
+                      {hasKeyboard ? (
+                        <span className="ml-2 text-xs text-primary-foreground">
+                          {shortcutHint}
+                        </span>
+                      ) : null}
                     </>
                   )}
                 </Button>
@@ -284,3 +288,4 @@ export default function NewTaskInput({
     </TooltipProvider>
   )
 }
+

--- a/lib/hooks/use-has-keyboard.ts
+++ b/lib/hooks/use-has-keyboard.ts
@@ -16,8 +16,10 @@ export function useHasKeyboard(): boolean {
 
     const mq = (q: string) => window.matchMedia(q)
 
-    const hasFinePointer = mq("(pointer: fine)").matches || mq("(any-pointer: fine)").matches
-    const hasHover = mq("(hover: hover)").matches || mq("(any-hover: hover)").matches
+    const hasFinePointer =
+      mq("(pointer: fine)").matches || mq("(any-pointer: fine)").matches
+    const hasHover =
+      mq("(hover: hover)").matches || mq("(any-hover: hover)").matches
 
     const ua = window.navigator.userAgent || ""
     const platform = window.navigator.platform || ""
@@ -27,26 +29,49 @@ export function useHasKeyboard(): boolean {
     const maxTouchPoints = window.navigator.maxTouchPoints ?? 0
 
     // Consider as desktop if platform looks like a desktop and touch points are few
-    const looksDesktopPlatform = /(Mac|Win|Linux)/i.test(platform) && maxTouchPoints < 2
+    const looksDesktopPlatform =
+      /(Mac|Win|Linux)/i.test(platform) && maxTouchPoints < 2
 
-    const initialHasKeyboard = (hasFinePointer && hasHover && !isMobileUA) || looksDesktopPlatform
+    const initialHasKeyboard =
+      (hasFinePointer && hasHover && !isMobileUA) || looksDesktopPlatform
 
     setHasKeyboard(initialHasKeyboard)
 
-    // Upgrade to true if any key is pressed (covers tablets w/ external keyboards)
-    const onKeyDown = () => setHasKeyboard(true)
+    // Upgrade to true only on signals typical of physical keyboards
+    const onKeyDown = (e: KeyboardEvent) => {
+      const isHardwareLike =
+        e.metaKey ||
+        e.ctrlKey ||
+        e.key === "Escape" ||
+        e.key === "Tab" ||
+        e.key.startsWith("Arrow") ||
+        /^F\d{1,2}$/.test(e.key)
+      if (isHardwareLike) setHasKeyboard(true)
+    }
     window.addEventListener("keydown", onKeyDown)
 
     // Listen for media changes to update heuristic
-    const listeners: Array<{ mql: MediaQueryList; handler: (e: MediaQueryListEvent) => void }> = []
+    const listeners: Array<{
+      mql: MediaQueryList
+      handler: (e: MediaQueryListEvent) => void
+    }> = []
     const makeListener = (query: string) => {
       const mql = mq(query)
       const handler = () => {
-        const nextFinePointer = mq("(pointer: fine)").matches || mq("(any-pointer: fine)").matches
-        const nextHasHover = mq("(hover: hover)").matches || mq("(any-hover: hover)").matches
-        const nextIsMobileUA = /Mobi|Android|iPhone|iPad|iPod|Phone/i.test(window.navigator.userAgent || "")
-        const nextLooksDesktopPlatform = /(Mac|Win|Linux)/i.test(window.navigator.platform || "") && (window.navigator.maxTouchPoints ?? 0) < 2
-        setHasKeyboard((nextFinePointer && nextHasHover && !nextIsMobileUA) || nextLooksDesktopPlatform)
+        const nextFinePointer =
+          mq("(pointer: fine)").matches || mq("(any-pointer: fine)").matches
+        const nextHasHover =
+          mq("(hover: hover)").matches || mq("(any-hover: hover)").matches
+        const nextIsMobileUA = /Mobi|Android|iPhone|iPad|iPod|Phone/i.test(
+          window.navigator.userAgent || ""
+        )
+        const nextLooksDesktopPlatform =
+          /(Mac|Win|Linux)/i.test(window.navigator.platform || "") &&
+          (window.navigator.maxTouchPoints ?? 0) < 2
+        setHasKeyboard(
+          (nextFinePointer && nextHasHover && !nextIsMobileUA) ||
+            nextLooksDesktopPlatform
+        )
       }
       mql.addEventListener("change", handler)
       listeners.push({ mql, handler })
@@ -59,10 +84,11 @@ export function useHasKeyboard(): boolean {
 
     return () => {
       window.removeEventListener("keydown", onKeyDown)
-      listeners.forEach(({ mql, handler }) => mql.removeEventListener("change", handler))
+      listeners.forEach(({ mql, handler }) =>
+        mql.removeEventListener("change", handler)
+      )
     }
   }, [])
 
   return hasKeyboard
 }
-

--- a/lib/hooks/use-has-keyboard.ts
+++ b/lib/hooks/use-has-keyboard.ts
@@ -16,26 +16,22 @@ export function useHasKeyboard(): boolean {
 
     const mq = (q: string) => window.matchMedia(q)
 
-    const hasFinePointer =
-      mq("(pointer: fine)").matches || mq("(any-pointer: fine)").matches
-    const hasHover =
-      mq("(hover: hover)").matches || mq("(any-hover: hover)").matches
+    const computeHasKeyboard = () => {
+      const hasFinePointer =
+        mq("(pointer: fine)").matches || mq("(any-pointer: fine)").matches
+      const hasHover =
+        mq("(hover: hover)").matches || mq("(any-hover: hover)").matches
 
-    const ua = window.navigator.userAgent || ""
-    const platform = window.navigator.platform || ""
+      const ua = window.navigator.userAgent || ""
+      const platform = window.navigator.platform || ""
+      const isMobileUA = /Mobi|Android|iPhone|iPad|iPod|Phone/i.test(ua)
+      const maxTouchPoints = window.navigator.maxTouchPoints ?? 0
+      const looksDesktopPlatform =
+        /(Mac|Win|Linux)/i.test(platform) && maxTouchPoints < 2
+      return (hasFinePointer && hasHover && !isMobileUA) || looksDesktopPlatform
+    }
 
-    // Heuristic mobile/tablet detection
-    const isMobileUA = /Mobi|Android|iPhone|iPad|iPod|Phone/i.test(ua)
-    const maxTouchPoints = window.navigator.maxTouchPoints ?? 0
-
-    // Consider as desktop if platform looks like a desktop and touch points are few
-    const looksDesktopPlatform =
-      /(Mac|Win|Linux)/i.test(platform) && maxTouchPoints < 2
-
-    const initialHasKeyboard =
-      (hasFinePointer && hasHover && !isMobileUA) || looksDesktopPlatform
-
-    setHasKeyboard(initialHasKeyboard)
+    setHasKeyboard(computeHasKeyboard())
 
     // Upgrade to true only on signals typical of physical keyboards
     const onKeyDown = (e: KeyboardEvent) => {
@@ -58,20 +54,7 @@ export function useHasKeyboard(): boolean {
     const makeListener = (query: string) => {
       const mql = mq(query)
       const handler = () => {
-        const nextFinePointer =
-          mq("(pointer: fine)").matches || mq("(any-pointer: fine)").matches
-        const nextHasHover =
-          mq("(hover: hover)").matches || mq("(any-hover: hover)").matches
-        const nextIsMobileUA = /Mobi|Android|iPhone|iPad|iPod|Phone/i.test(
-          window.navigator.userAgent || ""
-        )
-        const nextLooksDesktopPlatform =
-          /(Mac|Win|Linux)/i.test(window.navigator.platform || "") &&
-          (window.navigator.maxTouchPoints ?? 0) < 2
-        setHasKeyboard(
-          (nextFinePointer && nextHasHover && !nextIsMobileUA) ||
-            nextLooksDesktopPlatform
-        )
+        setHasKeyboard(computeHasKeyboard())
       }
       mql.addEventListener("change", handler)
       listeners.push({ mql, handler })

--- a/lib/hooks/use-has-keyboard.ts
+++ b/lib/hooks/use-has-keyboard.ts
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react"
+
+/**
+ * Heuristic hook to detect whether showing keyboard shortcut hints makes sense.
+ *
+ * We consider a device to "have a keyboard" when it's likely a desktop/laptop
+ * environment (hover available, fine pointer) and not a primarily touch device.
+ * We also flip to true if we ever detect a keydown event, which covers cases
+ * like tablets with external keyboards.
+ */
+export function useHasKeyboard(): boolean {
+  const [hasKeyboard, setHasKeyboard] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+
+    const mq = (q: string) => window.matchMedia(q)
+
+    const hasFinePointer = mq("(pointer: fine)").matches || mq("(any-pointer: fine)").matches
+    const hasHover = mq("(hover: hover)").matches || mq("(any-hover: hover)").matches
+
+    const ua = window.navigator.userAgent || ""
+    const platform = window.navigator.platform || ""
+
+    // Heuristic mobile/tablet detection
+    const isMobileUA = /Mobi|Android|iPhone|iPad|iPod|Phone/i.test(ua)
+    const maxTouchPoints = window.navigator.maxTouchPoints ?? 0
+
+    // Consider as desktop if platform looks like a desktop and touch points are few
+    const looksDesktopPlatform = /(Mac|Win|Linux)/i.test(platform) && maxTouchPoints < 2
+
+    const initialHasKeyboard = (hasFinePointer && hasHover && !isMobileUA) || looksDesktopPlatform
+
+    setHasKeyboard(initialHasKeyboard)
+
+    // Upgrade to true if any key is pressed (covers tablets w/ external keyboards)
+    const onKeyDown = () => setHasKeyboard(true)
+    window.addEventListener("keydown", onKeyDown)
+
+    // Listen for media changes to update heuristic
+    const listeners: Array<{ mql: MediaQueryList; handler: (e: MediaQueryListEvent) => void }> = []
+    const makeListener = (query: string) => {
+      const mql = mq(query)
+      const handler = () => {
+        const nextFinePointer = mq("(pointer: fine)").matches || mq("(any-pointer: fine)").matches
+        const nextHasHover = mq("(hover: hover)").matches || mq("(any-hover: hover)").matches
+        const nextIsMobileUA = /Mobi|Android|iPhone|iPad|iPod|Phone/i.test(window.navigator.userAgent || "")
+        const nextLooksDesktopPlatform = /(Mac|Win|Linux)/i.test(window.navigator.platform || "") && (window.navigator.maxTouchPoints ?? 0) < 2
+        setHasKeyboard((nextFinePointer && nextHasHover && !nextIsMobileUA) || nextLooksDesktopPlatform)
+      }
+      mql.addEventListener("change", handler)
+      listeners.push({ mql, handler })
+    }
+
+    makeListener("(pointer: fine)")
+    makeListener("(any-pointer: fine)")
+    makeListener("(hover: hover)")
+    makeListener("(any-hover: hover)")
+
+    return () => {
+      window.removeEventListener("keydown", onKeyDown)
+      listeners.forEach(({ mql, handler }) => mql.removeEventListener("change", handler))
+    }
+  }, [])
+
+  return hasKeyboard
+}
+


### PR DESCRIPTION
Summary
- Hide the keyboard shortcut hint on the "Create Github Issue" button for devices that likely don't have a physical keyboard (e.g., phones and most tablets).
- Keep showing the hint on desktop environments, and automatically enable it if any key is pressed (covers tablets with external keyboards).

Implementation details
- Added a new hook useHasKeyboard that heuristically detects whether a device has a keyboard based on:
  - CSS media queries: (hover: hover)/(any-hover: hover) and (pointer: fine)/(any-pointer: fine)
  - Navigator properties: platform and maxTouchPoints
  - User agent checks for common mobile identifiers
  - Fallback: once any keydown occurs, we set hasKeyboard to true
- Updated components/issues/NewTaskInput.tsx to conditionally render the shortcut hint only when useHasKeyboard() is true.

Why this approach
- It’s lightweight and avoids heavy UA sniffing.
- Works for typical desktop cases while hiding irrelevant shortcuts on mobile virtual keyboards.
- Still supports tablets + external keyboards: the hint appears after the first key press.

Testing
- Lint and type checks pass locally (pnpm run lint and pnpm run check:all).
- Visual check on mobile vs. desktop via responsive dev tools: the hint is hidden on mobile-sized, touch-first emulations and visible on desktop.

Scope
- Changes are isolated to the NewTaskInput and a new hook; minimal risk and no API changes.

Closes: Hide shortcut commands on mobile devices

Closes #1186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shortcut hint in the new task input now appears only on devices detected to have a physical keyboard, reducing clutter for touch-only users.
  * Detection updates in real time (e.g., when a keyboard is connected to a tablet), so hints appear automatically without reloading.
  * Button label corrected to "Create GitHub Issue".
  * No changes to task creation flow; only hint visibility and accessibility attributes adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->