### PR TITLE
Update worker TypeScript config for consistent import patterns

### DIFF
--- a/apps/workers/workflow-workers/tsconfig.json
+++ b/apps/workers/workflow-workers/tsconfig.json
@@ -1,16 +1,25 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    /* Make @/<...> resolve to this package's src like in Next.js apps */
+    "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["src/*"]
     },
+
+    /* Emit */
     "rootDir": "./src",
     "outDir": "./dist",
     "noEmit": false,
+
+    /* Modules */
     "target": "ES2020",
     "module": "ES2020",
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": false
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }
+


### PR DESCRIPTION
Problem
Workers were using imports that didn’t consistently match our Next.js style. In particular, using the @ alias wasn’t working reliably inside apps/workers/workflow-workers because the tsconfig there overrode root path mappings and didn’t set a local baseUrl. This made authoring @/… imports inconvenient and occasionally led to issues with ESM output not having .js extensions appended automatically.

What changed
- apps/workers/workflow-workers/tsconfig.json
  - Set compilerOptions.baseUrl to "." so that @/ resolves to this package’s src directory.
  - Add paths mapping for "@/*" → "src/*" to allow writing imports like `@/orchestrators/summarizeIssue`.
  - Keep moduleResolution as "bundler" and enable verbatimModuleSyntax and disallow importing TS extensions to align with modern ESM patterns.
  - No change to shared imports; continue importing the shared workspace as the package name (e.g. `shared/entities`), which remains clean and reliable at runtime.

Why this works
- Local worker imports can now be written as `@/...` without file extensions, mimicking our Next.js authoring experience.
- Our build already uses `tsc` + `tsc-esm-fix` + `tsc-alias`; these ensure that dist output gets proper .js extensions for local relative imports.
- Shared code remains imported via the `shared` workspace package (e.g. `shared/entities`), which avoids path alias rewrites into TS source and keeps runtime resolution robust.

Notes / Future
- If we later decide we want a true `@shared/...` authoring alias, we can add it, but it’s safer to point it to the built shared/dist or leave it to the package import (shared/...) to avoid runtime resolution to TS sources.

Repo checks
- Installed dependencies with pnpm.
- Ran `pnpm run check:all` (Next ESLint + Prettier check + root `tsc --noEmit`). No blocking errors were reported.

This PR keeps the change small and focused while aligning worker import ergonomics with the rest of the repo.

Closes #1294