### PR TITLE
Show install prompt when GitHub App is missing from repo pages

### DIFF
--- a/app/[username]/[repo]/layout.tsx
+++ b/app/[username]/[repo]/layout.tsx
@@ -1,0 +1,55 @@
+import Link from "next/link"
+
+import { isAppInstalledForRepo } from "@/lib/github/install-check"
+
+interface LayoutProps {
+  children: React.ReactNode
+  params: {
+    username: string
+    repo: string
+  }
+}
+
+export default async function RepoLayout({ children, params }: LayoutProps) {
+  const { username, repo } = params
+
+  // Build GitHub App installation URL if available
+  const appSlug = process.env.NEXT_PUBLIC_GITHUB_APP_SLUG
+  const installUrl = appSlug
+    ? `https://github.com/apps/${appSlug}/installations/new`
+    : undefined
+
+  const installed = await isAppInstalledForRepo({ owner: username, repo })
+
+  if (!installed) {
+    return (
+      <main className="container mx-auto p-4">
+        <div className="mb-6 rounded-md border border-yellow-300 bg-yellow-50 p-4 text-yellow-900">
+          <h1 className="text-xl font-semibold mb-2">
+            Issue to PR GitHub App is not installed for {username}/{repo}
+          </h1>
+          <p className="mb-4">
+            To use Issue to PR features on this repository, install the GitHub App.
+          </p>
+          {installUrl ? (
+            <Link
+              href={installUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center rounded-md bg-stone-900 px-4 py-2 text-white hover:bg-stone-800"
+            >
+              Install Issue to PR on GitHub
+            </Link>
+          ) : (
+            <div className="text-red-700">
+              The GitHub App slug is not configured. Please set NEXT_PUBLIC_GITHUB_APP_SLUG.
+            </div>
+          )}
+        </div>
+      </main>
+    )
+  }
+
+  return <>{children}</>
+}
+

--- a/lib/github/install-check.ts
+++ b/lib/github/install-check.ts
@@ -1,0 +1,32 @@
+import { getInstallationFromRepo } from "./repos"
+
+/**
+ * Checks whether the Issue-to-PR GitHub App is installed for the given repository.
+ * Returns true when installed, false when not installed or when the check fails
+ * with a 404 from GitHub. Other errors are logged and treated as not installed
+ * to avoid breaking the UX.
+ */
+export async function isAppInstalledForRepo({
+  owner,
+  repo,
+}: {
+  owner: string
+  repo: string
+}): Promise<boolean> {
+  try {
+    await getInstallationFromRepo({ owner, repo })
+    return true
+  } catch (error: unknown) {
+    // Octokit errors expose a numeric `status` code
+    const status = (error as { status?: number })?.status
+    if (status === 404) {
+      return false
+    }
+    console.error(
+      `[github/install-check] Failed to determine installation for ${owner}/${repo}:`,
+      error
+    )
+    return false
+  }
+}
+


### PR DESCRIPTION
Summary
- Adds a repository-level layout that checks whether the Issue to PR GitHub App is installed for the current repo.
- If the app is not installed for the repo, the layout renders a prominent message with a CTA to install the app and hides the rest of the repo content. This matches the request to "just show a main message" when the app is missing.
- The CTA uses NEXT_PUBLIC_GITHUB_APP_SLUG to build the installation URL: https://github.com/apps/${appSlug}/installations/new.

Details
- New helper: lib/github/install-check.ts with isAppInstalledForRepo(). It uses GET /repos/{owner}/{repo}/installation via existing getInstallationFromRepo(). Returns false on 404 (not installed) and logs other errors.
- New layout: app/[username]/[repo]/layout.tsx wraps all repo subpages (issues, pull requests, settings, etc.).
  - Checks installation status server-side.
  - If missing, shows message and install button.
  - If env var is missing, shows a configuration hint instead of a broken link.

Why a layout?
- Keeps changes small and focused while applying consistently across all repo subpages.
- Avoids duplicating installation checks in each page (issues, pullRequests, settings).

Notes
- We considered deep-linking the install flow to preselect the current repo, but GitHub’s generic installations/new URL is reliable and was requested as the fallback.
- ESLint (next lint) passes. We avoided running Prettier/TypeScript checks that fail globally in the current repository setup.

How to test
1) Visit a repo path without the app installed, e.g. /youngchingjui/ai-breakfast/issues — you should see the install prompt only.
2) After installing the app for that repo, refresh the page — the normal repo content should render.

Env
Ensure NEXT_PUBLIC_GITHUB_APP_SLUG is set to the correct GitHub App slug (e.g., issue-to-pr-dev or issue-to-pr).

Closes #1259