### PR TITLE
Allow auto-resolve workflow to run on any branch

### DIFF
--- a/app/api/workflow/autoResolveIssue/route.ts
+++ b/app/api/workflow/autoResolveIssue/route.ts
@@ -11,7 +11,7 @@ import autoResolveIssue from "@/lib/workflows/autoResolveIssue"
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
-    const { issueNumber, repoFullName } =
+    const { issueNumber, repoFullName, branch } =
       AutoResolveIssueRequestSchema.parse(body)
 
     const apiKey = await getUserOpenAIApiKey()
@@ -41,6 +41,7 @@ export async function POST(request: NextRequest) {
           repository: repo,
           apiKey,
           jobId,
+          branch,
         })
       } catch (error) {
         console.error(error)
@@ -62,3 +63,4 @@ export async function POST(request: NextRequest) {
     )
   }
 }
+

--- a/components/issues/controllers/AutoResolveIssueController.tsx
+++ b/components/issues/controllers/AutoResolveIssueController.tsx
@@ -8,6 +8,7 @@ interface Props {
   onStart: () => void
   onComplete: () => void
   onError: () => void
+  branch?: string
 }
 
 export default function AutoResolveIssueController({
@@ -16,6 +17,7 @@ export default function AutoResolveIssueController({
   onStart,
   onComplete,
   onError,
+  branch,
 }: Props) {
   const execute = async () => {
     try {
@@ -23,7 +25,7 @@ export default function AutoResolveIssueController({
       const response = await fetch("/api/workflow/autoResolveIssue", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ issueNumber, repoFullName }),
+        body: JSON.stringify({ issueNumber, repoFullName, branch }),
       })
 
       if (!response.ok) {
@@ -53,3 +55,4 @@ export default function AutoResolveIssueController({
 
   return { execute }
 }
+

--- a/lib/schemas/api.ts
+++ b/lib/schemas/api.ts
@@ -82,4 +82,6 @@ export const ResolveRequestSchema = z.object({
 export const AutoResolveIssueRequestSchema = z.object({
   issueNumber: z.number(),
   repoFullName: z.string().min(1),
+  branch: z.string().min(1).optional(),
 })
+


### PR DESCRIPTION
Summary
- Adds the ability to launch the auto-resolve issue workflow on any branch, not just the default branch.

Key changes
- API schema: AutoResolveIssueRequestSchema now accepts an optional `branch` parameter.
- API route: /api/workflow/autoResolveIssue reads `branch` from the request body and passes it along to the workflow.
- Workflow: lib/workflows/autoResolveIssue.ts accepts an optional `branch` param. When provided, it uses that branch throughout the workflow; otherwise it falls back to generating a non-conflicting feature branch (previous behavior).
- Container setup: The containerized workspace is created and checked out on the provided branch so:
  - Code cloned/copied is on that branch
  - The agent operates within that branch
  - The directory tree presented to the agent reflects the branch content
- UI controller: AutoResolveIssueController supports an optional `branch` prop and forwards it to the API. This is backward compatible and does not change existing usage. It enables future UI updates (e.g., wiring in the BranchSelector) without further API changes.

Notes
- Commit protection against committing directly to the default branch remains enforced by the Commit tool; running on a non-default branch is recommended.
- No breaking changes: If `branch` is omitted, behavior is unchanged.

Validation
- Installed dependencies and ran repository checks (next lint, prettier --check, tsc --noEmit). Linting passed and TypeScript compiles without errors.

Closes #1097

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Auto Resolve Issue now supports specifying a target branch. If not provided, the app will choose or create a working branch as before.
  * UI accepts an optional branch input and passes it through to the workflow.

* Improvements
  * Clearer status updates indicate whether a provided branch is used or a working/default branch was selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->