### PR TITLE
Redesign auto-resolve workflow and streamline event emitting

### DIFF
--- a/shared/src/ports/agents/autoResolve.ts
+++ b/shared/src/ports/agents/autoResolve.ts
@@ -1,0 +1,27 @@
+/**
+ * Port for running the Auto-Resolve workflow agent.
+ *
+ * App layer should provide an implementation that encapsulates
+ * environment provisioning (containers/host), repository setup,
+ * and calls to concrete agent(s).
+ */
+export interface AutoResolveAgentPort<ResultT = unknown> {
+  /**
+   * Run the auto-resolve agent for a given issue.
+   *
+   * The implementation is responsible for any heavy lifting
+   * (setting up workspace, reading comments/tree, etc.).
+   */
+  run(params: {
+    apiKey: string
+    repoFullName: string
+    issueNumber: number
+    /** Optional working branch to use. */
+    branch?: string
+    /** Optional workflow id for correlating emitted events. */
+    workflowId?: string
+  }): Promise<ResultT>
+}
+
+export type { AutoResolveAgentPort as default }
+

--- a/shared/src/ports/events/publisher.ts
+++ b/shared/src/ports/events/publisher.ts
@@ -6,10 +6,41 @@ import type { EventBusPort } from "@shared/ports/events/eventBus"
 
 type Metadata = Record<string, unknown> | undefined
 
+export interface WorkflowEventPublisherShape {
+  emit: (
+    type: WorkflowEventType,
+    content?: string,
+    metadata?: Metadata
+  ) => void
+  workflow: {
+    started: (content: string, metadata?: Metadata) => void
+    completed: (content?: string, metadata?: Metadata) => void
+    error: (content: string, metadata?: Metadata) => void
+  }
+  status: (content: string, metadata?: Metadata) => void
+  issue: {
+    fetched: (content?: string, metadata?: Metadata) => void
+  }
+  llm: {
+    started: (content?: string, metadata?: Metadata) => void
+    completed: (content?: string, metadata?: Metadata) => void
+  }
+  /** Create a scoped publisher that automatically tags events with a stage. */
+  scoped: (stage: string) => WorkflowEventPublisherShape
+  /**
+   * Convenience helper to wrap a step. Emits status started/completed and
+   * captures failures as a failed status with an error message.
+   */
+  step: <T>(
+    name: string,
+    fn: (p: WorkflowEventPublisherShape) => Promise<T>
+  ) => Promise<T>
+}
+
 export function createWorkflowEventPublisher(
   eventBus?: EventBusPort,
   workflowId?: string
-) {
+): WorkflowEventPublisherShape {
   const safePublish = (
     type: WorkflowEventType,
     content?: string,
@@ -25,31 +56,56 @@ export function createWorkflowEventPublisher(
     void eventBus.publish(workflowId, event).catch(() => {})
   }
 
-  return {
-    emit: safePublish,
-    workflow: {
-      started: (content: string, metadata?: Metadata) =>
-        safePublish("workflow.started", content, metadata),
-      completed: (content?: string, metadata?: Metadata) =>
-        safePublish("workflow.completed", content, metadata),
-      error: (content: string, metadata?: Metadata) =>
-        safePublish("workflow.error", content, metadata),
-    },
-    status: (content: string, metadata?: Metadata) =>
-      safePublish("status", content, metadata),
-    issue: {
-      fetched: (content?: string, metadata?: Metadata) =>
-        safePublish("issue.fetched", content, metadata),
-    },
-    llm: {
-      started: (content?: string, metadata?: Metadata) =>
-        safePublish("llm.started", content, metadata),
-      completed: (content?: string, metadata?: Metadata) =>
-        safePublish("llm.completed", content, metadata),
-    },
-  } as const
+  const makeScoped = (stage?: string): WorkflowEventPublisherShape => {
+    const withStage = (meta?: Metadata) =>
+      stage ? { stage, ...(meta ?? {}) } : meta
+
+    return {
+      emit: (type, content, metadata) =>
+        safePublish(type, content, withStage(metadata)),
+      workflow: {
+        started: (content: string, metadata?: Metadata) =>
+          safePublish("workflow.started", content, withStage(metadata)),
+        completed: (content?: string, metadata?: Metadata) =>
+          safePublish("workflow.completed", content, withStage(metadata)),
+        error: (content: string, metadata?: Metadata) =>
+          safePublish("workflow.error", content, withStage(metadata)),
+      },
+      status: (content: string, metadata?: Metadata) =>
+        safePublish("status", content, withStage(metadata)),
+      issue: {
+        fetched: (content?: string, metadata?: Metadata) =>
+          safePublish("issue.fetched", content, withStage(metadata)),
+      },
+      llm: {
+        started: (content?: string, metadata?: Metadata) =>
+          safePublish("llm.started", content, withStage(metadata)),
+        completed: (content?: string, metadata?: Metadata) =>
+          safePublish("llm.completed", content, withStage(metadata)),
+      },
+      scoped: (nextStage: string) => makeScoped(nextStage),
+      step: async <T>(
+        name: string,
+        fn: (p: WorkflowEventPublisherShape) => Promise<T>
+      ) => {
+        const scopedPub = makeScoped(name)
+        scopedPub.status("started")
+        try {
+          const res = await fn(scopedPub)
+          scopedPub.status("completed")
+          return res
+        } catch (e) {
+          scopedPub.status("failed", {
+            error: e instanceof Error ? e.message : String(e),
+          })
+          throw e
+        }
+      },
+    }
+  }
+
+  return makeScoped()
 }
 
-export type WorkflowEventPublisher = ReturnType<
-  typeof createWorkflowEventPublisher
->
+export type WorkflowEventPublisher = WorkflowEventPublisherShape
+

--- a/shared/src/usecases/workflows/autoResolveIssue.ts
+++ b/shared/src/usecases/workflows/autoResolveIssue.ts
@@ -1,0 +1,89 @@
+import { err, ok, type Result } from "@shared/entities/result"
+import type { AuthReaderPort } from "@shared/ports/auth/reader"
+import type { EventBusPort } from "@shared/ports/events/eventBus"
+import { createWorkflowEventPublisher } from "@shared/ports/events/publisher"
+import type { SettingsReaderPort } from "@shared/ports/repositories/settings.reader"
+import type { AutoResolveAgentPort } from "@shared/ports/agents/autoResolve"
+
+export interface AutoResolveIssueParams {
+  /** Repository full name (e.g., "owner/repo") */
+  repoFullName: string
+  /** Issue number */
+  issueNumber: number
+  /** Optional explicit working branch */
+  branch?: string
+  /** Optional workflow id for emitting events */
+  workflowId?: string
+}
+
+export type AutoResolveIssueErrorCode =
+  | "AUTH_REQUIRED"
+  | "MISSING_API_KEY"
+  | "AGENT_ERROR"
+  | "UNKNOWN"
+
+export interface AutoResolveIssueOk<ResultT = unknown> {
+  /** Optional workflow id, useful for correlating events */
+  workflowId?: string
+  /** Result returned by the underlying agent */
+  result: ResultT
+}
+
+export async function autoResolveIssue<ResultT = unknown>(
+  ports: {
+    auth: AuthReaderPort
+    settings: SettingsReaderPort
+    agent: AutoResolveAgentPort<ResultT>
+    eventBus?: EventBusPort
+  },
+  params: AutoResolveIssueParams
+): Promise<
+  Result<AutoResolveIssueOk<ResultT>, AutoResolveIssueErrorCode, undefined>
+> {
+  const { auth, settings, eventBus, agent } = ports
+  const pub = createWorkflowEventPublisher(eventBus, params.workflowId)
+
+  try {
+    pub.workflow.started(
+      `Auto-resolve workflow for #${params.issueNumber} in ${params.repoFullName}`
+    )
+
+    // 1) Authentication
+    const authResult = await auth.getAuth()
+    if (!authResult.ok) {
+      pub.workflow.error("Authentication required")
+      return err("AUTH_REQUIRED")
+    }
+
+    const { user: login } = authResult.value
+
+    // 2) Resolve API key
+    const apiKeyResult = await settings.getOpenAIKey(login.githubLogin)
+    if (!apiKeyResult.ok || !apiKeyResult.value) {
+      pub.workflow.error("Missing OpenAI API key")
+      return err("MISSING_API_KEY")
+    }
+
+    // 3) Execute agent
+    try {
+      pub.status("Starting auto-resolve agent")
+      const result = await agent.run({
+        apiKey: apiKeyResult.value,
+        repoFullName: params.repoFullName,
+        issueNumber: params.issueNumber,
+        branch: params.branch,
+        workflowId: params.workflowId,
+      })
+
+      pub.workflow.completed("Auto-resolve workflow completed")
+      return ok({ workflowId: params.workflowId, result })
+    } catch {
+      pub.workflow.error("Auto-resolve agent failed")
+      return err("AGENT_ERROR")
+    }
+  } catch {
+    pub.workflow.error("Unknown error occurred in auto-resolve workflow")
+    return err("UNKNOWN")
+  }
+}
+


### PR DESCRIPTION
Summary
- Introduces a new shared use case for auto-resolving issues: shared/src/usecases/workflows/autoResolveIssue.ts
- Adds a dedicated AutoResolveAgentPort so the application layer can provide an implementation that handles environment setup, repository preparation, and agent execution.
- Enhances the shared workflow event publisher with scoped and step helpers to reduce repetitive event emission and improve readability.

Why
The previous implementation of the auto-resolve workflow lived in the app layer and mixed responsibilities (environment, branching, agent orchestration) while scattering event-creation calls. This redesign moves the orchestration contract to the shared use case layer and provides a cleaner abstraction for emitting events.

What changed
1) New use case: autoResolveIssue
- Handles authentication and API key lookup via injected ports
- Emits start/complete/error workflow events via the shared event publisher
- Delegates actual resolving to an injected AutoResolveAgentPort

2) New port: AutoResolveAgentPort
- A minimal interface that the app layer can implement with the existing PlanAndCodeAgent (and any future agents)
- Keeps shared logic decoupled from environment/container specifics

3) Event publisher ergonomics
- createWorkflowEventPublisher now supports:
  - scoped(stage: string): returns a publisher that automatically tags events with the given stage
  - step(name, fn): convenience wrapper that emits started/completed/failed status around an async step

Notes
- No breaking changes: existing publisher methods (workflow/status/issue/llm) remain unchanged.
- TypeScript and ESLint checks pass. I avoided running repository-wide Prettier write operations to keep the diff minimal.

Follow-ups (optional)
- Provide an app-layer adapter that implements AutoResolveAgentPort using the existing PlanAndCodeAgent and containerized workspace utilities, then switch lib/workflows/autoResolveIssue.ts to compose this shared use case.
- Gradually replace scattered createStatusEvent calls with the new event publisher scoped/step helpers for improved readability.

Closes #1142