### PR TITLE
Refactor summarize issue workflow to use shared use case

### DIFF
--- a/shared/src/usecases/workflows/summarizeIssue.ts
+++ b/shared/src/usecases/workflows/summarizeIssue.ts
@@ -1,0 +1,31 @@
+import type { LLMPort } from "@shared/ports/llm"
+
+const SYSTEM_PROMPT =
+  "You are an expert GitHub assistant. Given an issue title and body, produce a concise, actionable summary (2-4 sentences) highlighting the problem, scope, and desired outcome. Return only the summary text."
+
+export async function summarizeIssue(
+  llm: LLMPort,
+  params: { title?: string; body?: string },
+  options: { model?: string; maxTokens?: number } = {}
+): Promise<string> {
+  const { title, body } = params
+  const { model, maxTokens } = options
+
+  const userPrompt = `Title: ${title ?? "(none)"}\n\nBody:\n${body ?? "(empty)"}`
+
+  const result = await llm.createCompletion({
+    system: SYSTEM_PROMPT,
+    messages: [{ role: "user", content: userPrompt }],
+    model,
+    maxTokens,
+  })
+
+  if (!result.ok) {
+    throw new Error("LLM error")
+  }
+
+  return result.value.trim()
+}
+
+export default summarizeIssue
+

--- a/shared/src/usecases/workflows/summarizeIssue.ts
+++ b/shared/src/usecases/workflows/summarizeIssue.ts
@@ -21,11 +21,11 @@ export async function summarizeIssue(
   })
 
   if (!result.ok) {
-    throw new Error("LLM error")
+    const reason = "error" in result ? result.error : "unknown"
+    throw new Error(`LLM error: ${reason}`)
   }
 
   return result.value.trim()
 }
 
 export default summarizeIssue
-


### PR DESCRIPTION
Summary
- Introduces a shared use case for summarizing an issue: shared/src/usecases/workflows/summarizeIssue.ts
- Refactors the workflow worker orchestrator to act purely as an orchestrator, instantiating adapters and delegating to the shared use case via ports.

Details
- Created summarizeIssue use case that:
  - Accepts an LLMPort and inputs { title, body }
  - Calls createCompletion with a focused system prompt and user prompt
  - Returns the trimmed summary or throws on LLM errors
- Updated apps/workers/workflow-workers/src/orchestrators/summarizeIssue.ts to:
  - Instantiate OpenAIAdapter with OPENAI_API_KEY taken from env
  - Call summarizeIssue(llm, { title, body }, { model: "gpt-4o" })

Why
- This follows the ports-and-adapters architecture, keeping the orchestrator responsible only for wiring and delegating, while business logic lives in the shared layer.
- Aligns with existing shared use cases (e.g., generateIssueTitle) that wrap a single LLM completion.

Notes
- Lint/check commands were run locally (next lint, prettier --check, tsc --noEmit). The new/modified files conform to the repository’s TypeScript and ESLint setup.
- No external behavior change beyond centralizing the logic; the same prompts are used with the shared LLM port.


Closes #1291

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized issue summarization into a shared workflow, improving consistency across services.
  * Switched to adapter-based AI integration for better configurability and resilience.
  * Standardized prompts and error handling for more predictable summaries.
  * No changes to existing interfaces; end-user behavior remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->