### PR TITLE
ESLint: Restrict process.env usage in shared code

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,10 +32,13 @@
   },
   "overrides": [
     {
-      "files": ["shared/src/**/*.{ts,tsx,js,jsx}", "shared/**/*.{ts,tsx,js,jsx}"],
+      "files": [
+        "shared/src/**/*.{ts,tsx,js,jsx}",
+        "shared/**/*.{ts,tsx,js,jsx}"
+      ],
       "rules": {
         "no-restricted-properties": [
-          "warn",
+          "warn", // Change to error after full migration
           {
             "object": "process",
             "property": "env",
@@ -50,4 +53,3 @@
     "ecmaVersion": "latest"
   }
 }
-

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,8 +30,24 @@
       }
     ]
   },
+  "overrides": [
+    {
+      "files": ["shared/src/**/*.{ts,tsx,js,jsx}", "shared/**/*.{ts,tsx,js,jsx}"],
+      "rules": {
+        "no-restricted-properties": [
+          "warn",
+          {
+            "object": "process",
+            "property": "env",
+            "message": "Do not access process.env from shared code. Pass required values from the app layer via function params or configuration."
+          }
+        ]
+      }
+    }
+  ],
   "parserOptions": {
     "sourceType": "module",
     "ecmaVersion": "latest"
   }
 }
+


### PR DESCRIPTION
Summary
- Add an ESLint override that warns when process.env is accessed from the shared package (shared/src/**). This enforces the convention that environment variables should only be read at the app layer (e.g., Next.js app) and never within shared code.

Details
- Introduced no-restricted-properties rule scoped to shared files:
  - Selector: process.env
  - Severity: warn
  - Message explains to pass values from the app layer via params/config instead of reading from process.env in shared.

Why warn, not error?
- The repository currently has a few references to process.env in shared. Using a warning avoids breaking existing workflows while still surfacing the anti-pattern and guiding migration. Once the codebase is refactored, we can easily bump this to an error severity.

Notes
- Lint command remains unchanged and passes. Editors will display warnings in shared files. If desired later, CI could be extended to lint all workspaces to ensure this rule is enforced during PR checks.

Closes #1209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a linting override that warns when shared code accesses environment variables (encourages passing values via parameters/config).
  * Applies to JS and TS files in shared code paths.
  * Rule is non-blocking (warnings only); comment notes plan to escalate to error after migration.

* **Note**
  * No user-facing changes in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->