### PR TITLE
Streamlined use case for fetching github issue

### DIFF
--- a/app/[username]/[repo]/issues/[issueId]/page.tsx
+++ b/app/[username]/[repo]/issues/[issueId]/page.tsx
@@ -6,7 +6,7 @@ import IssueDetailsWrapper from "@/components/issues/IssueDetailsWrapper"
 import IssueWorkflowRuns from "@/components/issues/IssueWorkflowRuns"
 import TableSkeleton from "@/components/layout/TableSkeleton"
 import { Button } from "@/components/ui/button"
-import { getIssue } from "@/lib/github/issues"
+import { getIssue } from "@/lib/fetch/github/issues"
 import { listWorkflowRuns } from "@/lib/neo4j/services/workflow"
 
 interface Props {
@@ -22,10 +22,7 @@ export default async function IssueDetailsPage({ params }: Props) {
   const repoFullName = `${username}/${repo}`
   const issueNumber = Number.parseInt(issueId, 10)
 
-  const result = await getIssue({
-    fullName: repoFullName,
-    issueNumber,
-  })
+  const result = await getIssue(repoFullName, issueNumber)
 
   if (result.type === "not_found") {
     return (

--- a/lib/fetch/github/issues.ts
+++ b/lib/fetch/github/issues.ts
@@ -1,0 +1,72 @@
+"use server"
+
+import { makeIssueReaderAdapter } from "@shared/adapters/github/IssueReaderAdapter"
+import {
+  makeAccessTokenProviderFrom,
+  makeSessionProvider,
+} from "@shared/providers/auth"
+import { makeOctokitProvider } from "@shared/providers/clients"
+import { makeGetIssueUseCase } from "@shared/usecases/getIssue"
+
+import { auth } from "@/auth"
+import type { GetIssueResult } from "@/lib/types/github"
+
+export const getIssue = async (
+  repoFullName: string,
+  issueNumber: number
+): Promise<GetIssueResult> => {
+  try {
+    // Boundary: obtain session from NextAuth on the server
+    const sessionProvider = makeSessionProvider(() => auth())
+    const accessTokenProvider = makeAccessTokenProviderFrom(
+      sessionProvider,
+      (s) => s?.token?.access_token as unknown as string | null | undefined
+    )
+
+    // Provider: Octokit (lazy), not directly used here but ready for composition
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const _octokitProvider = makeOctokitProvider(accessTokenProvider)
+
+    // Adapter: IssueReader using GitHub OAuth user token via provider
+    const issueReader = makeIssueReaderAdapter(async () => ({
+      type: "oauth_user" as const,
+      token: await accessTokenProvider(),
+    }))
+
+    // Use case
+    const runGetIssue = makeGetIssueUseCase({ issueReader })
+    const res = await runGetIssue({ repoFullName, number: issueNumber })
+
+    if (!res.ok) {
+      switch (res.error) {
+        case "NotFound":
+        case "RepoNotFound":
+          return { type: "not_found" }
+        case "Forbidden":
+        case "AuthRequired":
+          return { type: "forbidden" }
+        default:
+          return { type: "other_error", error: res }
+      }
+    }
+
+    // Map IssueDetails -> GitHubIssue-like expected by UI
+    const d = res.value
+    const issue = {
+      number: d.number,
+      title: d.title ?? "",
+      body: d.body ?? "",
+      state: d.state === "OPEN" ? "open" : "closed",
+      html_url: d.url,
+      created_at: d.createdAt,
+      updated_at: d.updatedAt,
+      closed_at: d.closedAt ?? undefined,
+      user: d.authorLogin ? { login: d.authorLogin } : undefined,
+      repository: { full_name: d.repoFullName },
+    } as unknown as import("@/lib/types/github").GitHubIssue
+
+    return { type: "success", issue }
+  } catch (error) {
+    return { type: "other_error", error }
+  }
+}

--- a/shared/src/providers/auth.ts
+++ b/shared/src/providers/auth.ts
@@ -1,0 +1,37 @@
+import { lazy } from "../utils/lazy"
+
+export interface SessionWithTokenLike {
+  token?: { access_token?: string | null } | null
+}
+
+// Build a lazy session provider by injecting the boundary-specific session factory
+export const makeSessionProvider = <TSession>(
+  createSession: () => Promise<TSession | null>
+) => lazy(createSession)
+
+// Build a lazy access token provider from a session provider
+export const makeAccessTokenProvider = (
+  sessionProvider: () => Promise<SessionWithTokenLike | null>
+) =>
+  lazy(async () => {
+    const session = await sessionProvider()
+    const token = session?.token?.access_token ?? null
+    if (typeof token !== "string" || token.length === 0) {
+      throw new Error("No access token")
+    }
+    return token
+  })
+
+// More flexible variant where caller specifies how to extract token
+export const makeAccessTokenProviderFrom = <TSession>(
+  sessionProvider: () => Promise<TSession | null>,
+  getToken: (session: TSession | null) => string | null | undefined
+) =>
+  lazy(async () => {
+    const session = await sessionProvider()
+    const token = getToken(session)
+    if (typeof token !== "string" || token.length === 0) {
+      throw new Error("No access token")
+    }
+    return token
+  })

--- a/shared/src/providers/clients.ts
+++ b/shared/src/providers/clients.ts
@@ -1,0 +1,17 @@
+// packages/infra/providers/clientProviders.ts
+import { Octokit } from "@octokit/rest"
+import { lazy } from "@shared/utils/lazy"
+import OpenAI from "openai"
+
+export type OctokitProvider = () => Promise<Octokit>
+export type OpenAIProvider = () => Promise<OpenAI>
+
+export const makeOctokitProvider = (
+  tokenProvider: () => Promise<string>
+): OctokitProvider =>
+  lazy(async () => new Octokit({ auth: await tokenProvider() }))
+
+export const makeOpenAIProvider = (
+  apiKeyProvider: () => Promise<string>
+): OpenAIProvider =>
+  lazy(async () => new OpenAI({ apiKey: await apiKeyProvider() }))

--- a/shared/src/usecases/getIssue.ts
+++ b/shared/src/usecases/getIssue.ts
@@ -1,0 +1,25 @@
+import { err, type Result } from "@shared/entities/result"
+import type {
+  GetIssueErrors,
+  IssueDetails,
+  IssueReaderPort,
+  IssueRef,
+} from "@shared/ports/github/issue.reader"
+
+export type GetIssueInput = IssueRef
+export type GetIssueOutput = Result<IssueDetails, GetIssueErrors>
+
+export interface GetIssueDeps {
+  issueReader: IssueReaderPort
+}
+
+export function makeGetIssueUseCase({ issueReader }: GetIssueDeps) {
+  return async function getIssue(
+    input: GetIssueInput
+  ): Promise<GetIssueOutput> {
+    if (!input?.repoFullName || !input?.number) {
+      return err("RepoNotFound")
+    }
+    return await issueReader.getIssue(input)
+  }
+}

--- a/shared/src/utils/lazy.ts
+++ b/shared/src/utils/lazy.ts
@@ -1,0 +1,15 @@
+export const lazy = <T>(fn: () => Promise<T>) => {
+  console.log("start of lazy")
+  let done = false,
+    value: Promise<T>
+  return () => {
+    console.log("inside lazy", "done", done, "value", value)
+    if (!done) {
+      console.log("not done")
+      value = fn()
+      done = true
+    }
+    console.log("done", "value: ", value)
+    return value
+  }
+}


### PR DESCRIPTION
We try to separate a lot of concerns here in separate parts. Need a diagram to show why each part is separated. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Migrated issue loading to a new server-side fetching layer with standardized authentication and lazy-initialized API clients for improved reliability and responsiveness.
  - Streamlined internal use case for retrieving issue details, reducing duplication and improving consistency.

- Bug Fixes
  - More consistent handling of issue states and errors on the issue page, with clearer outcomes when an issue is not found or access is restricted.
  - Minor stability improvements when loading issue data under varying network/auth conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->