### PR TITLE
Migrate autoResolveIssue to server action and remove API route

### DIFF
--- a/components/issues/controllers/AutoResolveIssueController.tsx
+++ b/components/issues/controllers/AutoResolveIssueController.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { autoResolveIssueAction } from "@/lib/actions/workflows/autoResolveIssue"
 import { toast } from "@/lib/hooks/use-toast"
 
 interface Props {
@@ -22,15 +23,14 @@ export default function AutoResolveIssueController({
   const execute = async () => {
     try {
       onStart()
-      const response = await fetch("/api/workflow/autoResolveIssue", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ issueNumber, repoFullName, branch }),
+      const result = await autoResolveIssueAction({
+        issueNumber,
+        repoFullName,
+        branch,
       })
 
-      if (!response.ok) {
-        const data = await response.json()
-        throw new Error(data.error || "Failed to run workflow")
+      if (result.status !== "success") {
+        throw new Error(result.message || "Failed to run workflow")
       }
 
       toast({

--- a/lib/actions/schemas.ts
+++ b/lib/actions/schemas.ts
@@ -144,3 +144,37 @@ export const createDependentPRResultSchema = z.discriminatedUnion("status", [
 export type CreateDependentPRResult = z.infer<
   typeof createDependentPRResultSchema
 >
+
+// =================================================
+// Auto Resolve Issue Action
+// =================================================
+
+export const autoResolveIssueRequestSchema = z.object({
+  repoFullName: z.string().min(1),
+  issueNumber: z.number().int().positive(),
+  branch: z.string().min(1).optional(),
+  jobId: z.string().optional(),
+})
+export type AutoResolveIssueRequest = z.infer<
+  typeof autoResolveIssueRequestSchema
+>
+
+const autoResolveIssueSuccessSchema = z.object({
+  status: z.literal("success"),
+  jobId: z.string().min(1),
+})
+
+const autoResolveIssueErrorSchema = z.object({
+  status: z.literal("error"),
+  code: z.enum(["INVALID_INPUT", "UNKNOWN"]),
+  message: z.string().min(1),
+})
+
+export const autoResolveIssueResultSchema = z.discriminatedUnion("status", [
+  autoResolveIssueSuccessSchema,
+  autoResolveIssueErrorSchema,
+])
+export type AutoResolveIssueResult = z.infer<
+  typeof autoResolveIssueResultSchema
+>
+

--- a/lib/actions/workflows/autoResolveIssue.ts
+++ b/lib/actions/workflows/autoResolveIssue.ts
@@ -1,34 +1,54 @@
-import { NextRequest, NextResponse } from "next/server"
+"use server"
+
 import { v4 as uuidv4 } from "uuid"
-import { z } from "zod"
 
 import { nextAuthReader } from "@/lib/adapters/auth/AuthReader"
 import { getRepoFromString } from "@/lib/github/content"
 import { getIssue } from "@/lib/github/issues"
 import { neo4jDs } from "@/lib/neo4j"
 import * as userRepo from "@/lib/neo4j/repositories/user"
-import { AutoResolveIssueRequestSchema } from "@/lib/schemas/api"
-import autoResolveIssue from "@/lib/workflows/autoResolveIssue"
+import { autoResolveIssue } from "@/lib/workflows/autoResolveIssue"
 import { EventBusAdapter } from "@/shared/src/adapters/ioredis/EventBusAdapter"
 import { makeSettingsReaderAdapter } from "@/shared/src/adapters/neo4j/repositories/SettingsReaderAdapter"
 
-export async function POST(request: NextRequest) {
+import {
+  type AutoResolveIssueRequest,
+  autoResolveIssueRequestSchema,
+  type AutoResolveIssueResult,
+} from "../schemas"
+
+// Overload for typed usage
+export async function autoResolveIssueAction(
+  input: AutoResolveIssueRequest
+): Promise<AutoResolveIssueResult>
+// Accept unknown at boundary and validate
+export async function autoResolveIssueAction(
+  input: unknown
+): Promise<AutoResolveIssueResult>
+export async function autoResolveIssueAction(
+  input: unknown
+): Promise<AutoResolveIssueResult> {
   try {
     // =================================================
     // Step 1: Parse inputs
     // =================================================
-    const body = await request.json()
-    const { issueNumber, repoFullName, branch } =
-      AutoResolveIssueRequestSchema.parse(body)
+    const parsed = autoResolveIssueRequestSchema.safeParse(input)
+    if (!parsed.success) {
+      return {
+        status: "error",
+        code: "INVALID_INPUT",
+        message: parsed.error.message,
+      }
+    }
+    const { issueNumber, repoFullName, branch, jobId } = parsed.data
 
-    const jobId = uuidv4()
+    const effectiveJobId = jobId || uuidv4()
 
     const redisUrl = process.env.REDIS_URL
 
     // =================================================
     // Step 2: Prepare adapters
     // =================================================
-
     const settingsAdapter = makeSettingsReaderAdapter({
       getSession: () => neo4jDs.getSession(),
       userRepo: userRepo,
@@ -37,8 +57,9 @@ export async function POST(request: NextRequest) {
     const authAdapter = nextAuthReader
 
     const eventBus = redisUrl ? new EventBusAdapter(redisUrl) : undefined
+
     // =================================================
-    // Step 3: Launch the background job
+    // Step 3: Launch the background job (fire-and-forget)
     // =================================================
 
     ;(async () => {
@@ -57,7 +78,7 @@ export async function POST(request: NextRequest) {
           {
             issue: issueResult.issue,
             repository: repo,
-            jobId,
+            jobId: effectiveJobId,
             branch,
           },
           {
@@ -67,7 +88,7 @@ export async function POST(request: NextRequest) {
           }
         )
       } catch (error) {
-        console.error(error)
+        console.error("[autoResolveIssueAction] background run failed:", error)
       }
     })()
 
@@ -75,18 +96,14 @@ export async function POST(request: NextRequest) {
     // Step 4: Return the job ID
     // =================================================
 
-    return NextResponse.json({ jobId })
+    return { status: "success", jobId: effectiveJobId }
   } catch (error) {
-    console.error("Error processing request:", error)
-    if (error instanceof z.ZodError) {
-      return NextResponse.json(
-        { error: "Invalid request data", details: error.errors },
-        { status: 400 }
-      )
+    console.error("[autoResolveIssueAction] Error:", error)
+    return {
+      status: "error",
+      code: "UNKNOWN",
+      message: "Failed to process request",
     }
-    return NextResponse.json(
-      { error: "Failed to process request" },
-      { status: 500 }
-    )
   }
 }
+


### PR DESCRIPTION
Summary
- Implemented autoResolveIssueAction as a server action under lib/actions/workflows.
- Added Zod schemas and strong typing overloads for request and response in lib/actions/schemas.ts.
- Updated UI controller (components/issues/controllers/AutoResolveIssueController.tsx) to call the server action instead of hitting the API route.
- Removed the legacy API route at app/api/workflow/autoResolveIssue/route.ts.

Details
- The new server action launches the same background workflow logic as the previous route handler and returns a jobId on success.
- Input is validated via Zod; on invalid input an error result is returned. The action otherwise follows a fire-and-forget pattern consistent with the previous route.
- No functional changes to the workflow behavior itself.

Why
- Aligns with the project’s move to server actions for POST requests.
- Provides better type safety via action-specific request/response schemas and overloads.

Testing & Linting
- Installed dependencies with pnpm.
- Ran lint and type-check to verify no errors.

Follow-ups
- Updated references in UI; no other subscribers were calling the old route beyond the controller that was changed.
- Optional: Update app/api/README.md to reflect the removal of the autoResolveIssue API endpoint if you want docs parity.

Closes #1265