### PR TITLE
workers: graceful shutdown polish and Dockerfile fixes for workflow-workers

### DIFF
--- a/apps/workers/workflow-workers/.env.example
+++ b/apps/workers/workflow-workers/.env.example
@@ -1,2 +1,4 @@
 REDIS_URL=
 OPENAI_API_KEY=
+# Optional: time allowed for graceful shutdown before force exit (in ms)
+# SHUTDOWN_TIMEOUT_MS=3600000

--- a/apps/workers/workflow-workers/Dockerfile
+++ b/apps/workers/workflow-workers/Dockerfile
@@ -2,8 +2,8 @@
 FROM node:22-alpine AS builder
 WORKDIR /app
 
-# Install pnpm
-RUN npm install -g pnpm
+# Enable Corepack and activate the pinned pnpm version from packageManager
+RUN corepack enable && corepack prepare pnpm@10.6.4 --activate
 
 # Copy workspace manifests first for better caching
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
@@ -16,27 +16,23 @@ RUN pnpm install --frozen-lockfile --filter @issue-to-pr/workflow-workers...
 # TODO: Investigate NOT copying the NextJS-related files
 COPY . .
 
-# Build the workflow worker
-RUN pnpm --filter @issue-to-pr/workflow-workers build
+# Build and prepare a production-ready deployable package for the workflow worker
+RUN pnpm --filter @issue-to-pr/workflow-workers build \
+  && pnpm --filter @issue-to-pr/workflow-workers deploy --prod /app/workflow-workers-deploy
 
 # Production stage
 FROM node:22-alpine AS production
 WORKDIR /app
 
-RUN npm install -g pnpm
+# Enable Corepack (not strictly needed at runtime since we copy a pruned deploy)
+RUN corepack enable && corepack prepare pnpm@10.6.4 --activate
 
-# Copy workspace manifests for production install
-COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
-COPY apps/workers/workflow-workers/package.json apps/workers/workflow-workers/
-
-# Install only production deps for the workflow worker
-RUN pnpm install --frozen-lockfile --prod --filter @issue-to-pr/workflow-workers...
-
-# Copy the built workflow worker
-COPY --from=builder /app/apps/workers/workflow-workers/dist ./apps/workers/workflow-workers/dist
+# Copy the prepared deploy (includes node_modules and built dist)
+COPY --from=builder /app/workflow-workers-deploy/ /app/
 
 ENV NODE_ENV=production
 # Send SIGTERM and allow time to shutdown gracefully
 STOPSIGNAL SIGTERM
-CMD ["pnpm", "--filter", "@issue-to-pr/workflow-workers", "start"]
+# Start directly with node; no pnpm needed at runtime
+CMD ["node", "dist/index.js"]
 

--- a/apps/workers/workflow-workers/Dockerfile
+++ b/apps/workers/workflow-workers/Dockerfile
@@ -8,6 +8,8 @@ RUN corepack enable && corepack prepare pnpm@10.6.4 --activate
 # Copy workspace manifests first for better caching
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY apps/workers/workflow-workers/package.json apps/workers/workflow-workers/
+# Include workspace dependency manifests needed by the worker (for proper filtered install and caching)
+COPY shared/package.json shared/
 
 # Install deps only for the workflow worker (and its transitive deps)
 RUN pnpm install --frozen-lockfile --filter @issue-to-pr/workflow-workers...
@@ -17,7 +19,7 @@ RUN pnpm install --frozen-lockfile --filter @issue-to-pr/workflow-workers...
 COPY . .
 
 # Build and prepare a production-ready deployable package for the workflow worker
-RUN pnpm --filter @issue-to-pr/workflow-workers build \
+RUN pnpm --filter @issue-to-pr/workflow-workers... build \
   && pnpm --filter @issue-to-pr/workflow-workers deploy --prod /app/workflow-workers-deploy
 
 # Production stage

--- a/apps/workers/workflow-workers/Dockerfile
+++ b/apps/workers/workflow-workers/Dockerfile
@@ -7,17 +7,17 @@ RUN npm install -g pnpm
 
 # Copy workspace manifests first for better caching
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
-COPY apps/workers/package.json apps/workers/
+COPY apps/workers/workflow-workers/package.json apps/workers/workflow-workers/
 
-# Install deps only for the worker (and its transitive deps)
-RUN pnpm install --frozen-lockfile --filter @issue-to-pr/worker...
+# Install deps only for the workflow worker (and its transitive deps)
+RUN pnpm install --frozen-lockfile --filter @issue-to-pr/workflow-workers...
 
 # Copy source
 # TODO: Investigate NOT copying the NextJS-related files
 COPY . .
 
-# Build the worker
-RUN pnpm --filter @issue-to-pr/worker build
+# Build the workflow worker
+RUN pnpm --filter @issue-to-pr/workflow-workers build
 
 # Production stage
 FROM node:22-alpine AS production
@@ -27,13 +27,16 @@ RUN npm install -g pnpm
 
 # Copy workspace manifests for production install
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
-COPY apps/workers/package.json apps/workers/
+COPY apps/workers/workflow-workers/package.json apps/workers/workflow-workers/
 
-# Install only production deps for the worker
-RUN pnpm install --frozen-lockfile --prod --filter @issue-to-pr/worker...
+# Install only production deps for the workflow worker
+RUN pnpm install --frozen-lockfile --prod --filter @issue-to-pr/workflow-workers...
 
-# Copy the built worker
-COPY --from=builder /app/apps/workers/dist ./apps/workers/dist
+# Copy the built workflow worker
+COPY --from=builder /app/apps/workers/workflow-workers/dist ./apps/workers/workflow-workers/dist
 
 ENV NODE_ENV=production
-CMD ["pnpm", "--filter", "@issue-to-pr/worker", "start"]
+# Send SIGTERM and allow time to shutdown gracefully
+STOPSIGNAL SIGTERM
+CMD ["pnpm", "--filter", "@issue-to-pr/workflow-workers", "start"]
+

--- a/apps/workers/workflow-workers/src/helper.ts
+++ b/apps/workers/workflow-workers/src/helper.ts
@@ -3,6 +3,7 @@ import IORedis from "ioredis"
 import path from "path"
 import { JOB_STATUS_CHANNEL, JobStatusUpdateSchema } from "shared/entities"
 import { fileURLToPath } from "url"
+import type { QueueEvents, Worker } from "bullmq"
 
 import { envSchema, type EnvVariables } from "./schemas"
 
@@ -49,3 +50,66 @@ export async function publishJobStatus(jobId: string, status: string) {
   const jobStatusUpdate = JobStatusUpdateSchema.parse({ jobId, status })
   await redis.publish(JOB_STATUS_CHANNEL, JSON.stringify(jobStatusUpdate))
 }
+
+// Register graceful shutdown handlers for the worker process.
+// Stops taking new jobs, waits for in-flight jobs to finish, then exits.
+// If the timeout elapses, forces exit(1) after disconnecting Redis.
+export function registerGracefulShutdown(opts: {
+  worker: Worker
+  queueEvents: QueueEvents
+  connection: IORedis
+  timeoutMs?: number
+}) {
+  const { worker, queueEvents, connection } = opts
+  const SHUTDOWN_TIMEOUT_MS =
+    opts.timeoutMs ?? Number(process.env.SHUTDOWN_TIMEOUT_MS ?? 3600000)
+
+  let shuttingDown = false
+
+  async function gracefulShutdown(signal: NodeJS.Signals) {
+    if (shuttingDown) return
+    shuttingDown = true
+
+    console.log(`[worker] Received ${signal}. Beginning graceful shutdown…`)
+    const timeout = setTimeout(() => {
+      console.warn(
+        `[worker] Graceful shutdown timed out after ${SHUTDOWN_TIMEOUT_MS}ms. Forcing exit.`
+      )
+      // Ensure connections are dropped before forcing exit (fire-and-forget)
+      try {
+        connection.disconnect()
+      } catch {}
+      process.exit(1)
+    }, SHUTDOWN_TIMEOUT_MS)
+
+    try {
+      // Close the worker: this stops fetching new jobs and waits for the current one to finish
+      await worker.close()
+      // Close queue event listener
+      await queueEvents.close()
+      // Close the redis connection
+      await connection.quit()
+      clearTimeout(timeout)
+      console.log("[worker] Shutdown complete. Exiting…")
+      process.exit(0)
+    } catch (err) {
+      console.error("[worker] Error during shutdown:", err)
+      clearTimeout(timeout)
+      process.exit(1)
+    }
+  }
+
+  process.on("SIGTERM", gracefulShutdown)
+  process.on("SIGINT", gracefulShutdown)
+
+  process.on("unhandledRejection", (reason) => {
+    console.error("[worker] Unhandled promise rejection:", reason)
+    void gracefulShutdown("SIGTERM")
+  })
+
+  process.on("uncaughtException", (err) => {
+    console.error("[worker] Uncaught exception:", err)
+    void gracefulShutdown("SIGTERM")
+  })
+}
+

--- a/apps/workers/workflow-workers/src/helper.ts
+++ b/apps/workers/workflow-workers/src/helper.ts
@@ -49,6 +49,8 @@ export async function publishJobStatus(jobId: string, status: string) {
   const redis = new IORedis(REDIS_URL)
   const jobStatusUpdate = JobStatusUpdateSchema.parse({ jobId, status })
   await redis.publish(JOB_STATUS_CHANNEL, JSON.stringify(jobStatusUpdate))
+  // Ensure we close the short-lived connection to avoid leaks
+  await redis.quit()
 }
 
 // Register graceful shutdown handlers for the worker process.

--- a/apps/workers/workflow-workers/src/index.ts
+++ b/apps/workers/workflow-workers/src/index.ts
@@ -72,3 +72,54 @@ queueEvents.on("failed", ({ jobId, failedReason, prev }) => {
     `Job event ${jobId} has failed with reason ${failedReason}; previous status was ${prev}`
   )
 })
+
+// Graceful shutdown handling: stop taking new jobs, wait for in-flight jobs to finish, then exit.
+const SHUTDOWN_TIMEOUT_MS = Number(process.env.SHUTDOWN_TIMEOUT_MS ?? 30000)
+let shuttingDown = false
+
+async function gracefulShutdown(signal: NodeJS.Signals) {
+  if (shuttingDown) return
+  shuttingDown = true
+
+  console.log(`[worker] Received ${signal}. Beginning graceful shutdown…`)
+  const timeout = setTimeout(() => {
+    console.warn(
+      `[worker] Graceful shutdown timed out after ${SHUTDOWN_TIMEOUT_MS}ms. Forcing exit.`
+    )
+    // Ensure connections are dropped before forcing exit
+    try {
+      connection.disconnect()
+    } catch {}
+    process.exit(1)
+  }, SHUTDOWN_TIMEOUT_MS)
+
+  try {
+    // Close the worker: this stops fetching new jobs and waits for the current one to finish
+    await worker.close()
+    // Close queue event listener
+    await queueEvents.close()
+    // Close the redis connection
+    await connection.quit()
+    clearTimeout(timeout)
+    console.log("[worker] Shutdown complete. Exiting…")
+    process.exit(0)
+  } catch (err) {
+    console.error("[worker] Error during shutdown:", err)
+    clearTimeout(timeout)
+    process.exit(1)
+  }
+}
+
+process.on("SIGTERM", gracefulShutdown)
+process.on("SIGINT", gracefulShutdown)
+
+process.on("unhandledRejection", (reason) => {
+  console.error("[worker] Unhandled promise rejection:", reason)
+})
+
+process.on("uncaughtException", (err) => {
+  console.error("[worker] Uncaught exception:", err)
+  // Try to shutdown gracefully as well
+  void gracefulShutdown("SIGTERM")
+})
+

--- a/docker/compose/worker.yml
+++ b/docker/compose/worker.yml
@@ -6,11 +6,12 @@ services:
     environment:
       - NODE_ENV=production
       - REDIS_URL=redis://redis:6379
+      - SHUTDOWN_TIMEOUT_MS=3600000
     env_file:
       - ${ENV_FILE}
     # Give the worker time to finish in-flight jobs before stopping
     stop_signal: SIGTERM
-    stop_grace_period: 60s
+    stop_grace_period: 1h
     restart: unless-stopped
     depends_on:
       - redis

--- a/docker/compose/worker.yml
+++ b/docker/compose/worker.yml
@@ -1,16 +1,19 @@
 services:
   worker:
-    # TODO: The build process does not activate when there are new updates to the worker code
     build:
       context: ../../
-      dockerfile: apps/workers/Dockerfile
+      dockerfile: apps/workers/workflow-workers/Dockerfile
     environment:
       - NODE_ENV=production
       - REDIS_URL=redis://redis:6379
     env_file:
       - ${ENV_FILE}
+    # Give the worker time to finish in-flight jobs before stopping
+    stop_signal: SIGTERM
+    stop_grace_period: 60s
     restart: unless-stopped
     depends_on:
       - redis
     networks:
       - issue-to-pr-network
+


### PR DESCRIPTION
Summary
Follow-up changes addressing review feedback on PR #1298 to make the workflow-workers container restart safely and predictably.

What changed
- Close Redis connection in publishJobStatus: Ensures the short‑lived IORedis client is cleanly closed to avoid connection leaks.
- Add SHUTDOWN_TIMEOUT_MS to .env.example: Documents the new, optional graceful shutdown timeout and its default intent.
- Dockerfile improvements for workflow-workers:
  - Include shared/package.json alongside the worker manifest during the initial copy so filtered installs resolve workspace dependencies (shared) correctly and benefit from layer caching.
  - Build transitive workspace dependencies by switching to pnpm --filter @issue-to-pr/workflow-workers... build (note the ellipsis), ensuring shared is built before deploy.
  - Keep the pruned deploy flow (pnpm deploy) and run with node dist/index.js at runtime.

Context/intent preserved
- Keeps the original goal intact: safe, graceful rolling restarts for workflow workers (SIGTERM-aware, long grace period, and no new jobs during shutdown).
- No behavioral changes to job handling other than ensuring resources are released and env is documented.

Verification
- Type checks (tsc) and Next lint pass locally via repo scripts.

Notes
- docker-compose already uses SIGTERM + stop_grace_period to allow in‑flight jobs to complete; this PR focuses on the small follow-ups requested in review.


Closes #1289