### PR TITLE
Implement Redis Streams event bus and emit resolveIssue workflow events

### DIFF
--- a/app/api/queues/[queueId]/jobs/route.ts
+++ b/app/api/queues/[queueId]/jobs/route.ts
@@ -33,8 +33,18 @@ export async function POST(
     )
   }
 
+  const redisUrl = process.env.REDIS_URL
+  if (!redisUrl) {
+    return NextResponse.json(
+      { success: false, error: "REDIS_URL is not set" },
+      { status: 500 }
+    )
+  }
+
   const jobIds = await Promise.all(
-    jobs.map((job) => addJob(queueId, job.name, job.data ?? {}, job.opts))
+    jobs.map((job) =>
+      addJob(queueId, job.name, job.data ?? {}, job.opts, redisUrl)
+    )
   )
 
   return NextResponse.json({ success: true, jobIds })

--- a/lib/actions/resolveIssue.ts
+++ b/lib/actions/resolveIssue.ts
@@ -1,7 +1,7 @@
 "use server"
 
 import { makeIssueReaderAdapter } from "@shared/adapters/github/IssueReaderAdapter"
-import { RedisStreamEventBusAdapter } from "@shared/adapters/ioredis/RedisStreamEventBusAdapter"
+import { EventBusAdapter } from "@shared/adapters/ioredis/EventBusAdapter"
 import { OpenAIAdapter } from "@shared/adapters/llm/OpenAIAdapter"
 import { makeSettingsReaderAdapter } from "@shared/adapters/neo4j/repositories/SettingsReaderAdapter"
 import { resolveIssue } from "@shared/usecases/workflows/resolveIssue"
@@ -66,9 +66,7 @@ export async function resolveIssueAction(
   // Step 3: Execute the use case
   // =================================================
   const redisUrl = process.env.REDIS_URL
-  const eventBus = redisUrl
-    ? new RedisStreamEventBusAdapter(redisUrl)
-    : undefined
+  const eventBus = redisUrl ? new EventBusAdapter(redisUrl) : undefined
   const result = await resolveIssue(
     {
       auth: authAdapter,

--- a/lib/actions/resolveIssue.ts
+++ b/lib/actions/resolveIssue.ts
@@ -1,6 +1,7 @@
 "use server"
 
 import { makeIssueReaderAdapter } from "@shared/adapters/github/IssueReaderAdapter"
+import { RedisStreamEventBusAdapter } from "@shared/adapters/ioredis/RedisStreamEventBusAdapter"
 import { OpenAIAdapter } from "@shared/adapters/llm/OpenAIAdapter"
 import { makeSettingsReaderAdapter } from "@shared/adapters/neo4j/repositories/SettingsReaderAdapter"
 import { resolveIssue } from "@shared/usecases/workflows/resolveIssue"
@@ -64,12 +65,17 @@ export async function resolveIssueAction(
   // =================================================
   // Step 3: Execute the use case
   // =================================================
+  const redisUrl = process.env.REDIS_URL
+  const eventBus = redisUrl
+    ? new RedisStreamEventBusAdapter(redisUrl)
+    : undefined
   const result = await resolveIssue(
     {
       auth: authAdapter,
       settings: settingsAdapter,
       llm: llmAdapter,
       issueReader: issueReaderAdapter,
+      eventBus,
     },
     {
       repoFullName,

--- a/shared/src/adapters/ioredis/EventBusAdapter.ts
+++ b/shared/src/adapters/ioredis/EventBusAdapter.ts
@@ -7,7 +7,7 @@ import type { EventBusPort } from "@shared/ports/events/eventBus"
  *
  * Stream key convention: workflow:{workflowId}:events
  */
-export class RedisStreamEventBusAdapter implements EventBusPort {
+export class EventBusAdapter implements EventBusPort {
   constructor(
     private readonly redisUrl: string,
     private readonly maxLen = 10000

--- a/shared/src/adapters/ioredis/RedisStreamEventBusAdapter.ts
+++ b/shared/src/adapters/ioredis/RedisStreamEventBusAdapter.ts
@@ -8,13 +8,16 @@ import type { EventBusPort } from "@shared/ports/events/eventBus"
  * Stream key convention: workflow:{workflowId}:events
  */
 export class RedisStreamEventBusAdapter implements EventBusPort {
-  constructor(private readonly maxLen = 10000) {}
+  constructor(
+    private readonly redisUrl: string,
+    private readonly maxLen = 10000
+  ) {}
   private streamKeyFor(workflowId: string) {
     return `workflow:${workflowId}:events`
   }
 
   async publish(workflowId: string, event: WorkflowEvent): Promise<void> {
-    const client = getRedisConnection()
+    const client = getRedisConnection(this.redisUrl)
 
     await client.xadd(
       this.streamKeyFor(workflowId),

--- a/shared/src/adapters/ioredis/RedisStreamEventBusAdapter.ts
+++ b/shared/src/adapters/ioredis/RedisStreamEventBusAdapter.ts
@@ -1,6 +1,6 @@
+import { getRedisConnection } from "@shared/adapters/ioredis/client"
 import type { WorkflowEvent } from "@shared/entities/events/WorkflowEvent"
 import type { EventBusPort } from "@shared/ports/events/eventBus"
-import { getRedisConnection } from "@shared/services/redis/ioredis"
 
 /**
  * Redis Streams implementation of the EventBusPort.

--- a/shared/src/adapters/ioredis/client.ts
+++ b/shared/src/adapters/ioredis/client.ts
@@ -16,6 +16,3 @@ export function getRedisConnection(): IORedis {
   connection = new IORedis(redisUrl)
   return connection
 }
-
-// TODO: This file should probably be in /src/adapters/redis/ioredis.ts
-// To follow clean architecture principles

--- a/shared/src/adapters/redis/RedisStreamEventBusAdapter.ts
+++ b/shared/src/adapters/redis/RedisStreamEventBusAdapter.ts
@@ -24,4 +24,3 @@ export class RedisStreamEventBusAdapter implements EventBusPort {
     )
   }
 }
-

--- a/shared/src/adapters/redis/RedisStreamEventBusAdapter.ts
+++ b/shared/src/adapters/redis/RedisStreamEventBusAdapter.ts
@@ -1,0 +1,27 @@
+import type { WorkflowEvent } from "@shared/entities/events/WorkflowEvent"
+import type { EventBusPort } from "@shared/ports/events/eventBus"
+import { getRedisConnection } from "@shared/services/redis/ioredis"
+
+/**
+ * Redis Streams implementation of the EventBusPort.
+ *
+ * Stream key convention: workflow:{workflowId}:events
+ */
+export class RedisStreamEventBusAdapter implements EventBusPort {
+  private streamKeyFor(workflowId: string) {
+    return `workflow:${workflowId}:events`
+  }
+
+  async publish(workflowId: string, event: WorkflowEvent): Promise<void> {
+    const client = getRedisConnection()
+
+    // XADD <key> * field value [field value ...]
+    await client.xadd(
+      this.streamKeyFor(workflowId),
+      "*",
+      "event",
+      JSON.stringify(event)
+    )
+  }
+}
+

--- a/shared/src/entities/events/WorkflowEvent.ts
+++ b/shared/src/entities/events/WorkflowEvent.ts
@@ -23,4 +23,3 @@ export interface WorkflowEvent {
    */
   metadata?: Record<string, unknown>
 }
-

--- a/shared/src/entities/events/WorkflowEvent.ts
+++ b/shared/src/entities/events/WorkflowEvent.ts
@@ -1,0 +1,26 @@
+/**
+ * Minimal workflow event representation for cross-layer communication.
+ * Avoids leaking domain internals; safe to persist/stream.
+ */
+export type WorkflowEventType =
+  | "workflow.started"
+  | "workflow.completed"
+  | "workflow.error"
+  | "status"
+  | "issue.fetched"
+  | "llm.started"
+  | "llm.completed"
+
+export interface WorkflowEvent {
+  type: WorkflowEventType
+  timestamp: string // ISO timestamp for transport-agnostic ordering
+  /**
+   * Human-readable content describing the event, when applicable.
+   */
+  content?: string
+  /**
+   * Optional structured metadata, small and serializable.
+   */
+  metadata?: Record<string, unknown>
+}
+

--- a/shared/src/ports/events/eventBus.ts
+++ b/shared/src/ports/events/eventBus.ts
@@ -11,4 +11,3 @@ export interface EventBusPort {
    */
   publish(workflowId: string, event: WorkflowEvent): Promise<void>
 }
-

--- a/shared/src/ports/events/eventBus.ts
+++ b/shared/src/ports/events/eventBus.ts
@@ -1,0 +1,14 @@
+import type { WorkflowEvent } from "@shared/entities/events/WorkflowEvent"
+
+/**
+ * Port for emitting workflow events to an event bus.
+ *
+ * Clean-architecture note: this abstracts the transport (Redis Streams, etc.).
+ */
+export interface EventBusPort {
+  /**
+   * Publish a workflow event to the event stream for the given workflowId.
+   */
+  publish(workflowId: string, event: WorkflowEvent): Promise<void>
+}
+

--- a/shared/src/ports/events/publisher.ts
+++ b/shared/src/ports/events/publisher.ts
@@ -1,0 +1,55 @@
+import type {
+  WorkflowEvent,
+  WorkflowEventType,
+} from "@shared/entities/events/WorkflowEvent"
+import type { EventBusPort } from "@shared/ports/events/eventBus"
+
+type Metadata = Record<string, unknown> | undefined
+
+export function createWorkflowEventPublisher(
+  eventBus?: EventBusPort,
+  workflowId?: string
+) {
+  const safePublish = (
+    type: WorkflowEventType,
+    content?: string,
+    metadata?: Metadata
+  ) => {
+    if (!eventBus || !workflowId) return
+    const event: WorkflowEvent = {
+      type,
+      timestamp: new Date().toISOString(),
+      content,
+      metadata,
+    }
+    void eventBus.publish(workflowId, event).catch(() => {})
+  }
+
+  return {
+    emit: safePublish,
+    workflow: {
+      started: (content: string, metadata?: Metadata) =>
+        safePublish("workflow.started", content, metadata),
+      completed: (content?: string, metadata?: Metadata) =>
+        safePublish("workflow.completed", content, metadata),
+      error: (content: string, metadata?: Metadata) =>
+        safePublish("workflow.error", content, metadata),
+    },
+    status: (content: string, metadata?: Metadata) =>
+      safePublish("status", content, metadata),
+    issue: {
+      fetched: (content?: string, metadata?: Metadata) =>
+        safePublish("issue.fetched", content, metadata),
+    },
+    llm: {
+      started: (content?: string, metadata?: Metadata) =>
+        safePublish("llm.started", content, metadata),
+      completed: (content?: string, metadata?: Metadata) =>
+        safePublish("llm.completed", content, metadata),
+    },
+  } as const
+}
+
+export type WorkflowEventPublisher = ReturnType<
+  typeof createWorkflowEventPublisher
+>

--- a/shared/src/services/job.ts
+++ b/shared/src/services/job.ts
@@ -1,6 +1,5 @@
+import { getQueue } from "@shared/services/queue"
 import { JobsOptions } from "bullmq"
-
-import { getQueue } from "@/shared/src/services/queue"
 
 /**
  * Enqueue a job onto a specific queue with a specific job name.
@@ -15,9 +14,10 @@ export async function addJob<T extends Record<string, unknown>>(
   queueName: string,
   jobName: string,
   data: T,
-  opts: JobsOptions = {}
+  opts: JobsOptions = {},
+  redisUrl: string
 ): Promise<string | undefined> {
-  const queue = getQueue(queueName)
+  const queue = getQueue(queueName, redisUrl)
   const job = await queue.add(jobName, data, opts)
   return job.id
 }

--- a/shared/src/services/queue.ts
+++ b/shared/src/services/queue.ts
@@ -1,13 +1,13 @@
+import { getRedisConnection } from "@shared/adapters/ioredis/client"
 import { Queue } from "bullmq"
 
-import { getRedisConnection } from "@/shared/src/services/redis/ioredis"
+const queuesByKey = new Map<string, Queue>()
+export function getQueue(name: string, redisUrl: string): Queue {
+  const key = `${name}::${redisUrl}`
+  if (queuesByKey.has(key)) return queuesByKey.get(key) as Queue
 
-const queues = new Map<string, Queue>()
-export function getQueue(name: string): Queue {
-  if (queues.has(name)) return queues.get(name) as Queue
-
-  const queue = new Queue(name, { connection: getRedisConnection() })
-  queues.set(name, queue)
+  const queue = new Queue(name, { connection: getRedisConnection(redisUrl) })
+  queuesByKey.set(key, queue)
 
   return queue
 }

--- a/shared/src/usecases/workflows/resolveIssue.ts
+++ b/shared/src/usecases/workflows/resolveIssue.ts
@@ -1,10 +1,10 @@
-import { Issue } from "@shared/entities/Issue"
 import type { WorkflowEvent } from "@shared/entities/events/WorkflowEvent"
+import { Issue } from "@shared/entities/Issue"
 import { err, ok, type Result } from "@shared/entities/result"
 import type { AuthReaderPort } from "@shared/ports/auth/reader"
+import type { EventBusPort } from "@shared/ports/events/eventBus"
 import type { IssueReaderPort } from "@shared/ports/github/issue.reader"
 import type { LLMPort } from "@shared/ports/llm"
-import type { EventBusPort } from "@shared/ports/events/eventBus"
 import type { SettingsReaderPort } from "@shared/ports/repositories/settings.reader"
 
 /**
@@ -257,4 +257,3 @@ export async function resolveIssue(
     return err("UNKNOWN")
   }
 }
-

--- a/shared/src/usecases/workflows/resolveIssue.ts
+++ b/shared/src/usecases/workflows/resolveIssue.ts
@@ -1,8 +1,10 @@
 import { Issue } from "@shared/entities/Issue"
+import type { WorkflowEvent } from "@shared/entities/events/WorkflowEvent"
 import { err, ok, type Result } from "@shared/entities/result"
 import type { AuthReaderPort } from "@shared/ports/auth/reader"
 import type { IssueReaderPort } from "@shared/ports/github/issue.reader"
 import type { LLMPort } from "@shared/ports/llm"
+import type { EventBusPort } from "@shared/ports/events/eventBus"
 import type { SettingsReaderPort } from "@shared/ports/repositories/settings.reader"
 
 /**
@@ -17,6 +19,8 @@ export interface ResolveIssueParams {
   model?: string
   /** Optional max tokens for LLM response */
   maxTokens?: number
+  /** Optional workflow id for emitting events */
+  workflowId?: string
 }
 
 /**
@@ -80,18 +84,40 @@ export async function resolveIssue(
     settings: SettingsReaderPort
     llm: LLMPort | ((apiKey: string) => LLMPort)
     issueReader: IssueReaderPort | ((token: string) => IssueReaderPort)
+    eventBus?: EventBusPort
   },
   params: ResolveIssueParams
 ): Promise<
   Result<ResolveIssueOk, ResolveIssueErrorCode, ResolveIssueErrorDetails>
 > {
-  const { auth, settings } = ports
+  const { auth, settings, eventBus } = ports
+
+  const publish = async (event: WorkflowEvent) => {
+    if (!eventBus || !params.workflowId) return
+    try {
+      await eventBus.publish(params.workflowId, event)
+    } catch {
+      // Deliberately swallow event bus errors to not affect core flow
+    }
+  }
+
   try {
     // =================================================
     // Step 1: Get login and token
     // =================================================
+    await publish({
+      type: "workflow.started",
+      timestamp: new Date().toISOString(),
+      content: `Resolving issue #${params.issueNumber} in ${params.repoFullName}`,
+    })
+
     const authResult = await auth.getAuth()
     if (!authResult.ok) {
+      await publish({
+        type: "workflow.error",
+        timestamp: new Date().toISOString(),
+        content: "Authentication required",
+      })
       return err("AUTH_REQUIRED")
     }
     const { user: login, token } = authResult.value
@@ -112,6 +138,15 @@ export async function resolveIssue(
     })
 
     if (!issueResult.ok) {
+      await publish({
+        type: "workflow.error",
+        timestamp: new Date().toISOString(),
+        content: "Failed to fetch issue",
+        metadata: {
+          repoFullName: params.repoFullName,
+          issueNumber: params.issueNumber,
+        },
+      })
       return err("ISSUE_FETCH_FAILED", {
         issueRef: {
           repoFullName: params.repoFullName,
@@ -122,7 +157,19 @@ export async function resolveIssue(
 
     const issue = Issue.fromDetails(issueResult.value)
 
+    await publish({
+      type: "issue.fetched",
+      timestamp: new Date().toISOString(),
+      content: `Fetched issue #${issue.ref.number}`,
+      metadata: { state: issue.state },
+    })
+
     if (!issue.isResolvable) {
+      await publish({
+        type: "workflow.error",
+        timestamp: new Date().toISOString(),
+        content: "Issue is not open/resolvable",
+      })
       return err("ISSUE_NOT_OPEN", { issue, issueRef: issue.ref })
     }
 
@@ -131,6 +178,11 @@ export async function resolveIssue(
     // =================================================
     const apiKeyResult = await settings.getOpenAIKey(login.githubLogin)
     if (!apiKeyResult.ok || !apiKeyResult.value) {
+      await publish({
+        type: "workflow.error",
+        timestamp: new Date().toISOString(),
+        content: "Missing OpenAI API key",
+      })
       return err("MISSING_API_KEY")
     }
     const apiKey = apiKeyResult.value
@@ -148,6 +200,12 @@ export async function resolveIssue(
     const userMessage = `Please analyze and provide a solution for this GitHub issue:\n\n${issue.summary}\n\nRepository: ${params.repoFullName}`
 
     try {
+      await publish({
+        type: "llm.started",
+        timestamp: new Date().toISOString(),
+        content: "Requesting completion from LLM",
+      })
+
       const llmResult = await llmPort.createCompletion({
         system: RESOLUTION_SYSTEM_PROMPT,
         messages: [{ role: "user", content: userMessage }],
@@ -156,8 +214,25 @@ export async function resolveIssue(
       })
 
       if (!llmResult.ok) {
+        await publish({
+          type: "workflow.error",
+          timestamp: new Date().toISOString(),
+          content: "LLM returned an error",
+        })
         return err("LLM_ERROR", { issueRef: issue.ref })
       }
+
+      await publish({
+        type: "llm.completed",
+        timestamp: new Date().toISOString(),
+        content: "LLM completed successfully",
+      })
+
+      await publish({
+        type: "workflow.completed",
+        timestamp: new Date().toISOString(),
+        content: "ResolveIssue workflow completed",
+      })
 
       return ok({
         issue,
@@ -165,10 +240,21 @@ export async function resolveIssue(
       })
     } catch {
       // Intentionally do not surface upstream error details to avoid leaking sensitive info
+      await publish({
+        type: "workflow.error",
+        timestamp: new Date().toISOString(),
+        content: "LLM call failed",
+      })
       return err("LLM_ERROR", { issueRef: issue.ref })
     }
   } catch {
     // Fallback unknown error; do not leak raw error messages
+    await publish({
+      type: "workflow.error",
+      timestamp: new Date().toISOString(),
+      content: "Unknown error occurred",
+    })
     return err("UNKNOWN")
   }
 }
+


### PR DESCRIPTION
Summary
- Added a clean architecture EventBusPort to abstract event publishing
- Implemented RedisStreamEventBusAdapter that uses Redis Streams (XADD) with stream key convention workflow:{workflowId}:events
- Created a minimal WorkflowEvent entity with common event types
- Updated shared resolveIssue use case to optionally publish workflow run events when a workflowId and eventBus are provided

Details
- Events emitted: workflow.started, issue.fetched, llm.started, llm.completed, workflow.completed, workflow.error
- Emission is non-intrusive: any event bus error is swallowed to avoid impacting the core business flow
- No changes required to existing consumers; the event bus is injected through ports to keep boundaries clear

How to use
- Construct a RedisStreamEventBusAdapter and inject it via ports as eventBus
- Provide a workflowId in ResolveIssueParams. When both are present, events will be appended to Redis Stream workflow:{workflowId}:events

Notes
- Uses existing shared Redis connection setup (ioredis). Honors REDIS_URL
- Kept changes small, focused, and isolated to shared for portability and testability

Checks
- TypeScript and ESLint checks pass (pnpm run lint:tsc, pnpm run lint:eslint).

Closes #1202

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Live workflow activity updates with event-based telemetry (start, completion, status, issue fetched, and LLM phases).
  - Richer, structured error signals surfaced during workflows.
  - Optional integration with a scalable event bus for real-time streaming (supports Redis Streams).
- Bug Fixes
  - None.
- Chores
  - Minor cleanup of obsolete comments in Redis client code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->