### PR TITLE
Update PR workflow to target default (main) branch

### DIFF
--- a/lib/agents/DependentPRAgent.ts
+++ b/lib/agents/DependentPRAgent.ts
@@ -19,7 +19,7 @@ Objective
 - Read reviewer comments, reviews, and code-review threads for a given PR.
 - Make small, targeted changes that address the feedback without altering the original intent.
 - Use the provided tools to search, read, edit, and verify code. Keep commits minimal and meaningful.
-- When finished, push your dependent branch and create a new dependent PR targeting the original PR's head branch using the provided tool.
+- When finished, push your dependent branch and create a new PR targeting the repository's default branch (for example, main) using the provided tool.
 
 Operating principles
 1) Understand the PR and feedback: skim the diff and read comments/reviews to determine concrete follow-ups.
@@ -31,7 +31,7 @@ Operating principles
 Required end state
 - All changes committed on the dependent branch.
 - Branch synchronized to remote.
-- A dependent PR has been created using the tool with the correct base (the original PR's head branch).
+- A PR has been created using the tool with the correct base (the repository's default branch).
 `
 
 export interface DependentPRAgentParams extends AgentConstructorParams {
@@ -39,7 +39,7 @@ export interface DependentPRAgentParams extends AgentConstructorParams {
   defaultBranch: string
   /** Full repository name (e.g. owner/repo) */
   repoFullName: string
-  /** The base ref name the dependent PR must target (usually the original PR's head) */
+  /** The base ref name the PR must target (the repository's default branch) */
   baseRefName: string
   /** GitHub token with push permissions (for SyncBranchTool) */
   sessionToken?: string

--- a/lib/workflows/createDependentPR.ts
+++ b/lib/workflows/createDependentPR.ts
@@ -183,7 +183,7 @@ export async function createDependentPRWorkflow({
       env,
       defaultBranch: repo.default_branch,
       repoFullName,
-      baseRefName: headRef,
+      baseRefName: repo.default_branch,
       sessionToken: sessionToken || undefined,
       jobId: workflowId,
     })
@@ -228,7 +228,7 @@ export async function createDependentPRWorkflow({
 
     const message = `
 # Goal
-Implement a follow-up patch that addresses reviewer comments and discussion on PR #${pullNumber}. Work directly on branch '${dependentBranch}' which is branched off '${headRef}'. When done, push this branch to origin using the sync tool, then create a dependent PR targeting base '${headRef}' using the create_dependent_pull_request tool.
+Implement a follow-up patch that addresses reviewer comments and discussion on PR #${pullNumber}. Work directly on branch '${dependentBranch}' which is branched off '${headRef}'. When done, push this branch to origin using the sync tool, then create a new PR targeting the repository's default branch ('${repo.default_branch}') using the create_dependent_pull_request tool.
 
 # Repository
 ${repoFullName}
@@ -253,7 +253,7 @@ ${formattedReviewThreads ? `# Review Line Comments\n${formattedReviewThreads}\n`
 - Use meaningful commit messages.
 - Run repo checks (type-check/lint) via the provided tools before finishing.
 - When finished, push branch '${dependentBranch}' to GitHub using the sync tool.
-- Finally, create a dependent PR with base '${headRef}' using the create_dependent_pull_request tool. Choose a clear title and provide a detailed description of the changes you made in response to the reviews.
+- Finally, create a PR with base '${repo.default_branch}' using the create_dependent_pull_request tool. Choose a clear title and provide a detailed description of the changes you made in response to the reviews.
 `
 
     await agent.addInput({ role: "user", type: "message", content: message })


### PR DESCRIPTION
Summary
This change updates the dependent PR workflow so that follow-up pull requests created in response to review feedback are based against the repository's default branch (e.g., main), rather than the original PR's head branch.

What changed
- lib/workflows/createDependentPR.ts
  - Passes repo.default_branch as the baseRefName for the PR creation tool
  - Updates the workflow instructions shown to the agent to explicitly create the new PR against the default branch
- lib/agents/DependentPRAgent.ts
  - Updates the agent system prompt to reflect the new behavior (open PRs targeting the default branch)
  - Clarifies the baseRefName parameter JSDoc

Why
Previously, follow-up PRs were created with the base set to the original PR’s head branch, effectively making them dependent on the first PR. Per the issue request, these follow-ups should be separate PRs against main (or the default branch), not stacked onto the previous PR.

Notes
- No API surface changes; only behavior and guidance to the agent/workflow changed.
- Lint/TS checks were run locally via pnpm run check:all and passed with no TypeScript errors; ESLint produced only warnings in unrelated files.



Closes #1235

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - PRs are now created against the repository’s default branch by default, improving clarity and consistency.
- Refactor
  - Updated workflow logic to target the default branch when creating PRs; other steps remain unchanged.
  - Revised user-facing prompts to refer to creating a “new PR” instead of a “dependent PR.”
- Documentation
  - Clarified public-facing descriptions to state that PRs must target the repository’s default branch.
  - Updated in-app messaging to reflect the new default-branch targeting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->