### PR TITLE
Webhook HMAC over raw bytes; safer routing; Dockerode cleanup

### DIFF
--- a/lib/docker.ts
+++ b/lib/docker.ts
@@ -81,7 +81,7 @@ export async function startContainer({
 
   // 2. Build environment variable flags: -e "KEY=value"
   const envFlags = Object.entries(env).map(
-    ([key, value]) => `-e \"${key}=${value.replace(/"/g, '\\\\"')}\"`
+    ([key, value]) => `-e \"${key}=${value.replace(/"/g, '\\\"')}\"`
   )
 
   // 3. Build label flags: --label key=value
@@ -226,7 +226,22 @@ export async function execInContainerWithDockerode({
 
 export async function stopAndRemoveContainer(name: string): Promise<void> {
   try {
-    await execPromise(`docker rm -f ${name}`)
+    const docker = new Docker({ socketPath: "/var/run/docker.sock" })
+    const container = docker.getContainer(name)
+
+    // Inspect state and stop if running
+    try {
+      const info = await container.inspect()
+      if (info.State?.Running) {
+        await container.stop()
+        console.log(`Stopped container: ${name}`)
+      }
+    } catch (error) {
+      console.warn(`Warning inspecting/stopping container ${name}:`, error)
+    }
+
+    await container.remove({ force: true })
+    console.log(`Removed container: ${name}`)
   } catch (e) {
     console.warn(`[WARNING] Failed to stop/remove container ${name}:`, e)
   }
@@ -271,21 +286,25 @@ export async function listRunningContainers(): Promise<RunningContainer[]> {
 export async function listContainersByLabels(
   labels: Record<string, string>
 ): Promise<string[]> {
-  const filters: string[] = []
-  for (const [key, value] of Object.entries(labels)) {
-    if (value !== undefined && value !== null) {
-      filters.push(`--filter \"label=${key}=${value}\"`)
-    }
-  }
-  const cmd = ["docker ps -a", ...filters, "--format '{{.Names}}'"].join(" ")
-
   try {
-    const { stdout } = await execPromise(cmd)
-    return stdout
-      .trim()
-      .split("\n")
-      .map((s) => s.trim())
+    const docker = new Docker({ socketPath: "/var/run/docker.sock" })
+
+    const labelFilters = Object.entries(labels)
+      .filter(([, v]) => v != null && String(v).trim().length > 0)
+      .map(([k, v]) => `${k}=${v}`)
+
+    const containers = await docker.listContainers({
+      all: true,
+      filters: { label: labelFilters },
+    })
+
+    const names = containers
+      .flatMap((c) => c.Names ?? [])
+      .map((n) => n.replace(/^\//, ""))
       .filter(Boolean)
+
+    // Deduplicate
+    return [...new Set(names)]
   } catch (error) {
     console.error("[ERROR] Failed to list containers by labels:", error)
     return []
@@ -448,3 +467,4 @@ export async function getContainerGitInfo(
     diff,
   }
 }
+


### PR DESCRIPTION
Summary
This follow-up addresses review feedback from PR #1244 around webhook security and Docker cleanup while keeping the original intent intact.

What changed
- Webhook HMAC verification
  - Compute the signature over the raw request bytes (Buffer) instead of a JSON string to avoid encoding discrepancies.
  - Compare raw digest bytes using crypto.timingSafeEqual for constant‑time comparison.
  - Read the body via req.arrayBuffer() first, verify, then JSON.parse only after verification.
  - Guard missing x-github-event header and return 400 with a clear error.
  - Wrap routeWebhookHandler call in try/catch to prevent unhandled rejections in the fire‑and‑forget path.
  - Pass installation id to runWithInstallationId as a string explicitly.

- Docker utilities
  - stopAndRemoveContainer now uses Dockerode: inspects/stops if running and removes with force for robustness; logs are clearer.
  - listContainersByLabels now uses Dockerode filters API instead of shelling out to docker ps, eliminating command-injection risk and improving reliability. It also:
    - ignores empty label values,
    - normalizes and deduplicates container names.

Rationale / how this addresses feedback
- The HMAC raw-bytes verification aligns with GitHub’s recommendation and eliminates potential mismatches due to JSON serialization/whitespace differences (as noted in review).
- Adding explicit header checks and exception handling makes the webhook handler more resilient and easier to diagnose.
- Moving container cleanup/listing to Dockerode follows the guidance to avoid constructing shell command strings from label values, removing an injection surface.

Scope
- No changes to overall webhook behavior or routing logic; only hardening and error handling improvements.
- No broader refactors applied (e.g., zod validation/router extraction) to keep this follow‑up minimal and focused.

Testing
- Type checks (tsc) and lint (ESLint) pass locally.
- Manual reasoning: signature verification now uses the exact bytes GitHub signs, then safely parses JSON after verification.

Notes
- There is a pre-existing ESLint warning in lib/workflows/autoResolveIssue.ts unrelated to this change (unused var). This follow-up does not alter that logic.

If anything else is desired from the earlier review (e.g., further Dockerode adoption for container start or Zod-based request validation), I can add those in a separate, scoped PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - More reliable GitHub webhook validation with clear HTTP status responses for invalid/missing data.
  - Correct handling of environment variables containing quotes to prevent container start issues.
  - Safer container stop/remove flow with graceful handling of non-running or missing containers.
  - More accurate container listing by labels.

- Refactor
  - Streamlined webhook processing to verify signatures before parsing payloads, improving security and stability.
  - Unified container management via Docker API for consistency and resilience.
  - Improved logging and standardized success/error responses for easier monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->