### PR TITLE
Implement getRepository port and Octokit REST adapter in shared

### DIFF
--- a/shared/src/adapters/github/octokit/rest/repository.reader.ts
+++ b/shared/src/adapters/github/octokit/rest/repository.reader.ts
@@ -1,0 +1,63 @@
+import { Octokit } from "@octokit/rest"
+import { err, ok, type Result } from "@shared/entities/result"
+import type {
+  GetRepositoryErrors,
+  RepositoryDetails,
+  RepositoryReaderPort,
+  RepositoryRef,
+} from "@shared/ports/github/repository.reader"
+
+/**
+ * Factory to create a REST-based GitHub adapter implementing RepositoryReaderPort.
+ */
+export function makeRepositoryReaderAdapter(params: {
+  token: string
+}): RepositoryReaderPort {
+  const octokit = new Octokit({ auth: params.token })
+
+  async function getRepository(
+    ref: RepositoryRef
+  ): Promise<Result<RepositoryDetails, GetRepositoryErrors>> {
+    const [owner, repo] = ref.repoFullName.split("/")
+    if (!owner || !repo) return err("RepoNotFound")
+
+    try {
+      const { data } = await octokit.repos.get({ owner, repo })
+
+      const visibility = (data.visibility || (data.private ? "private" : "public")).toUpperCase() as
+        | "PUBLIC"
+        | "PRIVATE"
+        | "INTERNAL"
+
+      const details: RepositoryDetails = {
+        repoFullName: ref.repoFullName,
+        owner: data.owner?.login ?? owner,
+        name: data.name ?? repo,
+        description: data.description ?? null,
+        defaultBranch: data.default_branch ?? "main",
+        visibility,
+        url: data.html_url ?? `https://github.com/${owner}/${repo}`,
+        cloneUrl: data.clone_url ?? `https://github.com/${owner}/${repo}.git`,
+      }
+
+      return ok(details)
+    } catch (e: unknown) {
+      if (typeof e !== "object" || e === null) return err("Unknown")
+      const anyErr = e as { status?: number; message?: string }
+      if (anyErr.status === 404)
+        return err("RepoNotFound", { message: anyErr.message })
+      if (anyErr.status === 403)
+        return err("Forbidden", { message: anyErr.message })
+      if (anyErr.status === 401)
+        return err("AuthRequired", { message: anyErr.message })
+      if (anyErr.status === 429)
+        return err("RateLimited", { message: anyErr.message })
+      return err("Unknown", { message: anyErr.message })
+    }
+  }
+
+  return { getRepository }
+}
+
+export default makeRepositoryReaderAdapter
+

--- a/shared/src/ports/github/repository.reader.ts
+++ b/shared/src/ports/github/repository.reader.ts
@@ -1,0 +1,43 @@
+import { type Result } from "@shared/entities/result"
+
+export interface RepositoryRef {
+  /** Full repository name (owner/repo) */
+  repoFullName: string
+}
+
+export interface RepositoryDetails extends RepositoryRef {
+  /** Repository owner */
+  owner: string
+  /** Repository name */
+  name: string
+  /** Short description of the repository */
+  description: string | null
+  /** Default branch name */
+  defaultBranch: string
+  /** Repository visibility */
+  visibility: "PUBLIC" | "PRIVATE" | "INTERNAL"
+  /** HTML URL of the repository */
+  url: string
+  /** Clone URL (HTTPS) */
+  cloneUrl: string
+}
+
+export type GetRepositoryErrors =
+  | "AuthRequired"
+  | "RepoNotFound"
+  | "Forbidden"
+  | "RateLimited"
+  | "Unknown"
+
+/**
+ * Abstraction over GitHub for reading repository metadata.
+ */
+export interface RepositoryReaderPort {
+  /**
+   * Fetch basic repository metadata used across workflows.
+   */
+  getRepository(
+    ref: RepositoryRef
+  ): Promise<Result<RepositoryDetails, GetRepositoryErrors>>
+}
+


### PR DESCRIPTION
What
- Add a new GitHub repository reader port to the shared package.
- Implement an Octokit REST adapter to fetch repository metadata via GitHub's API.

Why
- Aligns with our clean architecture pattern (ports/adapters) already used for issues and PRs.
- Provides a provider-agnostic interface to retrieve key repository information needed across workflows.

Details
- New port: shared/src/ports/github/repository.reader.ts
  - Types: RepositoryRef, RepositoryDetails
  - Errors: GetRepositoryErrors (AuthRequired | RepoNotFound | Forbidden | RateLimited | Unknown)
  - Interface: RepositoryReaderPort with getRepository(ref)

- New adapter: shared/src/adapters/github/octokit/rest/repository.reader.ts
  - Factory: makeRepositoryReaderAdapter({ token })
  - Uses @octokit/rest repos.get to map to RepositoryDetails
  - Normalizes visibility to one of PUBLIC | PRIVATE | INTERNAL

Notes
- Matches code style and structure seen in existing IssueReader adapters.
- Pure addition; no changes to existing code paths.
- Lint/tsc/prettier checks run successfully via `pnpm run check:all`.

Closes #1143