### PR TITLE
Automate safe rolling restarts for workflow workers (graceful shutdown + Docker/Compose fixes)

### DIFF
--- a/apps/workers/workflow-workers/Dockerfile
+++ b/apps/workers/workflow-workers/Dockerfile
@@ -7,17 +7,17 @@ RUN npm install -g pnpm
 
 # Copy workspace manifests first for better caching
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
-COPY apps/workers/package.json apps/workers/
+COPY apps/workers/workflow-workers/package.json apps/workers/workflow-workers/
 
-# Install deps only for the worker (and its transitive deps)
-RUN pnpm install --frozen-lockfile --filter @issue-to-pr/worker...
+# Install deps only for the workflow worker (and its transitive deps)
+RUN pnpm install --frozen-lockfile --filter @issue-to-pr/workflow-workers...
 
 # Copy source
 # TODO: Investigate NOT copying the NextJS-related files
 COPY . .
 
-# Build the worker
-RUN pnpm --filter @issue-to-pr/worker build
+# Build the workflow worker
+RUN pnpm --filter @issue-to-pr/workflow-workers build
 
 # Production stage
 FROM node:22-alpine AS production
@@ -27,13 +27,16 @@ RUN npm install -g pnpm
 
 # Copy workspace manifests for production install
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
-COPY apps/workers/package.json apps/workers/
+COPY apps/workers/workflow-workers/package.json apps/workers/workflow-workers/
 
-# Install only production deps for the worker
-RUN pnpm install --frozen-lockfile --prod --filter @issue-to-pr/worker...
+# Install only production deps for the workflow worker
+RUN pnpm install --frozen-lockfile --prod --filter @issue-to-pr/workflow-workers...
 
-# Copy the built worker
-COPY --from=builder /app/apps/workers/dist ./apps/workers/dist
+# Copy the built workflow worker
+COPY --from=builder /app/apps/workers/workflow-workers/dist ./apps/workers/workflow-workers/dist
 
 ENV NODE_ENV=production
-CMD ["pnpm", "--filter", "@issue-to-pr/worker", "start"]
+# Send SIGTERM and allow time to shutdown gracefully
+STOPSIGNAL SIGTERM
+CMD ["pnpm", "--filter", "@issue-to-pr/workflow-workers", "start"]
+

--- a/apps/workers/workflow-workers/src/index.ts
+++ b/apps/workers/workflow-workers/src/index.ts
@@ -72,3 +72,54 @@ queueEvents.on("failed", ({ jobId, failedReason, prev }) => {
     `Job event ${jobId} has failed with reason ${failedReason}; previous status was ${prev}`
   )
 })
+
+// Graceful shutdown handling: stop taking new jobs, wait for in-flight jobs to finish, then exit.
+const SHUTDOWN_TIMEOUT_MS = Number(process.env.SHUTDOWN_TIMEOUT_MS ?? 30000)
+let shuttingDown = false
+
+async function gracefulShutdown(signal: NodeJS.Signals) {
+  if (shuttingDown) return
+  shuttingDown = true
+
+  console.log(`[worker] Received ${signal}. Beginning graceful shutdown…`)
+  const timeout = setTimeout(() => {
+    console.warn(
+      `[worker] Graceful shutdown timed out after ${SHUTDOWN_TIMEOUT_MS}ms. Forcing exit.`
+    )
+    // Ensure connections are dropped before forcing exit
+    try {
+      connection.disconnect()
+    } catch {}
+    process.exit(1)
+  }, SHUTDOWN_TIMEOUT_MS)
+
+  try {
+    // Close the worker: this stops fetching new jobs and waits for the current one to finish
+    await worker.close()
+    // Close queue event listener
+    await queueEvents.close()
+    // Close the redis connection
+    await connection.quit()
+    clearTimeout(timeout)
+    console.log("[worker] Shutdown complete. Exiting…")
+    process.exit(0)
+  } catch (err) {
+    console.error("[worker] Error during shutdown:", err)
+    clearTimeout(timeout)
+    process.exit(1)
+  }
+}
+
+process.on("SIGTERM", gracefulShutdown)
+process.on("SIGINT", gracefulShutdown)
+
+process.on("unhandledRejection", (reason) => {
+  console.error("[worker] Unhandled promise rejection:", reason)
+})
+
+process.on("uncaughtException", (err) => {
+  console.error("[worker] Uncaught exception:", err)
+  // Try to shutdown gracefully as well
+  void gracefulShutdown("SIGTERM")
+})
+

--- a/docker/compose/worker.yml
+++ b/docker/compose/worker.yml
@@ -1,16 +1,19 @@
 services:
   worker:
-    # TODO: The build process does not activate when there are new updates to the worker code
     build:
       context: ../../
-      dockerfile: apps/workers/Dockerfile
+      dockerfile: apps/workers/workflow-workers/Dockerfile
     environment:
       - NODE_ENV=production
       - REDIS_URL=redis://redis:6379
     env_file:
       - ${ENV_FILE}
+    # Give the worker time to finish in-flight jobs before stopping
+    stop_signal: SIGTERM
+    stop_grace_period: 60s
     restart: unless-stopped
     depends_on:
       - redis
     networks:
       - issue-to-pr-network
+


### PR DESCRIPTION
Summary
- Adds graceful shutdown to the workflow workers so CI/CD restarts don’t interrupt in-flight jobs
- Corrects the workflow-workers Dockerfile to build the correct package
- Updates docker-compose worker service to use the workflow-workers image and to stop gracefully (SIGTERM + stop_grace_period)

What changed
1) Graceful shutdown in apps/workers/workflow-workers/src/index.ts
   - Listens to SIGTERM/SIGINT
   - Calls worker.close() to stop fetching new jobs and wait for current job to finish
   - Closes QueueEvents and Redis connections
   - Supports configurable timeout via SHUTDOWN_TIMEOUT_MS (default 30s) and forces exit if exceeded
   - Handles unhandledRejection/uncaughtException with logging and graceful shutdown attempt

2) Dockerfile fixes for workflow-workers
   - apps/workers/workflow-workers/Dockerfile now targets the @issue-to-pr/workflow-workers package (previously was filtering @issue-to-pr/worker)
   - Uses STOPSIGNAL SIGTERM and runs pnpm start for the correct filter

3) Docker Compose worker service
   - docker/compose/worker.yml now points to apps/workers/workflow-workers/Dockerfile
   - Adds stop_signal: SIGTERM and stop_grace_period: 60s to give the worker time to finish jobs during container stop/redeploy

Why this solves the issue
- During CI/CD deploys (or container restarts), the process now receives SIGTERM and will:
  - stop taking new jobs immediately
  - finish the in-flight job safely
  - exit cleanly so a new instance can start
- Docker/Compose are aligned with the workflow-workers package so deploys rebuild the correct image and respect graceful stop semantics.

Notes for Operations
- If you are running the worker under systemd instead of Docker, systemctl restart sends SIGTERM by default. With this change, the worker exits gracefully as well. You can optionally export SHUTDOWN_TIMEOUT_MS to control the max wait before force-exit.
- If using docker compose, apply the updated compose/worker.yml and run:
  docker compose build worker && docker compose up -d worker
  to trigger a rebuild and a rolling-style restart of the worker container.

Validation
- Repository lint/check scripts pass (next lint, prettier --check, tsc --noEmit)
- No behavioral changes to job processing except improved lifecycle management.

Follow-ups (optional)
- Consider adding a healthcheck endpoint or liveness/readiness signals if you plan to run multiple replicas behind an orchestrator like ECS/Kubernetes for true rolling updates.
- Consider enabling multiple replicas and a queue-based canary/rolling strategy if needed for zero downtime scale out.

Closes #1289

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added graceful shutdown for the worker to reduce interrupted jobs and improve stability during restarts and deployments.
  * Improved handling of unexpected errors to prevent abrupt exits.

* **Chores**
  * Updated container build and runtime configuration to target the correct worker service.
  * Set SIGTERM as the stop signal with an extended grace period for orderly shutdowns.
  * Adjusted startup command and production artifacts to align with the updated worker service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->