### PR TITLE
Update dependent PR workflow: detailed PR-body updates (initiator, links, commits, comments)

### DIFF
--- a/lib/actions/workflows/createDependentPR.ts
+++ b/lib/actions/workflows/createDependentPR.ts
@@ -79,6 +79,7 @@ export async function createDependentPRAction(
         pullNumber,
         apiKey,
         jobId: effectiveJobId,
+        initiator: { type: "ui_button", actorLogin: login },
       })
     } catch (e) {
       console.error("[create-dependent-pr] Background run failed:", e)
@@ -87,3 +88,4 @@ export async function createDependentPRAction(
 
   return { status: "success", jobId: effectiveJobId }
 }
+

--- a/lib/agents/DependentPRAgent.ts
+++ b/lib/agents/DependentPRAgent.ts
@@ -38,8 +38,6 @@ export interface DependentPRAgentParams extends AgentConstructorParams {
   defaultBranch: string
   /** GitHub repository metadata */
   repository?: GitHubRepository
-  /** Issue number that the dependent PR should close (if any) */
-  issueNumber?: number
   /** GitHub token with push permissions (for SyncBranchTool) */
   sessionToken?: string
   jobId?: string
@@ -47,15 +45,7 @@ export interface DependentPRAgentParams extends AgentConstructorParams {
 
 export class DependentPRAgent extends ResponsesAPIAgent {
   constructor(params: DependentPRAgentParams) {
-    const {
-      env,
-      defaultBranch,
-      repository,
-      issueNumber,
-      sessionToken,
-      jobId,
-      ...base
-    } = params
+    const { env, defaultBranch, repository, sessionToken, jobId, ...base } = params
 
     super({ model: "gpt-5", ...base })
 

--- a/lib/github/pullRequests.ts
+++ b/lib/github/pullRequests.ts
@@ -6,6 +6,7 @@ import {
   PullRequest,
   PullRequestList,
   PullRequestReview,
+  PullRequestReviewComment,
 } from "@/lib/types/github"
 
 export async function getPullRequestOnBranch({
@@ -337,6 +338,30 @@ export async function getPullRequestReviews({
   )
 
   return reviewsResponse.data
+}
+
+export async function getPullRequestReviewComments({
+  repoFullName,
+  pullNumber,
+}: {
+  repoFullName: string
+  pullNumber: number
+}): Promise<PullRequestReviewComment[]> {
+  const octokit = await getOctokit()
+  const [owner, repo] = repoFullName.split("/")
+  if (!octokit) {
+    throw new Error("No octokit found")
+  }
+  const response = await withTiming(
+    `GitHub REST: pulls.listReviewComments ${repoFullName}#${pullNumber}`,
+    () =>
+      octokit.rest.pulls.listReviewComments({
+        owner,
+        repo,
+        pull_number: pullNumber,
+      })
+  )
+  return response.data
 }
 
 // Interface for the GraphQL response for PR reviews and comments


### PR DESCRIPTION
Summary
- Update the createDependentPR workflow to work on the existing PR branch and append a detailed update section to the PR body after the agent run.
- Provide human-auditable context: who initiated the run, direct links to the workflow run, branch and commit refs, and links to referenced comments.

What changed
- lib/workflows/createDependentPR.ts
  - Append a rich markdown update to the existing PR body including:
    - Initiator information (UI button/webhook/API) and actor when available
    - Link to the workflow run page using NEXT_PUBLIC_BASE_URL (if configured)
    - Starting and new head SHAs with GitHub links, plus branch link
    - Commits added during the run with links
    - Referenced comments with direct links (issue comments and code review comments)
    - A brief note on decisions and where to find detailed rationale (workflow log)
  - Capture starting head SHA before edits and compute new head SHA after pushing. Collect commits between the two for easy audit.
  - Continue to update the same PR (no new PRs are created).
- lib/github/pullRequests.ts
  - Add getPullRequestReviewComments (REST) to retrieve html_url for code review comments so we can link directly from the PR body.
  - Add updatePullRequestBody helper used by the workflow.
- lib/actions/workflows/createDependentPR.ts
  - Pass initiator information (UI button + actor) through to the workflow so it can be recorded in the PR update note.
- lib/agents/DependentPRAgent.ts
  - Remove unused parameter (issueNumber) to satisfy lint rules.

Why
- Addressed reviewer feedback to make the PR update comment concrete and auditable:
  - Show who initiated and how
  - Link to workflow run details
  - Show the exact commit the run executed on, and the new head
  - Link to the comments being addressed
  - Call out decision context (and where to find details)

Verification
- Ran eslint (next lint) locally and fixed issues flagged in this touch set.
- Type-checking may require workspace builds for the shared package; linting is clean for the modified files.

Notes
- The workflow links to the run details via NEXT_PUBLIC_BASE_URL if it is set in the environment. If not set, the PR update still includes the workflow ID.
- Behavior remains: no new PRs are created; updates are pushed to the existing PR’s head branch and the PR body is amended accordingly.

Closes #1414

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PR updates now track initiator information (UI button, webhook, or API).
  * Enhanced PR descriptions with detailed update notes including commit information, timestamps, comments, and initiator attribution.
  * Improved workflow to update existing PRs with comprehensive context.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->