### PR TITLE
Add demo API key fallback for users with demo access

### DIFF
--- a/lib/neo4j/services/user.ts
+++ b/lib/neo4j/services/user.ts
@@ -43,8 +43,18 @@ export async function setUserOpenAIApiKey(apiKey: string): Promise<void> {
 export async function getUserOpenAIApiKey(): Promise<string | null> {
   const settings = await getUserSettings()
   if (!settings) return null
-  const key = settings.openAIApiKey?.trim()
-  return key ? key : null
+
+  // 1) Prefer the user's own key if set
+  const userKey = settings.openAIApiKey?.trim()
+  if (userKey) return userKey
+
+  // 2) If user has demo access, fall back to the demo key from env
+  const hasDemoAccess = settings.roles?.includes("demo")
+  const demoKey = process.env.OPENAI_DEMO_API_KEY?.trim()
+  if (hasDemoAccess && demoKey) return demoKey
+
+  // 3) Otherwise, no key available
+  return null
 }
 
 /**
@@ -124,3 +134,4 @@ export async function getUserRoles(username: string): Promise<string[]> {
     await session.close()
   }
 }
+


### PR DESCRIPTION
Summary
- Introduces support for a separate demo OpenAI API key via OPENAI_DEMO_API_KEY.
- If a user has no personal key saved but has the `demo` role, their requests will now use the demo key automatically.

Why
This enables granting demo access without requiring each user to add a personal key. You can add users to demo projects (by assigning the `demo` role) and they will be able to run the agents using the demo key while demoing.

Implementation Details
- Updated lib/neo4j/services/user.ts:
  - getUserOpenAIApiKey():
    1) Return the user's own saved key if present.
    2) Otherwise, if the user has the `demo` role and OPENAI_DEMO_API_KEY is set, return the demo key.
    3) Otherwise, return null (same as before).

Notes
- No UI changes required; existing settings UI continues to save/validate personal keys.
- Endpoints that already rely on getUserOpenAIApiKey() automatically benefit from the new fallback.
- To grant demo access, assign the `demo` role to the user (using existing addRoleToUser) and set OPENAI_DEMO_API_KEY in the environment.

Validation
- Linting, type-checking, and Next.js lint pass via `pnpm run check:all`.

Env
- Add OPENAI_DEMO_API_KEY to your environment to enable the fallback for demo users.

Closes #1164

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prioritized OpenAI API key selection: uses your saved key first; for demo users without a key, automatically uses a demo key when available; otherwise no key is used.
  * Empty or whitespace-only keys are ignored, ensuring reliable detection.
  * Improves the out-of-the-box experience for demo accounts and reduces setup friction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->