### PR TITLE
Fix Claude SDK runner failing as root in agent containers

### DIFF
--- a/__tests__/lib/agents/claude/runClaudeAgentInContainer.test.ts
+++ b/__tests__/lib/agents/claude/runClaudeAgentInContainer.test.ts
@@ -46,7 +46,11 @@ const baseInput = {
 describe("Claude agent runner — output collection", () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    // First exec call writes the input JSON into the container
+    // Call 1: write input JSON into the container
+    mockExec.mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 })
+    // Call 2: chown /workspace for the non-root agent user
+    mockExec.mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 })
+    // Call 3: git config for the agent user
     mockExec.mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 })
   })
 

--- a/docker/agent-base/Dockerfile
+++ b/docker/agent-base/Dockerfile
@@ -61,7 +61,7 @@ RUN cd /usr/local/lib/claude-runner && npm init -y && npm install zod
 # The SDK's CLI refuses --dangerously-skip-permissions when run as root.
 # Container setup (git clone, chown) still runs as root; only the SDK runner
 # switches to this user.
-RUN groupadd -g 1000 agent && useradd -m -u 1000 -g agent agent
+RUN groupadd -g 1001 agent && useradd -m -u 1001 -g agent agent
 
 # Set working directory where the agent will later receive a repository to work on
 WORKDIR /workspace

--- a/docker/agent-base/Dockerfile
+++ b/docker/agent-base/Dockerfile
@@ -57,6 +57,12 @@ RUN rg --version \
 COPY shared/src/lib/agents/claude/runner.mjs /usr/local/lib/claude-runner/index.mjs
 RUN cd /usr/local/lib/claude-runner && npm init -y && npm install zod
 
+# Create a non-root user for running the Claude Agent SDK.
+# The SDK's CLI refuses --dangerously-skip-permissions when run as root.
+# Container setup (git clone, chown) still runs as root; only the SDK runner
+# switches to this user.
+RUN groupadd -g 1000 agent && useradd -m -u 1000 -g agent agent
+
 # Set working directory where the agent will later receive a repository to work on
 WORKDIR /workspace
 

--- a/shared/src/lib/agents/claude/runClaudeAgentInContainer.ts
+++ b/shared/src/lib/agents/claude/runClaudeAgentInContainer.ts
@@ -17,6 +17,9 @@ import {
 /** Path to the runner script inside the agent-base Docker image. */
 const RUNNER_SCRIPT_PATH = "/usr/local/lib/claude-runner/index.mjs"
 
+/** Non-root user created in the agent-base Dockerfile for running the SDK. */
+const AGENT_USER = "agent:agent"
+
 interface RunnerInput {
   issueTitle: string
   issueBody: string
@@ -55,7 +58,16 @@ export async function runClaudeAgentInContainer({
     command: `echo '${inputBase64}' | base64 -d > /tmp/claude-input.json`,
   })
 
-  // 2. Execute the runner script (baked into the Docker image)
+  // 2. Grant the non-root agent user ownership of /workspace so the SDK
+  //    runner can read/write files. Setup commands run as root (default).
+  await execInContainerWithDockerode({
+    name: containerName,
+    command: "chown -R agent:agent /workspace",
+  })
+
+  // 3. Execute the runner script as the non-root agent user.
+  //    The Claude Agent SDK CLI refuses --dangerously-skip-permissions
+  //    when running as root, so we must switch to a non-root user.
   await createStatusEvent({
     workflowId,
     content: "Starting Claude Agent SDK runner",
@@ -64,6 +76,7 @@ export async function runClaudeAgentInContainer({
   const { stdout, stderr, exitCode } = await execInContainerWithDockerode({
     name: containerName,
     command: `node ${RUNNER_SCRIPT_PATH} < /tmp/claude-input.json`,
+    user: AGENT_USER,
   })
 
   // 3. Parse NDJSON output

--- a/shared/src/lib/agents/claude/runClaudeAgentInContainer.ts
+++ b/shared/src/lib/agents/claude/runClaudeAgentInContainer.ts
@@ -60,12 +60,28 @@ export async function runClaudeAgentInContainer({
 
   // 2. Grant the non-root agent user ownership of /workspace so the SDK
   //    runner can read/write files. Setup commands run as root (default).
+  const chownResult = await execInContainerWithDockerode({
+    name: containerName,
+    command: `chown -R ${AGENT_USER} /workspace`,
+  })
+  if (chownResult.exitCode !== 0) {
+    const errorMsg =
+      chownResult.stderr ||
+      "Failed to grant the agent user access to /workspace"
+    await createErrorEvent({ workflowId, content: errorMsg })
+    throw new Error(`Claude agent setup failed: ${errorMsg}`)
+  }
+
+  // 3. Set git identity for the agent user. The global config set during
+  //    container setup lives under /root and is invisible to non-root users.
   await execInContainerWithDockerode({
     name: containerName,
-    command: "chown -R agent:agent /workspace",
+    command:
+      'git config --global user.name "Issue To PR agent" && git config --global user.email "agent@issuetopr.dev"',
+    user: AGENT_USER,
   })
 
-  // 3. Execute the runner script as the non-root agent user.
+  // 4. Execute the runner script as the non-root agent user.
   //    The Claude Agent SDK CLI refuses --dangerously-skip-permissions
   //    when running as root, so we must switch to a non-root user.
   await createStatusEvent({
@@ -79,7 +95,7 @@ export async function runClaudeAgentInContainer({
     user: AGENT_USER,
   })
 
-  // 3. Parse NDJSON output
+  // 5. Parse NDJSON output
   const messages: Array<{ role: string; content: string }> = []
   const lines = stdout.split("\n").filter((line) => line.trim().length > 0)
 

--- a/shared/src/lib/agents/claude/runClaudeAgentInContainer.ts
+++ b/shared/src/lib/agents/claude/runClaudeAgentInContainer.ts
@@ -74,12 +74,20 @@ export async function runClaudeAgentInContainer({
 
   // 3. Set git identity for the agent user. The global config set during
   //    container setup lives under /root and is invisible to non-root users.
-  await execInContainerWithDockerode({
+  //    Use --file to avoid relying on $HOME being set in Docker exec.
+  const gitConfigResult = await execInContainerWithDockerode({
     name: containerName,
     command:
-      'git config --global user.name "Issue To PR agent" && git config --global user.email "agent@issuetopr.dev"',
+      'git config --file /home/agent/.gitconfig user.name "Issue To PR agent" && git config --file /home/agent/.gitconfig user.email "agent@issuetopr.dev"',
     user: AGENT_USER,
   })
+  if (gitConfigResult.exitCode !== 0) {
+    const errorMsg =
+      gitConfigResult.stderr ||
+      "Failed to configure git identity for the agent user"
+    await createErrorEvent({ workflowId, content: errorMsg })
+    throw new Error(`Claude agent setup failed: ${errorMsg}`)
+  }
 
   // 4. Execute the runner script as the non-root agent user.
   //    The Claude Agent SDK CLI refuses --dangerously-skip-permissions

--- a/shared/src/lib/docker.ts
+++ b/shared/src/lib/docker.ts
@@ -156,10 +156,13 @@ export async function execInContainerWithDockerode({
   name,
   command,
   cwd,
+  user = "root:root",
 }: {
   name: string
   command: string | string[]
   cwd?: string
+  /** UID:GID or username to run the command as (default "root:root") */
+  user?: string
 }): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   if (!name || typeof name !== "string" || !name.trim()) {
     return {
@@ -203,7 +206,7 @@ export async function execInContainerWithDockerode({
       AttachStdout: true,
       AttachStderr: true,
       WorkingDir: cwd,
-      User: "root:root",
+      User: user,
     })
     const stream = await exec.start({})
     let stdout = ""


### PR DESCRIPTION
## Summary

- The Claude Agent SDK CLI refuses `--dangerously-skip-permissions` when running as root, causing all Anthropic provider workflow runs to fail with `Claude Code process exited with code 1`
- Adds a non-root `agent` user (UID 1000) to the agent-base Dockerfile
- Makes `execInContainerWithDockerode` accept an optional `user` parameter (defaults to `root:root` for backward compatibility)
- Runs the SDK runner as `agent:agent` in `runClaudeAgentInContainer`, with a `chown` step to grant workspace access

Closes #1535

## Test plan

- [ ] Rebuild agent-base image (`./scripts/build-agent-image.sh`)
- [ ] Pull new image on prod (`ssh youngandai-ec2 "docker pull ghcr.io/youngchingjui/agent-base:latest"`)
- [ ] Trigger an Anthropic provider workflow (label an issue with "I2PR: Resolve Issue") and verify it completes successfully
- [ ] Verify OpenAI provider workflows still work (they use `root:root` exec, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Docker image build now creates and uses a dedicated non-root account for container runtime.
  * Container startup adjusts workspace ownership and configures VCS settings so the SDK runner executes as the non-root account.
  * Docker execution utilities now allow specifying the container user instead of forcing root.

* **Tests**
  * Updated tests to reflect the new container initialization steps and execution order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->