### PR TITLE
Add Repositories page links and expose in navigation

### DIFF
--- a/components/RepositoryList.tsx
+++ b/components/RepositoryList.tsx
@@ -26,12 +26,29 @@ export default async function RepositoryList({
     <ul className="space-y-4">
       {repositories.map((repo) => (
         <li key={repo.id} className="bg-white shadow rounded-lg p-4">
-          <Link
-            href={`/${username}/${repo.name}/issues`}
-            className="text-blue-600 hover:underline"
-          >
-            {repo.name}
-          </Link>
+          <div className="flex items-center justify-between flex-wrap gap-2">
+            <Link
+              href={`/${username}/${repo.name}/issues`}
+              className="text-blue-600 hover:underline font-medium"
+            >
+              {repo.name}
+            </Link>
+            <div className="flex items-center gap-4 text-sm">
+              <Link
+                href={`/${username}/${repo.name}/issues`}
+                className="text-stone-700 hover:underline"
+              >
+                Issues
+              </Link>
+              <span className="text-stone-300">|</span>
+              <Link
+                href={`/${username}/${repo.name}/pullRequests`}
+                className="text-stone-700 hover:underline"
+              >
+                Pull Requests
+              </Link>
+            </div>
+          </div>
         </li>
       ))}
       <Pagination>
@@ -51,3 +68,4 @@ export default async function RepositoryList({
     </ul>
   )
 }
+

--- a/components/layout/DynamicNavigation.tsx
+++ b/components/layout/DynamicNavigation.tsx
@@ -36,10 +36,13 @@ const landingNavItems = [
 
 // Shared navigation items for authenticated users
 const authenticatedNavItems = (
-  isAdmin: boolean
+  isAdmin: boolean,
+  username?: string
 ): Array<{ label: string; href: string }> => {
   const items = [
     { label: "Workflows", href: "/workflow-runs" },
+    // Repositories page is user-specific
+    ...(username ? [{ label: "Repositories", href: `/${username}` }] : []),
     { label: "Issues", href: "/issues" },
     { label: "Kanban", href: "/kanban" },
     { label: "Contribute", href: "/contribute" },
@@ -58,10 +61,12 @@ export default function DynamicNavigation({
   isAuthenticated,
   isAdmin,
   avatarUrl,
+  username,
 }: {
   isAuthenticated: boolean
   isAdmin: boolean
   avatarUrl?: string
+  username?: string
 }) {
   const pathname = usePathname()
   const searchParams = useSearchParams()
@@ -140,7 +145,7 @@ export default function DynamicNavigation({
   }
 
   if (isAuthenticated) {
-    const navItems = authenticatedNavItems(isAdmin)
+    const navItems = authenticatedNavItems(isAdmin, username)
 
     const handleSignOut = async () => {
       await signOut({ redirect: false })
@@ -227,3 +232,4 @@ export default function DynamicNavigation({
     </>
   )
 }
+

--- a/components/layout/Navigation.tsx
+++ b/components/layout/Navigation.tsx
@@ -50,9 +50,11 @@ export default async function Navigation() {
             isAuthenticated={!!session?.user}
             isAdmin={isAdmin}
             avatarUrl={avatarUrl}
+            username={githubUser?.login}
           />
         </div>
       </div>
     </HideOnScroll>
   )
 }
+


### PR DESCRIPTION
Summary
- Adds explicit Issues and Pull Requests links for each repository on the repositories page.
- Exposes a new “Repositories” entry in the authenticated dropdown menu that routes to /<username>, which lists all repositories the authenticated user has access to.

Details
- components/RepositoryList.tsx: Now renders inline links for Issues and Pull Requests per repository card while keeping existing pagination.
- components/layout/DynamicNavigation.tsx: Adds a dynamic "Repositories" menu item (only when username is available) and updates the authenticated navigation builder to accept the username.
- components/layout/Navigation.tsx: Passes the authenticated GitHub username to DynamicNavigation so the menu can link to /<username>.

Why
This implements the requested repositories page and makes it discoverable via the dynamic navigation dropdown. The page lists repos and gives quick access to each repo’s Issues and Pull Requests pages.

Notes
- The repositories page already existed at /[username]; this PR wires it into the nav with the correct dynamic path and improves the list UI with direct Issue/PR links.
- Lint and type checks pass via `pnpm run lint` and `pnpm run check:all` in the CI-like environment.

Closes #1222