### PR TITLE
Add emoji-based SVG favicon to Next.js app

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,6 +15,9 @@ export const metadata = {
   title: "Issue-to-PR: Automated GitHub Issue Resolution",
   description:
     "Automatically resolve your GitHub issues and create Pull Requests using AI.",
+  icons: {
+    icon: "/favicon.svg",
+  },
 }
 
 export default async function RootLayout({

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <rect width="100%" height="100%" fill="white"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="52">📝</text>
+</svg>
+


### PR DESCRIPTION
Summary
- Added a new SVG favicon using the 📝 emoji at public/favicon.svg.
- Updated the root Next.js app metadata in app/layout.tsx to serve /favicon.svg as the browser tab icon.

Details
- Created a minimal, scalable favicon as an SVG so it looks crisp at all sizes.
- Kept changes small and scoped to the main app.
- No breaking changes; existing functionality remains unchanged.

Implementation Notes
- We leverage Next.js Metadata to set icons via:
  
  export const metadata = {
    ...,
    icons: { icon: "/favicon.svg" },
  }

- SVG content centers the emoji and provides a white background to ensure proper visibility across themes.

Verification
- Run the app and check the browser tab; you should see the 📝 emoji favicon.
- ESLint and TypeScript checks pass (pnpm run lint, pnpm run lint:tsc).

Considerations
- Some older browsers might not support SVG favicons; if needed, we can retain app/favicon.ico as a fallback or generate PNG versions. Currently, the project still contains app/favicon.ico which may be requested by some user agents; our metadata now explicitly includes the SVG, which modern browsers will use.

Closes #1212

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a site icon (favicon) that appears in browser tabs, bookmarks, and shortcuts, improving brand recognition and visual consistency.
* **Style**
  * Updated app visuals to include an SVG favicon for crisper display across devices and high-DPI screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->