### PR TITLE
Add TODO comments for technical debt and architecture improvements

### DIFF
--- a/__tests__/api/webhook/github/route.test.ts
+++ b/__tests__/api/webhook/github/route.test.ts
@@ -639,6 +639,7 @@ describe("POST /api/webhook/github", () => {
       expect(response.status).toBe(200)
     })
 
+    // TODO: the test here doesn't seem to match what we're actually doing. Maybe we need to review this.
     it("accepts issue_comment events without calling handlers", async () => {
       const payload = {
         action: "created",

--- a/lib/actions/workflows/createDependentPR.ts
+++ b/lib/actions/workflows/createDependentPR.ts
@@ -1,5 +1,10 @@
 "use server"
 
+// TODO: Migrate this server action to enqueue a worker job instead of directly
+// invoking the workflow. This will match the webhook pattern and use the new
+// DatabaseStorage port via the worker orchestrator. See the webhook handler
+// implementation for reference.
+
 import { v4 as uuidv4 } from "uuid"
 
 import { auth } from "@/auth"

--- a/shared/src/adapters/github/octokit/graphql/pullRequest.reader.ts
+++ b/shared/src/adapters/github/octokit/graphql/pullRequest.reader.ts
@@ -276,6 +276,15 @@ export function makeGitHubPRGraphQLAdapter(params: {
 export const makeGithubPRGraphQLAdapter = (token: string) =>
   makeGitHubPRGraphQLAdapter({ token })
 
+// TODO: I don't like how we inject the authProvider directly into this feature function.
+// To me, I would imagine that we have 1 object that handles the authentication, so that should receive the
+// auth provider on construction. Then, we use that object to call these specific functions.
+
+// TODO: I think we're mixing a lot of concerns here. We have the graphql query, the type shape, and also seemingly some data transformations.
+// I think it maybe makes sense to keep the query and the type shape together.
+// But perhaps we should wrap those queries in a method where we define the input and output shapes clearly with typescript.
+// And we have a separate portion that maps the raw data to our desired shapes.
+// This way, the wrapped queries can also define the shape of the variables too.
 export const getPullRequestMetaAndLinkedIssue = async (
   repoFullName: string,
   pullNumber: number,

--- a/shared/src/adapters/neo4j/types.ts
+++ b/shared/src/adapters/neo4j/types.ts
@@ -171,6 +171,8 @@ export const issueSchema = z.object({
 
 //--------Event Types--------
 
+// TODO: It seems that we mix "messages" with "events", but I think these concepts should be separated.
+// TODO: We're not really using llmResponseWithPlan anymore, I think we can start to remove this feature.
 const eventTypes = z.enum([
   "error",
   "llmResponse",

--- a/shared/src/lib/types/db/neo4j.ts
+++ b/shared/src/lib/types/db/neo4j.ts
@@ -140,6 +140,7 @@ export const messageEventSchema = z.union([
   ]),
 ])
 
+// TODO: We're mixing messages and events here. we should separate them into different concepts.
 export const anyEventSchema = z.discriminatedUnion("type", [
   errorEventSchema,
   llmResponseSchema,


### PR DESCRIPTION
## Summary
Adds standalone TODO comments to document technical debt and architecture improvement opportunities. These comments were separated from functional changes in PR #1473 to reduce its size and improve review focus.

## Changes
1. **Test review**: Flag test case that may not match actual implementation (`__tests__/api/webhook/github/route.test.ts:642`)
2. **Worker migration**: Document plan to migrate server action to worker pattern (`lib/actions/workflows/createDependentPR.ts`)
3. **Auth injection pattern**: Note concerns about direct auth provider injection into feature functions (`shared/src/adapters/github/octokit/graphql/pullRequest.reader.ts`)
4. **GraphQL architecture**: Highlight mixing of queries, type definitions, and data transformations (`shared/src/adapters/github/octokit/graphql/pullRequest.reader.ts`)
5. **Event/message separation**: Document need to separate event and message concepts (`shared/src/adapters/neo4j/types.ts`, `shared/src/lib/types/db/neo4j.ts`)
6. **Legacy code cleanup**: Mark deprecated `llmResponseWithPlan` feature for removal (`shared/src/adapters/neo4j/types.ts`)

## Why separate PR?
These TODOs make sense standalone and don't require the functional changes from PR #1473 to understand. Separating them:
- Reduces the size of PR #1473 for easier review
- Allows these documentation improvements to be merged independently
- Makes it easier to track and prioritize technical debt items

## Related
- Part of cleanup for PR #1473

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added function to retrieve pull request metadata and linked issues.

* **Tests**
  * Added test coverage for issue comment webhook events.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->