### PR TITLE
Shrink create issue button when shortcut helpers are hidden

### DIFF
--- a/components/issues/NewTaskInput.tsx
+++ b/components/issues/NewTaskInput.tsx
@@ -260,12 +260,11 @@ export default function NewTaskInput({
                   ) : (
                     <>
                       Create GitHub Issue
-                      <span
-                        className={`ml-2 text-xs text-primary-foreground ${hasKeyboard ? "" : "invisible"}`}
-                        aria-hidden={!hasKeyboard}
-                      >
-                        {shortcutHint}
-                      </span>
+                      {hasKeyboard && (
+                        <span className="ml-2 text-xs text-primary-foreground">
+                          {shortcutHint}
+                        </span>
+                      )}
                     </>
                   )}
                 </Button>
@@ -289,3 +288,4 @@ export default function NewTaskInput({
     </TooltipProvider>
   )
 }
+


### PR DESCRIPTION
Problem
On mobile or devices without a hardware keyboard, the keyboard shortcut helper next to the “Create GitHub Issue” label is hidden via CSS using `invisible`. Because `invisible` preserves layout space, the submit button remained stretched as if the helper were visible.

Solution
Switch to conditional rendering of the shortcut helper based on `hasKeyboard` instead of applying `invisible`. When `hasKeyboard` is false, the helper span is not rendered at all, allowing the button to shrink to fit its actual contents.

Changes
- components/issues/NewTaskInput.tsx: Render the shortcut helper only when `hasKeyboard` is true. Removed the `invisible` fallback and `aria-hidden` since the element is not present when hidden.

Why this approach
- Keeps the DOM minimal and avoids layout artifacts on small screens.
- No behavior change when a keyboard is present.
- Small, focused change scoped to the affected button.

QA
- With a hardware keyboard (desktop): The shortcut (⌘ + Enter / Ctrl + Enter) still appears next to the button text.
- Without a hardware keyboard (mobile): The helper is not rendered, and the button shrinks to only the label text.

Checks
- Repo setup with pnpm
- Ran `pnpm run check:all` (ESLint / Prettier check / TypeScript) — no lint errors and TypeScript passes.

Closes #1197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - The shortcut hint in the “Create GitHub Issue” button now appears only when applicable (keyboard detected), reducing confusion and visual clutter.
  - Improves accessibility by removing a hidden hint that could be announced by assistive technologies.

- Refactor
  - Streamlined rendering of the shortcut hint to reduce unnecessary DOM elements and ARIA toggling, resulting in a cleaner button label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->