### PR TITLE
remove cacheing for getRepo

### DIFF
--- a/lib/adapters/github/fetch/repository.reader.ts
+++ b/lib/adapters/github/fetch/repository.reader.ts
@@ -99,7 +99,7 @@ export function makeFetchRepositoryReaderAdapter(params: {
       const url = `https://api.github.com/repos/${owner}/${repo}`
       const res = await fetch(url, {
         headers: baseHeaders,
-        next: { revalidate: 60, tags: ["repo", repository.fullName] },
+        cache: "no-store",
       })
 
       if (!res.ok) {


### PR DESCRIPTION
There is no webhook to check for updates on `has_issues` setting on repository, so it's best to just not cache this data fetch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace Next.js revalidation tags with `cache: "no-store"` in `getRepo` to always fetch fresh repository details.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ef55ed0da894f28e268d6173d3a328352f1db85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repository data is now fetched fresh on every request to ensure you always see the most current information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->