### PR TITLE
Refactor git branch checkout in dependent PR workflow with ports and error handling

### DIFF
--- a/lib/adapters/ContainerDockerodeAdapter.ts
+++ b/lib/adapters/ContainerDockerodeAdapter.ts
@@ -1,0 +1,49 @@
+import type { ContainerWritePort } from "@shared/ports/container/write"
+import {
+  execInContainerWithDockerode,
+  startContainer,
+  stopAndRemoveContainer,
+  writeFileInContainer,
+} from "@/lib/docker"
+
+export function makeDockerContainerAdapter(): ContainerWritePort {
+  return {
+    async executeCommand({ containerName, command, workingDirectory }) {
+      return await execInContainerWithDockerode({
+        name: containerName,
+        command,
+        cwd: workingDirectory,
+      })
+    },
+    async start(params) {
+      // Delegate to existing helper
+      return await startContainer({
+        image: params.image,
+        name: params.name,
+        user: params.user,
+        mounts: params.mounts,
+        workdir: params.workdir,
+        env: params.env,
+        labels: params.labels,
+        network: params.network,
+      })
+    },
+    async stop(containerName: string) {
+      // Stop+remove for now
+      await stopAndRemoveContainer(containerName)
+    },
+    async remove(containerName: string) {
+      await stopAndRemoveContainer(containerName)
+    },
+    async writeFile(params) {
+      return await writeFileInContainer({
+        name: params.containerName,
+        workdir: params.workdir,
+        relPath: params.relPath,
+        contents: params.contents,
+        makeDirs: params.makeDirs ?? true,
+      })
+    },
+  }
+}
+

--- a/shared/src/ports/git/errors.ts
+++ b/shared/src/ports/git/errors.ts
@@ -1,0 +1,19 @@
+export type GitCliError =
+  | "AuthFailed"
+  | "NetworkError"
+  | "RepositoryNotFound"
+  | "BranchNotFound"
+  | "CheckoutFailed"
+  | "FetchFailed"
+  | "RemoteNotSet"
+  | "InvalidRepository"
+  | "Unknown"
+
+export interface GitErrorDetails {
+  step: string
+  command?: string
+  exitCode?: number
+  stdout?: string
+  stderr?: string
+}
+

--- a/shared/src/usecases/git/ensureBranchCheckedOutInContainer.ts
+++ b/shared/src/usecases/git/ensureBranchCheckedOutInContainer.ts
@@ -1,0 +1,168 @@
+import type { ContainerWritePort } from "@shared/ports/container/write"
+import { err, ok, type Result } from "@shared/entities/result"
+import type { GitCliError, GitErrorDetails } from "@shared/ports/git/errors"
+
+interface Params {
+  containerName: string
+  /** Branch to ensure exists locally and is checked out */
+  headRef: string
+  /** Remote name to use (defaults to origin) */
+  remote?: string
+  /** Working directory inside container (defaults to /workspace) */
+  cwd?: string
+  /** If provided, set origin to this URL before fetching */
+  setRemoteUrl?: string
+}
+
+interface Output {
+  branch: string
+}
+
+/**
+ * Idempotently ensure a branch is available and checked out inside a containerized git repo.
+ * - Optionally sets the remote URL (useful for auth)
+ * - Fetches remote refs for the target branch
+ * - If the branch exists locally, checks it out and fast-forwards
+ * - Otherwise, creates the branch from the remote tracking ref
+ */
+export async function ensureBranchCheckedOutInContainer(
+  ports: { container: ContainerWritePort },
+  params: Params
+): Promise<Result<Output, GitCliError, GitErrorDetails>> {
+  const remote = params.remote ?? "origin"
+  const cwd = params.cwd ?? "/workspace"
+  const { containerName, headRef } = params
+
+  const run = async (command: string) =>
+    await ports.container.executeCommand({
+      containerName,
+      command,
+      workingDirectory: cwd,
+    })
+
+  // 1) Optionally set remote URL for auth
+  if (params.setRemoteUrl) {
+    const setRes = await run(
+      `git remote set-url ${remote} "${params.setRemoteUrl}"`
+    )
+    if (setRes.exitCode !== 0) {
+      return err("RemoteNotSet", {
+        step: "set-remote-url",
+        command: `git remote set-url ${remote} <redacted>`,
+        exitCode: setRes.exitCode,
+        stdout: setRes.stdout,
+        stderr: setRes.stderr,
+      })
+    }
+  }
+
+  // 2) Verify repository looks valid
+  const fsck = await run("git rev-parse --git-dir")
+  if (fsck.exitCode !== 0) {
+    return err("InvalidRepository", {
+      step: "verify-repo",
+      command: "git rev-parse --git-dir",
+      exitCode: fsck.exitCode,
+      stdout: fsck.stdout,
+      stderr: fsck.stderr,
+    })
+  }
+
+  // 3) Check remote branch existence first to give clearer error
+  const lsRemote = await run(`git ls-remote --heads ${remote} ${headRef}`)
+  if (lsRemote.exitCode !== 0) {
+    const stderr = (lsRemote.stderr || "").toLowerCase()
+    if (stderr.includes("auth") || stderr.includes("forbidden")) {
+      return err("AuthFailed", {
+        step: "ls-remote",
+        command: `git ls-remote --heads ${remote} ${headRef}`,
+        exitCode: lsRemote.exitCode,
+        stdout: lsRemote.stdout,
+        stderr: lsRemote.stderr,
+      })
+    }
+    if (stderr.includes("not found") || stderr.includes("could not read")) {
+      return err("RepositoryNotFound", {
+        step: "ls-remote",
+        command: `git ls-remote --heads ${remote} ${headRef}`,
+        exitCode: lsRemote.exitCode,
+        stdout: lsRemote.stdout,
+        stderr: lsRemote.stderr,
+      })
+    }
+    // Generic network failure
+    return err("NetworkError", {
+      step: "ls-remote",
+      command: `git ls-remote --heads ${remote} ${headRef}`,
+      exitCode: lsRemote.exitCode,
+      stdout: lsRemote.stdout,
+      stderr: lsRemote.stderr,
+    })
+  }
+  const remoteHasBranch = (lsRemote.stdout || "").trim().length > 0
+  if (!remoteHasBranch) {
+    return err("BranchNotFound", {
+      step: "ls-remote",
+      command: `git ls-remote --heads ${remote} ${headRef}`,
+      exitCode: lsRemote.exitCode,
+      stdout: lsRemote.stdout,
+      stderr: lsRemote.stderr,
+    })
+  }
+
+  // 4) Fetch just the target branch
+  const fetchRes = await run(`git fetch ${remote} ${headRef}`)
+  if (fetchRes.exitCode !== 0) {
+    return err("FetchFailed", {
+      step: "fetch",
+      command: `git fetch ${remote} ${headRef}`,
+      exitCode: fetchRes.exitCode,
+      stdout: fetchRes.stdout,
+      stderr: fetchRes.stderr,
+    })
+  }
+
+  // 5) Check if local branch exists
+  const revParse = await run(`git rev-parse --verify ${headRef}`)
+  if (revParse.exitCode !== 0) {
+    // Create local branch from remote tracking
+    const coCreate = await run(`git checkout -b ${headRef} ${remote}/${headRef}`)
+    if (coCreate.exitCode !== 0) {
+      return err("CheckoutFailed", {
+        step: "checkout-create",
+        command: `git checkout -b ${headRef} ${remote}/${headRef}`,
+        exitCode: coCreate.exitCode,
+        stdout: coCreate.stdout,
+        stderr: coCreate.stderr,
+      })
+    }
+  } else {
+    // Checkout and fast-forward
+    const co = await run(`git checkout -q ${headRef}`)
+    if (co.exitCode !== 0) {
+      return err("CheckoutFailed", {
+        step: "checkout",
+        command: `git checkout -q ${headRef}`,
+        exitCode: co.exitCode,
+        stdout: co.stdout,
+        stderr: co.stderr,
+      })
+    }
+    const pull = await run(`git pull --ff-only ${remote} ${headRef}`)
+    if (pull.exitCode !== 0) {
+      return err("CheckoutFailed", {
+        step: "pull-ff-only",
+        command: `git pull --ff-only ${remote} ${headRef}`,
+        exitCode: pull.exitCode,
+        stdout: pull.stdout,
+        stderr: pull.stderr,
+      })
+    }
+  }
+
+  // 6) Return current branch for sanity
+  const br = await run("git rev-parse --abbrev-ref HEAD")
+  const currentBranch = br.exitCode === 0 ? br.stdout.trim() : headRef
+  return ok({ branch: currentBranch })
+}
+


### PR DESCRIPTION
Summary
- Replaced ad-hoc git CLI calls in createDependentPRWorkflow with a clean use case that fetches and checks out the PR head branch inside the container.
- Introduced a Dockerode-backed container adapter implementing the shared ContainerWritePort, keeping environment-specific details out of use cases.
- Added shared Git CLI error types and a reusable use case to idempotently “ensure branch is checked out” with proper error mapping and structured Result return values.
- Emitted clearer status/error events (incl. stdout/stderr excerpts) to aid debugging when git operations fail.

Why
The linked run showed that the workflow likely failed to check out the PR head branch but we had no logs around git fetch/checkout. Git operations were scattered, mixed with concerns, and lacked structured error handling. This PR moves those steps behind ports/adapters and introduces a dedicated use case that:
- Sets remote URL for auth when provided
- Validates repository
- Checks that the remote branch exists (with clearer error messages)
- Fetches the branch
- Checks out the branch (creates from remote if missing) and fast-forwards
- Returns a typed Result with specific error categories

Changes
- shared/src/ports/git/errors.ts:
  - New GitCliError union and GitErrorDetails for structured error reporting.
- shared/src/usecases/git/ensureBranchCheckedOutInContainer.ts:
  - New use case that relies on ContainerWritePort to orchestrate git steps inside a container, returning Result with explicit error mapping (AuthFailed, BranchNotFound, FetchFailed, CheckoutFailed, etc.).
- lib/adapters/ContainerDockerodeAdapter.ts:
  - New adapter that implements ContainerWritePort by delegating to existing docker helpers (execInContainerWithDockerode, startContainer, stopAndRemoveContainer, writeFileInContainer).
- lib/workflows/createDependentPR.ts:
  - Use the new adapter + use case to fetch/checkout the PR head ref (and log any failures with step, stdout/stderr). This replaces the previous ad-hoc sequence of git commands.

Notes on error handling and where we previously fell short
- We were issuing git fetch/checkout without capturing stdout/stderr or mapping failures to actionable categories. Now we:
  - Check remote branch existence up front using `git ls-remote --heads`, mapping to BranchNotFound/AuthFailed/RepositoryNotFound/NetworkError.
  - Ensure a valid repo (`git rev-parse --git-dir`).
  - Return structured errors with the step name and command to simplify triage.
- We also trim/truncate logs in emitted events to avoid flooding the UI.

Follow-ups (can be separate issues)
- Provide a HostGit adapter implementing RepositoryReadPort/RepositoryWritePort so host-side git ops also use ports uniformly.
- Migrate remaining git helpers (`lib/git.ts`, `setupLocalRepository`) to use shared ports/use cases, ensuring consistent error mapping on the host side too.
- Add unit tests for the new use case covering error branches (auth, missing branch, fetch failure, checkout failure).

DX/Testing
- Type-checks pass (`pnpm run lint:tsc`).
- ESLint reports only warnings (import sort) and no errors.

This PR is intentionally scoped to the dependent PR workflow’s branch setup to minimize risk and to lay down the ports/use case structure for future refactors.

Closes #1254