### PR TITLE
Add specification for @issuetopr mention behavior

### DIFF
--- a/docs/specs/issuetopr-mention-behavior.md
+++ b/docs/specs/issuetopr-mention-behavior.md
@@ -2,124 +2,179 @@
 
 Specifies how the app should respond when users mention @issuetopr in GitHub issues and pull requests.
 
-## Trigger Locations
+## Use Cases
 
-Users can mention @issuetopr in these places:
+Users mention @issuetopr expecting different things depending on context. The key principle is **scope matching**: the response should match where and how the user asked.
 
-| Location | GitHub Event | When Received |
-| --- | --- | --- |
-| Issue comment | `issue_comment` | Immediately on post |
-| PR comment | `issue_comment` | Immediately on post |
-| PR review (top-level) | `pull_request_review` | When review is submitted |
-| PR review comment (inline) | `pull_request_review_comment` | When review is submitted |
+### Quick Answer
 
-## The PR Review Deduplication Problem
+User wants information, not code changes.
 
-When a user writes a GitHub PR review, they may:
-1. Write inline comments on specific code lines (review comments)
-2. Write a top-level summary comment
-3. Submit with an overall verdict (approve/request changes/comment)
+> "@issuetopr why does this function return null?"
 
-**Critical behavior:** GitHub holds all inline comments in a "pending" state until the user clicks "Submit review". At submission time, GitHub fires webhooks for:
-- One `pull_request_review` event (for the review itself)
-- Multiple `pull_request_review_comment` events (one per inline comment)
+**Expected:** A reply explaining the code. No commits, no workflow.
 
-These webhooks arrive nearly simultaneously. If the user mentions @issuetopr in both the top-level review AND an inline comment, we would trigger duplicate workflows without deduplication.
+### Targeted Fix
 
-### Deduplication Strategy
+User points at specific code and asks for a fix.
 
-We group related webhook events using a **review correlation window**.
+> "@issuetopr fix this typo" (inline comment on a specific line)
 
-When we receive any PR review-related event:
-1. Extract the `pull_request_review_id` from the payload (present in both event types)
-2. Check if we've already processed a trigger for this review ID
-3. If yes, skip processing
-4. If no, mark this review ID as processed and continue
+**Expected:** Fix only that line or immediate area. Don't refactor the whole file.
 
-This ensures that even if a user mentions @issuetopr in both the top-level review and multiple inline comments, we only trigger one workflow.
+### Address Review Feedback
 
-### Implementation Notes
+User leaves review comments requesting changes.
 
-- The correlation window should be short (30-60 seconds) since GitHub sends these events together
-- Store processed review IDs in a short-lived cache (Redis or in-memory with TTL)
-- Include the review ID in workflow audit logs for debugging
+> "@issuetopr please address these comments"
 
-## Response Behavior
+**Expected:** Apply changes requested in the review comments. Consider all inline comments as related feedback.
 
-### What Should Happen
+### Broader PR Changes
 
-When @issuetopr is mentioned, the app should:
+User asks for something that affects the whole PR.
 
-1. **Acknowledge** - React with eyes emoji (where supported) to show we're processing
-2. **Respond** - Post a comment linking to the workflow run page
-3. **Execute** - Run the appropriate workflow based on context
+> "@issuetopr this PR needs tests"
+
+**Expected:** Add tests across the PR, not just one file.
+
+### Create PR from Issue
+
+User mentions @issuetopr in an issue with no linked PR.
+
+> "@issuetopr please fix this" (in an issue)
+
+**Expected:** Create a new PR that addresses the issue.
+
+### Clarification Needed
+
+User's intent is unclear.
+
+> "@issuetopr this doesn't look right"
+
+**Expected:** Ask what specifically should change before making assumptions.
+
+## Response Flow
+
+When @issuetopr is mentioned:
+
+1. **Acknowledge** - React with eyes emoji to show we're processing
+2. **Respond** - Post a comment (with workflow link if running one)
+3. **Execute** - Run the appropriate workflow, or just reply if no action needed
 4. **Report** - Update the user on completion or failure
 
-### Deciding What To Do
+## Deciding: Reply vs Code Changes
 
-The app should analyze the context to decide the appropriate action:
+Not every mention needs code changes.
 
-| Context | Primary Action |
-| --- | --- |
-| Issue with no linked PR | Create a new PR to address the issue |
-| PR with feedback/requests | Apply requested changes to the PR |
-| Question or clarification request | Respond with answer (no code changes) |
-| Ambiguous request | Ask for clarification before acting |
+**Just reply when:**
 
-### Workflow vs Conversational Response
-
-Not every @issuetopr mention needs a full workflow. The app should distinguish:
-
-**Run a workflow when:**
-- User is asking for code changes
-- User is asking to fix something
-- User is asking to implement something
-- Clear action is required
-
-**Respond conversationally when:**
 - User is asking a question
 - User wants explanation of existing code
 - User is asking for suggestions without implementation
-- No clear action is implied
 
-In ambiguous cases, default to asking for clarification rather than making assumptions.
+**Make code changes when:**
+
+- User explicitly asks for a fix or implementation
+- User is giving feedback that implies changes are needed
+- Clear action is required
+
+**When ambiguous:** Ask for clarification rather than guessing.
+
+## Scope Matching
+
+The scope of action should match the scope of the request:
+
+| Mention Location                       | Default Scope               |
+| -------------------------------------- | --------------------------- |
+| Inline comment on specific line        | That line/function          |
+| Multiple inline comments in one review | All mentioned areas         |
+| Top-level PR comment                   | Entire PR                   |
+| Issue comment                          | Create new PR for the issue |
+
+Users can override scope with explicit instructions ("fix this across the whole codebase").
 
 ## Context Gathering
 
-Before taking action, the app should understand:
+Before taking action, understand:
 
-1. **The repository** - What kind of project, languages used, coding standards
-2. **The issue/PR** - Full description, existing comments, related discussions
+1. **The repository** - Languages, coding standards, patterns
+2. **The issue/PR** - Full description, existing comments, history
 3. **The specific comment** - What exactly is being asked
-4. **Previous interactions** - Has the user given feedback we should incorporate?
+4. **Previous interactions** - Incorporate earlier feedback
 
-For PR review comments specifically:
+For PR review comments:
+
 - Consider the code diff being reviewed
 - Consider the specific line(s) the comment is attached to
 - Consider other inline comments in the same review (they may be related)
 
 ## Feedback Loop
 
-Users should be able to iterate:
+Users iterate until satisfied:
 
 1. @issuetopr makes changes
 2. User reviews and provides feedback
 3. @issuetopr incorporates feedback
-4. Repeat until satisfied
+4. Repeat
 
-Each iteration should build on previous context rather than starting fresh.
+Each iteration builds on previous context rather than starting fresh.
 
 ## Error States
 
-| Situation | Response |
-| --- | --- |
-| User unauthorized | Silent ignore (don't reveal we're watching) |
-| User has no account | Reply with signup link |
-| Rate limited | Reply with cooldown notice |
-| Workflow fails | Reply with error details and retry guidance |
-| Unclear request | Ask for clarification |
+| Situation           | Response                                    |
+| ------------------- | ------------------------------------------- |
+| User unauthorized   | Silent ignore (don't reveal we're watching) |
+| User has no account | Reply with signup link                      |
+| Rate limited        | Reply with cooldown notice                  |
+| Workflow fails      | Reply with error details and retry guidance |
+| Unclear request     | Ask for clarification                       |
 
-## Out of Scope (For Now)
+## Trigger Locations
+
+Users can mention @issuetopr in these places:
+
+| Location                   | GitHub Event                  | When Received            |
+| -------------------------- | ----------------------------- | ------------------------ |
+| Issue comment              | `issue_comment`               | Immediately on post      |
+| PR comment                 | `issue_comment`               | Immediately on post      |
+| PR review (top-level)      | `pull_request_review`         | When review is submitted |
+| PR review comment (inline) | `pull_request_review_comment` | When review is submitted |
+
+## Implementation: PR Review Deduplication
+
+When a user writes a GitHub PR review, they may:
+
+1. Write inline comments on specific code lines
+2. Write a top-level summary comment
+3. Submit with an overall verdict (approve/request changes/comment)
+
+GitHub holds all inline comments in a "pending" state until the user clicks "Submit review". At submission time, GitHub fires:
+
+- One `pull_request_review` event (for the review itself)
+- Multiple `pull_request_review_comment` events (one per inline comment)
+
+These webhooks arrive nearly simultaneously. If the user mentions @issuetopr in multiple places, we need deduplication.
+
+### Deduplication Strategy
+
+Group related webhook events using a **review correlation window**.
+
+When we receive any PR review-related event:
+
+1. Extract the `pull_request_review_id` from the payload
+2. Check if we've already processed a trigger for this review ID
+3. If yes, skip processing
+4. If no, mark this review ID as processed and continue
+
+### Implementation Notes
+
+- Correlation window should be short (30-60 seconds)
+- Store processed review IDs in a short-lived cache (Redis or in-memory with TTL)
+- Include the review ID in workflow audit logs for debugging
+- **Note:** Verify `pull_request_review_id` field presence in actual webhook payloads before relying on it
+
+## Out of Scope
 
 - Proactively commenting without being mentioned
 - Watching for file changes without explicit trigger


### PR DESCRIPTION
## Summary

This PR adds a comprehensive specification document that defines how the @issuetopr app should respond when mentioned in GitHub issues and pull requests. This serves as a design guide for implementing the mention-triggered workflow functionality.

## Key Changes

- **New specification document** (`docs/specs/issuetopr-mention-behavior.md`) covering:
  - **Trigger locations**: Documents all places where @issuetopr can be mentioned (issue comments, PR comments, PR reviews, inline review comments)
  - **PR review deduplication**: Defines a strategy to prevent duplicate workflow triggers when users mention @issuetopr in both top-level reviews and inline comments using review ID correlation
  - **Response behavior**: Specifies the expected app behavior including acknowledgment, response, execution, and reporting
  - **Context-aware actions**: Guidance on deciding between running workflows vs. conversational responses based on user intent
  - **Context gathering**: Requirements for understanding repository, issue/PR, and comment context before taking action
  - **Feedback loop**: Support for iterative improvements through multiple interactions
  - **Error handling**: Defined responses for various error states (unauthorized users, rate limiting, unclear requests, etc.)

## Notable Implementation Details

- The deduplication strategy uses a short-lived cache (30-60 second window) keyed by `pull_request_review_id` to handle nearly-simultaneous webhook events from GitHub
- The spec distinguishes between workflow-triggering requests (code changes, fixes, implementations) and conversational responses (questions, explanations, suggestions)
- Emphasizes context gathering from repository, issue/PR history, and specific comments before taking action
- Defaults to asking for clarification in ambiguous cases rather than making assumptions

This specification provides the foundation for implementing the core mention-triggered functionality of the @issuetopr app.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime/code-path impact; risk is limited to potential misinterpretation of intended behavior.
> 
> **Overview**
> Adds a new spec doc, `docs/specs/issuetopr-mention-behavior.md`, defining expected @issuetopr behavior when mentioned in issues, PR comments, and PR reviews.
> 
> The spec covers reply-vs-change decision rules, scope matching based on mention location, the user interaction flow (acknowledge/respond/execute/report), and an approach to deduplicate near-simultaneous PR review webhooks via a short-lived cache keyed by `pull_request_review_id`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc4cf5a901223b54f671517c8543edcac5cbb59c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->