### PR TITLE
Disable microphone button when OpenAI API key is missing

### DIFF
--- a/app/[username]/[repo]/issues/page.tsx
+++ b/app/[username]/[repo]/issues/page.tsx
@@ -1,6 +1,7 @@
 import IssueTable from "@/components/issues/IssueTable"
 import NewTaskInput from "@/components/issues/NewTaskInput"
 import { getRepoFromString } from "@/lib/github/content"
+import { getUserOpenAIApiKey } from "@/lib/neo4j/services/user"
 import { repoFullNameSchema } from "@/lib/types/github"
 
 interface Props {
@@ -16,6 +17,8 @@ export default async function RepoPage({ params }: Props) {
   const repoFullName = repoFullNameSchema.parse(`${username}/${repo}`)
   const repoData = await getRepoFromString(repoFullName.fullName)
   const issuesEnabled = !!repoData.has_issues
+  const existingKey = await getUserOpenAIApiKey()
+  const hasOpenAIKey = !!(existingKey && existingKey.trim())
 
   return (
     <main className="container mx-auto p-4">
@@ -44,7 +47,7 @@ export default async function RepoPage({ params }: Props) {
         </div>
       ) : null}
 
-      <NewTaskInput repoFullName={repoFullName} issuesEnabled={issuesEnabled} />
+      <NewTaskInput repoFullName={repoFullName} issuesEnabled={issuesEnabled} hasOpenAIKey={hasOpenAIKey} />
 
       {issuesEnabled ? (
         <IssueTable repoFullName={repoFullName} />

--- a/app/[username]/[repo]/issues/page.tsx
+++ b/app/[username]/[repo]/issues/page.tsx
@@ -30,10 +30,12 @@ export default async function RepoPage({ params }: Props) {
 
       {!issuesEnabled ? (
         <div className="mb-6 rounded-md border border-yellow-300 bg-yellow-50 p-4 text-yellow-800">
-          <p className="mb-1 font-medium">GitHub Issues are disabled for this repository.</p>
+          <p className="mb-1 font-medium">
+            GitHub Issues are disabled for this repository.
+          </p>
           <p>
-            To enable issues, visit the repository settings on GitHub and turn on the
-            Issues feature. {" "}
+            To enable issues, visit the repository settings on GitHub and turn
+            on the Issues feature.{" "}
             <a
               href={`https://github.com/${username}/${repo}/settings#features`}
               target="_blank"
@@ -47,12 +49,13 @@ export default async function RepoPage({ params }: Props) {
         </div>
       ) : null}
 
-      <NewTaskInput repoFullName={repoFullName} issuesEnabled={issuesEnabled} hasOpenAIKey={hasOpenAIKey} />
+      <NewTaskInput
+        repoFullName={repoFullName}
+        issuesEnabled={issuesEnabled}
+        hasOpenAIKey={hasOpenAIKey}
+      />
 
-      {issuesEnabled ? (
-        <IssueTable repoFullName={repoFullName} />
-      ) : null}
+      {issuesEnabled ? <IssueTable repoFullName={repoFullName} /> : null}
     </main>
   )
 }
-

--- a/components/home/IssueDashboard.tsx
+++ b/components/home/IssueDashboard.tsx
@@ -29,4 +29,3 @@ export default async function IssueDashboard() {
     />
   )
 }
-

--- a/components/home/IssueDashboard.tsx
+++ b/components/home/IssueDashboard.tsx
@@ -2,6 +2,7 @@ import NoRepoCTA from "@/components/common/NoRepoCTA"
 import IssueDashboardClient from "@/components/home/IssueDashboardClient"
 import { getRepoFromString } from "@/lib/github/content"
 import { listUserAppRepositories } from "@/lib/github/repos"
+import { getUserOpenAIApiKey } from "@/lib/neo4j/services/user"
 import { repoFullNameSchema } from "@/lib/types/github"
 
 export default async function IssueDashboard() {
@@ -16,12 +17,15 @@ export default async function IssueDashboard() {
   const repoFullName = repoFullNameSchema.parse(firstRepo.full_name)
   const repo = await getRepoFromString(repoFullName.fullName)
   const issuesEnabled = !!repo.has_issues
+  const existingKey = await getUserOpenAIApiKey()
+  const hasOpenAIKey = !!(existingKey && existingKey.trim())
 
   return (
     <IssueDashboardClient
       repoFullName={repoFullName}
       repositories={repos}
       issuesEnabled={issuesEnabled}
+      hasOpenAIKey={hasOpenAIKey}
     />
   )
 }

--- a/components/home/IssueDashboardClient.tsx
+++ b/components/home/IssueDashboardClient.tsx
@@ -153,4 +153,3 @@ export default function IssueDashboardClient({
     </main>
   )
 }
-

--- a/components/home/IssueDashboardClient.tsx
+++ b/components/home/IssueDashboardClient.tsx
@@ -18,12 +18,14 @@ interface Props {
   repoFullName: RepoFullName
   repositories: AuthenticatedUserRepository[]
   issuesEnabled: boolean
+  hasOpenAIKey: boolean
 }
 
 export default function IssueDashboardClient({
   repoFullName,
   repositories,
   issuesEnabled,
+  hasOpenAIKey,
 }: Props) {
   const [issues, setIssues] = useState<IssueWithStatus[]>([])
   const [prMap, setPrMap] = useState<Record<number, number | null>>({})
@@ -121,6 +123,7 @@ export default function IssueDashboardClient({
         <NewTaskInput
           repoFullName={repoFullName}
           issuesEnabled={issuesEnabled}
+          hasOpenAIKey={hasOpenAIKey}
         />
       </div>
 
@@ -150,3 +153,4 @@ export default function IssueDashboardClient({
     </main>
   )
 }
+

--- a/components/issues/NewTaskContainer.tsx
+++ b/components/issues/NewTaskContainer.tsx
@@ -2,6 +2,7 @@ import RepoSelector from "@/components/common/RepoSelector"
 import IssueTable from "@/components/issues/IssueTable"
 import NewTaskInput from "@/components/issues/NewTaskInput"
 import { getRepoFromString } from "@/lib/github/content"
+import { getUserOpenAIApiKey } from "@/lib/neo4j/services/user"
 import { AuthenticatedUserRepository, RepoFullName } from "@/lib/types/github"
 
 interface Props {
@@ -20,6 +21,8 @@ export default async function NewTaskContainer({
 }: Props) {
   const repo = await getRepoFromString(repoFullName.fullName)
   const issuesEnabled = !!repo.has_issues
+  const existingKey = await getUserOpenAIApiKey()
+  const hasOpenAIKey = !!(existingKey && existingKey.trim())
 
   return (
     <main className="mx-auto max-w-4xl w-full py-10 px-4 sm:px-6">
@@ -53,7 +56,7 @@ export default async function NewTaskContainer({
       ) : null}
 
       <div className="mb-6">
-        <NewTaskInput repoFullName={repoFullName} issuesEnabled={issuesEnabled} />
+        <NewTaskInput repoFullName={repoFullName} issuesEnabled={issuesEnabled} hasOpenAIKey={hasOpenAIKey} />
       </div>
 
       {issuesEnabled ? <IssueTable repoFullName={repoFullName} /> : null}

--- a/components/issues/NewTaskContainer.tsx
+++ b/components/issues/NewTaskContainer.tsx
@@ -38,10 +38,12 @@ export default async function NewTaskContainer({
 
       {!issuesEnabled ? (
         <div className="mb-6 rounded-md border border-yellow-300 bg-yellow-50 p-4 text-yellow-800">
-          <p className="mb-1 font-medium">GitHub Issues are disabled for this repository.</p>
+          <p className="mb-1 font-medium">
+            GitHub Issues are disabled for this repository.
+          </p>
           <p>
-            To enable issues, visit the repository settings on GitHub and turn on the
-            Issues feature. {" "}
+            To enable issues, visit the repository settings on GitHub and turn
+            on the Issues feature.{" "}
             <a
               href={`https://github.com/${repoFullName.owner}/${repoFullName.repo}/settings#features`}
               target="_blank"
@@ -56,11 +58,14 @@ export default async function NewTaskContainer({
       ) : null}
 
       <div className="mb-6">
-        <NewTaskInput repoFullName={repoFullName} issuesEnabled={issuesEnabled} hasOpenAIKey={hasOpenAIKey} />
+        <NewTaskInput
+          repoFullName={repoFullName}
+          issuesEnabled={issuesEnabled}
+          hasOpenAIKey={hasOpenAIKey}
+        />
       </div>
 
       {issuesEnabled ? <IssueTable repoFullName={repoFullName} /> : null}
     </main>
   )
 }
-

--- a/components/issues/NewTaskInput.tsx
+++ b/components/issues/NewTaskInput.tsx
@@ -23,11 +23,13 @@ import { mapGithubErrorToCopy } from "@/lib/ui/errorMessages"
 interface Props {
   repoFullName: RepoFullName | null
   issuesEnabled?: boolean
+  hasOpenAIKey?: boolean
 }
 
 export default function NewTaskInput({
   repoFullName,
   issuesEnabled = true,
+  hasOpenAIKey = true,
 }: Props) {
   const [description, setDescription] = useState("")
   const [loading, setLoading] = useState(false)
@@ -207,6 +209,8 @@ export default function NewTaskInput({
     }
   }
 
+  const micDisabled = isDisabled || !hasOpenAIKey
+
   return (
     <TooltipProvider>
       <form
@@ -277,10 +281,11 @@ export default function NewTaskInput({
                 prev.trim() ? `${prev}\n${text}` : text
               )
             }
-            disabled={isDisabled}
+            disabled={micDisabled}
           />
         </div>
       </form>
     </TooltipProvider>
   )
 }
+

--- a/components/issues/NewTaskInput.tsx
+++ b/components/issues/NewTaskInput.tsx
@@ -24,13 +24,13 @@ import { mapGithubErrorToCopy } from "@/lib/ui/errorMessages"
 interface Props {
   repoFullName: RepoFullName | null
   issuesEnabled?: boolean
-  hasOpenAIKey?: boolean
+  hasOpenAIKey: boolean
 }
 
 export default function NewTaskInput({
   repoFullName,
   issuesEnabled = true,
-  hasOpenAIKey = true,
+  hasOpenAIKey,
 }: Props) {
   const [description, setDescription] = useState("")
   const [loading, setLoading] = useState(false)
@@ -292,4 +292,3 @@ export default function NewTaskInput({
     </TooltipProvider>
   )
 }
-


### PR DESCRIPTION
Summary
- Disables the microphone (voice dictation) button when the user does not have an OpenAI API key saved.
- Prevents a UX issue where users can start recording but transcription fails due to the missing key.

What changed
- components/issues/NewTaskInput.tsx
  - Added a new optional prop hasOpenAIKey (default true).
  - Disables VoiceDictationButton when no API key is available by combining existing disabled states with !hasOpenAIKey.
- app/[username]/[repo]/issues/page.tsx
  - Server component now fetches the user’s OpenAI API key via getUserOpenAIApiKey and passes hasOpenAIKey to NewTaskInput.
- components/issues/NewTaskContainer.tsx
  - Same as above for the shared container.
- components/home/IssueDashboard.tsx and components/home/IssueDashboardClient.tsx
  - Thread hasOpenAIKey from the server to the client and down to NewTaskInput.

Why
- The transcription API requires the user’s OpenAI API key (checked on the server in /api/openai/transcribe). If the key is missing, the request fails.
- Disabling the microphone button up-front avoids a confusing user flow.

Scope
- Targeted only the primary places where NewTaskInput is used, ensuring the microphone button is appropriately disabled.

Notes
- No API surface changes other than the NewTaskInput prop.
- The button will re-enable automatically once a valid key is saved (e.g., after visiting Settings).

Closes #1163

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - The app now detects whether your AI key is set and adjusts the New Task experience accordingly across issue pages and the dashboard.
  - Voice dictation and the task input are automatically disabled when no AI key is present, and enabled when it is, providing clear visual feedback (e.g., disabled microphone and textarea).
  - Consistent AI-key-aware behavior is applied wherever you create new tasks, ensuring a smoother and more predictable experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->